### PR TITLE
Concurrency: Increase setup to 2, cleanup infinite

### DIFF
--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -248,7 +248,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 async_proxmox_api=async_proxmox_api, config=config
             )
 
-            async with concurrency(f"proxmox-{instance.host}", 1):
+            async with concurrency(f"proxmox-{instance.host}", 2):
                 (
                     vm_configs_with_ids,
                     sdn_zone_id,
@@ -427,11 +427,10 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         cleanup_succeeded = False
         try:
             if any_vm_sandbox_environment is not None:
-                async with concurrency(f"proxmox-{instance.host}", 1):
-                    await any_vm_sandbox_environment.infra_commands.delete_sdn_and_vms(
-                        sdn_zone_id=any_vm_sandbox_environment.sdn_zone_id,
-                        vm_ids=any_vm_sandbox_environment.all_vm_ids,
-                    )
+                await any_vm_sandbox_environment.infra_commands.delete_sdn_and_vms(
+                    sdn_zone_id=any_vm_sandbox_environment.sdn_zone_id,
+                    vm_ids=any_vm_sandbox_environment.all_vm_ids,
+                )
                 cleanup_succeeded = True
                 instance_id = instance.instance_id if instance else "unknown"
                 cls.logger.info(


### PR DESCRIPTION
For short runs with long setups, the per-host setup concurrency becomes the bottleneck. 

We think we can increase this to 2 without any issues.

The cleanup should have been infinite already, maybe this got lost in the branch merging.