### PR TITLE
Fix default timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 - 2025-05-16
+
+- Bugfix: if no timeout is specified by Inspect for long-running exec, RetryError happens after 30s.
+- Docs: correct OVA docs to reflect recent 0.6.0 change
+
 ## 0.6.0 - 2025-05-14
 
 - Performance enhancement: OVAs generate template VMs, per-sample VMs are now linked clones.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ sandbox=SandboxEnvironmentSpec(
                 # extra_proxmox_native_config = dict() TODO
             ),
             # A virtual machine from a local OVA, which will be uploaded from here to the Proxmox server.
-            # Note, the OVA is not re-uploaded if it is changed locally, so must be manually deleted on the server in this case.
             VmConfig(
                 vm_source_config=VmSourceConfig(
                     ova=Path("./tests/oVirtTinyCore64-13.11.ova")
@@ -188,7 +187,8 @@ to convert it into an OVA.
 This provider creates a template VM for every OVA-type VM specified in an eval.
 Next time you run the eval, a linked clone of the template VM will be created.
 This is for performance. If you change the OVA, as long as the filesize changes, 
-a new template VM will be created.
+a new template VM will be created. If you change the OVA but the filesize remains
+the same, you should manually delete it from the Proxmox server.
 
 These template VMs are *not* cleaned up because that needs to happen outside
 the lifecycle of an Inspect eval. You need to do this manually at the moment.

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -333,7 +333,9 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
 
         @tenacity.retry(
             wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
-            stop=tenacity.stop_after_delay(timeout if timeout is not None else 30),
+            stop=tenacity.stop_after_delay(timeout)
+            if timeout is not None
+            else tenacity.stop_never,
             retry=tenacity.retry_if_result(lambda x: x is False),
         )
         async def wait_for_exec(vm_id: int, exec_response_pid: int) -> bool | Dict:

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -87,8 +87,6 @@ class VmSourceConfig(BaseModel, frozen=True):
     Attributes:
         existing_vm_template_tag: Clone VM from existing Proxmox template with this tag
         ova: Create VM from this OVA file in the local (not Proxmox) filesystem.
-            Note, the OVA is not re-uploaded if it is changed locally, so must be
-            manually deleted on the server in this case.
         existing_backup_name: Create VM from existing Proxmox backup
         built_in: Use this provider's built-in VM template (currently "ubuntu24.04"
             is supported)

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
@@ -184,7 +184,7 @@ async def test_ova() -> None:
                 vm_source_config=VmSourceConfig(
                     ova=CURRENT_DIR / ".." / "oVirtTinyCore64-13.11.ova"
                 ),
-                name="test-ova"
+                name="test-ova",
             ),
         )
     )


### PR DESCRIPTION
Currently if no timeout is specified by Inspect for long-running exec, RetryError happens after 30s.