### PR TITLE
Sinman/windows support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ It will handle the extra configuration mentioned in this project's README.
 
 ## Tests
 
-To run the tests, you will need a proxmox instance and an .env file per README.md.
+To run the tests, you will need a Proxmox instance and an `.env` file per README.md.
 
 If running from the CLI, you'll need to run first `set -a; source .env; set +a`.
 
@@ -44,6 +44,23 @@ uv run pytest
 ```
 
 The tests require your Proxmox node to have at least 3 vCPUs available.
+
+### Windows VM Tests
+
+By default, tests run against Linux VMs using the built-in `ubuntu24.04` image.
+
+To also run tests against Windows VMs:
+
+1. Create a Windows VM on your Proxmox server with `qemu-guest-agent` installed and running
+2. Convert it to a template (right-click → Convert to Template)
+3. Add tags `inspect;<your-tag>` to the template (e.g., `inspect;windows-test`)
+4. Set the environment variable:
+
+```bash
+export PROXMOX_WINDOWS_TEMPLATE_TAG=<your-tag>
+```
+
+With this set, tests in `test_proxmox_sandbox_agent_commands.py` will run for both Linux and Windows.
 
 ## Linting & Formatting
 

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -55,11 +55,18 @@ class InfraCommands(abc.ABC):
 
         known_builtins = await self.built_in_vm.known_builtins()
 
+        # Create ALL DHCP mappings FIRST, before creating/starting any VMs.
+        # This prevents race conditions where a booting VM's DHCP request
+        # causes Proxmox to auto-allocate IPs that we wanted to reserve.
+        self.logger.info(
+            f"[INFRA_DEBUG] Creating all DHCP mappings first for {len(vms_config)} VMs"
+        )
         for vm_config in vms_config:
-            # We have to create the IPAM entries before booting the VMs
-            # otherwise they will not get the defined static IPs.
             await self.create_dhcp_mappings(vnet_aliases, vm_config, sdn_zone_id)
+        self.logger.info("[INFRA_DEBUG] All DHCP mappings created, now creating VMs")
 
+        # Now create and start VMs
+        for vm_config in vms_config:
             with trace_action(self.logger, self.TRACE_NAME, f"create VM {vm_config=}"):
                 vm_id = await self.qemu_commands.create_and_start_vm(
                     sdn_vnet_aliases=vnet_aliases,

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -58,15 +58,12 @@ class InfraCommands(abc.ABC):
         # Create ALL DHCP mappings FIRST, before creating/starting any VMs.
         # This prevents race conditions where a booting VM's DHCP request
         # causes Proxmox to auto-allocate IPs that we wanted to reserve.
-        self.logger.info(
-            f"[INFRA_DEBUG] Creating all DHCP mappings first for {len(vms_config)} VMs"
-        )
         for vm_config in vms_config:
             await self.create_dhcp_mappings(vnet_aliases, vm_config, sdn_zone_id)
-        self.logger.info("[INFRA_DEBUG] All DHCP mappings created, now creating VMs")
 
         # Now create and start VMs
-        for vm_config in vms_config:
+        for i, vm_config in enumerate(vms_config):
+            self.logger.info(f"Creating VM {i+1}/{len(vms_config)}: {vm_config.name}")
             with trace_action(self.logger, self.TRACE_NAME, f"create VM {vm_config=}"):
                 vm_id = await self.qemu_commands.create_and_start_vm(
                     sdn_vnet_aliases=vnet_aliases,
@@ -77,10 +74,10 @@ class InfraCommands(abc.ABC):
 
         # TODO check for failed starts in the log somehow
 
-        for vm_configs_with_id in vm_configs_with_ids:
-            await self.qemu_commands.await_vm(
-                vm_configs_with_id[0], vm_configs_with_id[1].is_sandbox
-            )
+        for vm_id, vm_config in vm_configs_with_ids:
+            self.logger.info(f"Waiting for VM {vm_config.name} (ID={vm_id})")
+            await self.qemu_commands.await_vm(vm_id, vm_config.is_sandbox)
+            self.logger.info(f"VM {vm_config.name} is ready")
 
         # TODO types here
         return vm_configs_with_ids, sdn_zone_id

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -182,8 +182,14 @@ class QemuCommands(abc.ABC):
         ):
             raise NotImplementedError("disk_controller is only supported for OVA")
 
-        if (vm_config.os_type != "l26") and (vm_config.vm_source_config.ova is None):
-            raise NotImplementedError("os_type is only supported for OVA")
+        if (
+            vm_config.os_type != "l26"
+            and vm_config.vm_source_config.ova is None
+            and vm_config.vm_source_config.existing_vm_template_tag is None
+        ):
+            raise NotImplementedError(
+                "os_type is only supported for OVA or existing_vm_template_tag"
+            )
 
         if vm_config.vm_source_config.built_in:
             vm_id_to_clone = built_in_vm_ids[vm_config.vm_source_config.built_in]

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -61,7 +61,9 @@ class QemuCommands(abc.ABC):
             vm_status = await self.async_proxmox.request(
                 "GET", f"/nodes/{self.node}/qemu/{vm_id}/status/current"
             )
-            if vm_status["status"] != status_for_wait:
+            current_status = vm_status["status"]
+            if current_status != status_for_wait:
+                self.logger.debug(f"VM {vm_id} status is {current_status}, waiting for {status_for_wait}")
                 raise ValueError(f"vm {vm_id} not {status_for_wait}")
 
         with trace_action(
@@ -72,18 +74,23 @@ class QemuCommands(abc.ABC):
             await is_in_status()
 
         if is_sandbox and status_for_wait == "running":
+            attempt_count = [0]  # Use list to allow mutation in nested function
 
             @tenacity.retry(
                 wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
                 stop=tenacity.stop_after_delay(300),
             )
             async def qemu_agent_reachable() -> None:
+                attempt_count[0] += 1
+                if attempt_count[0] % 10 == 1:  # Log every 10 attempts
+                    self.logger.info(f"VM {vm_id} QEMU agent ping attempt {attempt_count[0]}")
                 await self.ping_qemu_agent(vm_id)
 
             with trace_action(
                 self.logger, self.TRACE_NAME, f"await VM {vm_id} QEMU agent"
             ):
                 await qemu_agent_reachable()
+            self.logger.info(f"VM {vm_id} QEMU agent responded after {attempt_count[0]} attempts")
 
     async def destroy_vm(self, vm_id: int) -> None:
         with trace_action(self.logger, self.TRACE_NAME, f"stop VM {vm_id}"):
@@ -200,6 +207,7 @@ class QemuCommands(abc.ABC):
                 ova_tag = f"ova-{vm_config.vm_source_config.ova.name}-{ova_size}"
                 ova_tag = re.sub(r"[^a-zA-Z0-9_\-]", "_", ova_tag)
                 ova_tag = ova_tag.lower()
+                self.logger.info(f"Looking for existing template with tag: {ova_tag}")
 
                 existing_vms = await self.list_vms()
 
@@ -213,9 +221,11 @@ class QemuCommands(abc.ABC):
                         and ova_tag in existing_vm["tags"].split(";")
                     ):
                         found_existing_template = existing_vm["vmid"]
+                        self.logger.info(f"Found existing template: vmid={found_existing_template}")
                         break
 
                 if found_existing_template is None:
+                    self.logger.info(f"No existing template found, importing from OVA")
                     await self.storage_commands.upload_file_to_storage(
                         file=vm_config.vm_source_config.ova,
                         content_type="import",
@@ -287,6 +297,7 @@ class QemuCommands(abc.ABC):
                     )
 
                     await self.remove_existing_nics(new_vm_template_id)
+                    self.logger.info(f"New template created: vmid={new_vm_template_id}")
 
                 else:
                     new_vm_template_id = found_existing_template
@@ -514,9 +525,13 @@ class QemuCommands(abc.ABC):
             json_for_create["bios"] = "ovmf"
 
     async def ping_qemu_agent(self, vm_id: int):
-        await self.async_proxmox.request(
-            "POST", f"/nodes/{self.node}/qemu/{vm_id}/agent/ping"
-        )
+        try:
+            await self.async_proxmox.request(
+                "POST", f"/nodes/{self.node}/qemu/{vm_id}/agent/ping"
+            )
+        except Exception as e:
+            self.logger.debug(f"VM {vm_id} agent ping failed: {type(e).__name__}: {e}")
+            raise
 
     async def connection_url(self, vm_id: int) -> str:
         return f"{self.async_proxmox.base_url}/?console=kvm&novnc=1&vmid={vm_id}&node={self.node}"  # noqa: E501

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -531,13 +531,9 @@ class QemuCommands(abc.ABC):
             json_for_create["bios"] = "ovmf"
 
     async def ping_qemu_agent(self, vm_id: int):
-        try:
-            await self.async_proxmox.request(
-                "POST", f"/nodes/{self.node}/qemu/{vm_id}/agent/ping"
-            )
-        except Exception as e:
-            self.logger.debug(f"VM {vm_id} agent ping failed: {type(e).__name__}: {e}")
-            raise
+        await self.async_proxmox.request(
+            "POST", f"/nodes/{self.node}/qemu/{vm_id}/agent/ping"
+        )
 
     async def connection_url(self, vm_id: int) -> str:
         return f"{self.async_proxmox.base_url}/?console=kvm&novnc=1&vmid={vm_id}&node={self.node}"  # noqa: E501

--- a/src/proxmoxsandbox/_impl/sdn_commands.py
+++ b/src/proxmoxsandbox/_impl/sdn_commands.py
@@ -352,7 +352,7 @@ class SdnCommands(abc.ABC):
                                 f"/cluster/sdn/vnets/{vnet}/subnets/{subnet_id}",
                             )
                         except Exception as e:
-                            self.logger.warning(f"Failed to delete subnet {subnet_id}: {e}")
+                            self.logger.error(f"Failed to delete subnet {subnet_id}: {e}")
                     await self.async_proxmox.request(
                         "DELETE", f"/cluster/sdn/vnets/{vnet}"
                     )

--- a/src/proxmoxsandbox/_impl/sdn_commands.py
+++ b/src/proxmoxsandbox/_impl/sdn_commands.py
@@ -346,10 +346,13 @@ class SdnCommands(abc.ABC):
                     )
                     for subnet_details in subnets:
                         subnet_id = subnet_details["id"]
-                        await self.async_proxmox.request(
-                            "DELETE",
-                            f"/cluster/sdn/vnets/{vnet}/subnets/{subnet_id}",
-                        )
+                        try:
+                            await self.async_proxmox.request(
+                                "DELETE",
+                                f"/cluster/sdn/vnets/{vnet}/subnets/{subnet_id}",
+                            )
+                        except Exception as e:
+                            self.logger.warning(f"Failed to delete subnet {subnet_id}: {e}")
                     await self.async_proxmox.request(
                         "DELETE", f"/cluster/sdn/vnets/{vnet}"
                     )
@@ -383,10 +386,6 @@ class SdnCommands(abc.ABC):
             self.TRACE_NAME,
             f"create DHCP mapping {vnet_id=} {zone_id=} {mac_address=} {ip_addr=}",
         ):
-            # This is probably not how you're supposed to do this stuff.
-            # please correct me, I'm not a dev.
-
-            # We tack the ip allocations so that we can delete them later
             reservation: ProxmoxJsonDataType = {
                 "ip": ip_addr,
                 "vnet": vnet_id,

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -666,6 +666,9 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         exec_response_pid = exec_post_response["pid"]
 
         assert isinstance(exec_response_pid, int)
+        self.logger.debug(
+            f"VM {self.vm_id} exec pid={exec_response_pid}: {cmd[:100]}"
+        )
 
         with trace_action(
             self.logger,

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -30,6 +30,7 @@ from proxmoxsandbox._impl.qemu_commands import QemuCommands
 from proxmoxsandbox._impl.task_wrapper import TaskWrapper
 from proxmoxsandbox._proxmox_pool import ProxmoxPoolABC, QueueBasedProxmoxPool
 from proxmoxsandbox.schema import (
+    OsType,
     ProxmoxInstanceConfig,
     ProxmoxSandboxEnvironmentConfig,
     SdnConfigType,
@@ -60,7 +61,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     instance: ProxmoxInstanceConfig | None
     pool_id: str | None
     # OS type for Windows support
-    os_type: str | None
+    os_type: OsType | None
 
     def __init__(
         self,
@@ -72,7 +73,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         sdn_zone_id: str | None,
         instance: ProxmoxInstanceConfig | None = None,
         pool_id: str | None = None,
-        os_type: str | None = None,
+        os_type: OsType | None = None,
     ):
         self.infra_commands = InfraCommands(async_proxmox=proxmox, node=node)
         self.agent_commands = AgentCommands(async_proxmox=proxmox, node=node)
@@ -598,8 +599,8 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
 
         is_windows = self._is_windows()
 
-        # Use Windows-compatible temp path for Windows VMs
-        # C:\Windows\Temp always exists, unlike C:\Temp
+        # Hardcoded path because the QEMU guest agent doesn't expand
+        # environment variables like %TEMP%. C:\Windows\Temp always exists.
         if is_windows:
             tmp_start = f"C:\\Windows\\Temp\\{__name__}{time.time_ns()}_"
             self.logger.info(

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -59,6 +59,8 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     # Multi-instance pool fields
     instance: ProxmoxInstanceConfig | None
     pool_id: str | None
+    # OS type for Windows support
+    os_type: str | None
 
     def __init__(
         self,
@@ -70,6 +72,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         sdn_zone_id: str | None,
         instance: ProxmoxInstanceConfig | None = None,
         pool_id: str | None = None,
+        os_type: str | None = None,
     ):
         self.infra_commands = InfraCommands(async_proxmox=proxmox, node=node)
         self.agent_commands = AgentCommands(async_proxmox=proxmox, node=node)
@@ -82,6 +85,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         self.sdn_zone_id = sdn_zone_id
         self.instance = instance
         self.pool_id = pool_id
+        self.os_type = os_type
 
     # originally from k8s sandbox
     def _pipe_user_input(self, stdin: str | bytes) -> str:
@@ -106,6 +110,64 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         # `-k 5s` sends SIGKILL after grace period in case user command doesn't respect
         # SIGTERM.
         return f"timeout -k 5s {timeout}s "
+
+    def _is_windows(self) -> bool:
+        """Check if this VM is running Windows based on os_type."""
+        if self.os_type is None:
+            return False
+        # Windows os_types: w2k, w2k3, w2k8, win10, win11, win7, win8, wvista, wxp
+        return self.os_type.startswith("w")
+
+    def _build_batch_script(
+        self,
+        tmp_start: str,
+        command: List[str],
+        stdin: str | bytes | None,
+        cwd: str | None,
+        env: dict[str, str],
+        user: str | None,
+        timeout: int | None,
+    ) -> str:
+        """Build a batch script for Windows VMs."""
+        lines = ["@echo off"]
+
+        # Remove old output files
+        lines.append(f'del /f /q "{tmp_start}script.stdout" 2>nul')
+        lines.append(f'del /f /q "{tmp_start}script.stderr" 2>nul')
+        lines.append(f'del /f /q "{tmp_start}script.returncode" 2>nul')
+
+        # Set environment variables
+        for key, value in env.items():
+            # Escape special batch characters
+            escaped_value = value.replace("%", "%%").replace("^", "^^")
+            lines.append(f'set "{key}={escaped_value}"')
+
+        # Change directory if specified
+        if cwd is not None:
+            lines.append(f'cd /d "{cwd}"')
+
+        # Build the command - escape for batch
+        escaped_args = []
+        for arg in command:
+            # Escape special characters for cmd.exe
+            escaped_arg = (
+                arg.replace("^", "^^")
+                .replace("&", "^&")
+                .replace("|", "^|")
+                .replace("<", "^<")
+                .replace(">", "^>")
+            )
+            if " " in arg or '"' in arg:
+                escaped_arg = f'"{escaped_arg}"'
+            escaped_args.append(escaped_arg)
+        cmd_str = " ".join(escaped_args)
+
+        # Execute command with output redirection
+        # Note: stdin piping in batch is limited, skip for now
+        lines.append(f'{cmd_str} > "{tmp_start}script.stdout" 2> "{tmp_start}script.stderr"')
+        lines.append(f'echo %ERRORLEVEL% > "{tmp_start}script.returncode"')
+
+        return "\r\n".join(lines)
 
     # originally from k8s sandbox
     # TODO extract this to its own module and unit test it locally
@@ -276,6 +338,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                     sdn_zone_id=sdn_zone_id,
                     instance=instance,
                     pool_id=pool_id,
+                    os_type=vm_config_and_id[1].os_type,
                 )
                 if not found_default and vm_config_and_id[1].is_sandbox:
                     sandboxes["default"] = vm_sandbox_environment
@@ -533,7 +596,18 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         if self.vm_id is None:
             raise ValueError("VM ID is not set")
 
-        tmp_start = f"/tmp/{__name__}{time.time_ns()}_"
+        is_windows = self._is_windows()
+
+        # Use Windows-compatible temp path for Windows VMs
+        # C:\Windows\Temp always exists, unlike C:\Temp
+        if is_windows:
+            tmp_start = f"C:\\Windows\\Temp\\{__name__}{time.time_ns()}_"
+            self.logger.info(
+                f"[WINDOWS_EXEC] Using Windows paths for VM {self.vm_id}, "
+                f"os_type={self.os_type}, tmp_start={tmp_start}"
+            )
+        else:
+            tmp_start = f"/tmp/{__name__}{time.time_ns()}_"
 
         @tenacity.retry(
             wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
@@ -559,21 +633,35 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             else:
                 return exec_status
 
-        script = self._build_shell_script(
-            tmp_start=tmp_start,
-            command=cmd,
-            stdin=input,
-            cwd=cwd,
-            env=env,
-            user=user,
-            timeout=timeout,
-        )
-
-        await self._write_file_only(f"{tmp_start}script.sh", script)
-
-        exec_post_response = await self.agent_commands.exec_command(
-            vm_id=self.vm_id, command=["sh", f"{tmp_start}script.sh"]
-        )
+        if is_windows:
+            script = self._build_batch_script(
+                tmp_start=tmp_start,
+                command=cmd,
+                stdin=input,
+                cwd=cwd,
+                env=env,
+                user=user,
+                timeout=timeout,
+            )
+            script_path = f"{tmp_start}script.bat"
+            await self._write_file_only(script_path, script)
+            exec_post_response = await self.agent_commands.exec_command(
+                vm_id=self.vm_id, command=["cmd.exe", "/c", script_path]
+            )
+        else:
+            script = self._build_shell_script(
+                tmp_start=tmp_start,
+                command=cmd,
+                stdin=input,
+                cwd=cwd,
+                env=env,
+                user=user,
+                timeout=timeout,
+            )
+            await self._write_file_only(f"{tmp_start}script.sh", script)
+            exec_post_response = await self.agent_commands.exec_command(
+                vm_id=self.vm_id, command=["sh", f"{tmp_start}script.sh"]
+            )
 
         exec_response_pid = exec_post_response["pid"]
 
@@ -624,10 +712,16 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             )
 
         # cleanup - we don't need to wait for the result of this
-        await self.agent_commands.exec_command(
-            vm_id=self.vm_id,
-            command=["sh", "-c", f"rm -f {tmp_start}*"],
-        )
+        if is_windows:
+            await self.agent_commands.exec_command(
+                vm_id=self.vm_id,
+                command=["cmd.exe", "/c", f'del /f /q "{tmp_start}*" 2>nul'],
+            )
+        else:
+            await self.agent_commands.exec_command(
+                vm_id=self.vm_id,
+                command=["sh", "-c", f"rm -f {tmp_start}*"],
+            )
 
         if exec_response.returncode == 124:
             raise TimeoutError("Command timed out")
@@ -689,7 +783,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     @override
     async def write_file(self, file: str, contents: str | bytes) -> None:
         # Writes contents to file, handling large files by splitting them into chunks
-        # and recombining using cat.
+        # and recombining using cat (Linux) or copy /b (Windows).
 
         CHUNK_SIZE = (
             40 * 1024
@@ -699,7 +793,18 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         # potentially be increased here. Would need to check the
         # version number to ensure backward compatibility.
 
-        await self.exec(cmd=["mkdir", "-p", "--", str(Path(file).parent.as_posix())])
+        is_windows = self._is_windows()
+
+        # Create parent directory
+        if is_windows:
+            parent_dir = str(Path(file).parent)
+            await self.exec(
+                cmd=["cmd.exe", "/c", f'if not exist "{parent_dir}" mkdir "{parent_dir}"']
+            )
+        else:
+            await self.exec(
+                cmd=["mkdir", "-p", "--", str(Path(file).parent.as_posix())]
+            )
 
         # If content is small enough, write directly
         if len(contents) <= CHUNK_SIZE:
@@ -714,29 +819,58 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         # Calculate padding width based on number of chunks
         padding_width = len(str(len(chunks) - 1))
 
-        tmp_start = f"/tmp/{__name__}_write_file_{time.time_ns()}_"
+        # Use appropriate temp directory
+        if is_windows:
+            tmp_start = f"C:\\Windows\\Temp\\{__name__}_write_file_{time.time_ns()}_"
+            temp_dir = f"{tmp_start}split_{Path(file).name}"
+        else:
+            tmp_start = f"/tmp/{__name__}_write_file_{time.time_ns()}_"
+            temp_dir = f"{tmp_start}split_{Path(file).name}"
 
-        temp_dir = f"{tmp_start}split_{Path(file).name}"
         try:
-            await self.exec(cmd=["mkdir", "-p", "--", temp_dir])
+            if is_windows:
+                await self.exec(
+                    cmd=["cmd.exe", "/c", f'if not exist "{temp_dir}" mkdir "{temp_dir}"']
+                )
+            else:
+                await self.exec(cmd=["mkdir", "-p", "--", temp_dir])
 
             # Write chunks to temp files with zero-padded numbers
             for i, chunk in enumerate(chunks):
-                chunk_file = f"{temp_dir}/chunk_{i:0{padding_width}d}"
+                if is_windows:
+                    chunk_file = f"{temp_dir}\\chunk_{i:0{padding_width}d}"
+                else:
+                    chunk_file = f"{temp_dir}/chunk_{i:0{padding_width}d}"
                 await self._write_file_only(chunk_file, chunk)
 
-            combine_script = (
-                f"rm -f {file}\n"
-                f'for i in $(seq -f "%0{padding_width}.0f" 0 {len(chunks) - 1}); do\n'
-                f'  cat "{temp_dir}/chunk_$i" >> {file}\n'
-                f"done\n"
-            )
-            combine_script_path = f"{temp_dir}/combine.sh"
-            await self._write_file_only(combine_script_path, combine_script)
-            await self.exec(cmd=["sh", combine_script_path])
+            if is_windows:
+                # Batch script to combine chunks using copy /b
+                combine_script = f'@echo off\r\ndel /f /q "{file}" 2>nul\r\n'
+                for i in range(len(chunks)):
+                    chunk_file = f"{temp_dir}\\chunk_{i:0{padding_width}d}"
+                    if i == 0:
+                        combine_script += f'copy /b "{chunk_file}" "{file}"\r\n'
+                    else:
+                        combine_script += f'copy /b "{file}"+"{chunk_file}" "{file}"\r\n'
+                combine_script_path = f"{temp_dir}\\combine.bat"
+                await self._write_file_only(combine_script_path, combine_script)
+                await self.exec(cmd=["cmd.exe", "/c", combine_script_path])
+            else:
+                combine_script = (
+                    f"rm -f {file}\n"
+                    f'for i in $(seq -f "%0{padding_width}.0f" 0 {len(chunks) - 1}); do\n'
+                    f'  cat "{temp_dir}/chunk_$i" >> {file}\n'
+                    f"done\n"
+                )
+                combine_script_path = f"{temp_dir}/combine.sh"
+                await self._write_file_only(combine_script_path, combine_script)
+                await self.exec(cmd=["sh", combine_script_path])
 
         finally:
-            await self.exec(cmd=["rm", "-rf", temp_dir])
+            if is_windows:
+                await self.exec(cmd=["cmd.exe", "/c", f'rmdir /s /q "{temp_dir}"'])
+            else:
+                await self.exec(cmd=["rm", "-rf", temp_dir])
 
     @override
     async def read_file(self, file: str, text: bool = True) -> Union[str | bytes]:  # type: ignore

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -4,7 +4,7 @@ import re
 import shlex
 import time
 from logging import getLogger
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, Generator, List, Tuple, Type, Union
 
 import tenacity
@@ -825,7 +825,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         # Use appropriate temp directory
         if is_windows:
             tmp_start = f"C:\\Windows\\Temp\\{__name__}_write_file_{time.time_ns()}_"
-            temp_dir = f"{tmp_start}split_{Path(file).name}"
+            temp_dir = f"{tmp_start}split_{PureWindowsPath(file).name}"
         else:
             tmp_start = f"/tmp/{__name__}_write_file_{time.time_ns()}_"
             temp_dir = f"{tmp_start}split_{Path(file).name}"

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -150,6 +150,24 @@ class VmNicConfig(BaseModel, frozen=True):
         return self
 
 
+# Proxmox QEMU OS types. See https://pve.proxmox.com/wiki/Manual:_qm.conf
+OsType: TypeAlias = Literal[
+    "l24",  # Linux 2.4 kernel
+    "l26",  # Linux 2.6+  kernel
+    "other",
+    "solaris",
+    "w2k",  # Windows 2000
+    "w2k3",  # Windows 2003
+    "w2k8",  # Windows 2008
+    "win10",  # Windows 10/2016/2019
+    "win11",  # Windows 11/2022/2025
+    "win7",  # Windows 7/2008r2
+    "win8",  # Windows 8/2012
+    "wvista",  # Windows Vista/2008
+    "wxp",  # Windows XP/2003
+]
+
+
 class VmConfig(BaseModel, frozen=True):
     """
     Configuration for a virtual machine.
@@ -192,23 +210,7 @@ class VmConfig(BaseModel, frozen=True):
     disk_controller: Optional[Literal["scsi", "ide"]] = None
     nic_controller: Optional[Literal["virtio", "e1000"]] = None
     firewall: bool = False
-    os_type: Optional[
-        Literal[
-            "l24",
-            "l26",
-            "other",
-            "solaris",
-            "w2k",
-            "w2k3",
-            "w2k8",
-            "win10",
-            "win11",
-            "win7",
-            "win8",
-            "wvista",
-            "wxp",
-        ]
-    ] = "l26"
+    os_type: Optional[OsType] = "l26"
 
 
 class ProxmoxInstanceConfig(BaseModel, frozen=True):

--- a/tests/proxmoxsandboxtest/conftest.py
+++ b/tests/proxmoxsandboxtest/conftest.py
@@ -1,4 +1,5 @@
 # tests/conftest.py
+import os
 import random
 from typing import AsyncGenerator
 
@@ -13,6 +14,13 @@ from proxmoxsandbox._proxmox_sandbox_environment import (
     ProxmoxSandboxEnvironment,
     ProxmoxSandboxEnvironmentConfig,
 )
+from proxmoxsandbox.schema import VmConfig, VmSourceConfig
+
+# Set PROXMOX_WINDOWS_TEMPLATE_TAG to run tests against a Windows VM.
+# The value should match the tag on an existing Proxmox VM template.
+# The template must be tagged with "inspect;<tag>" and have the QEMU
+# guest agent installed. When unset, Windows test variants are skipped.
+WINDOWS_TEMPLATE_TAG = os.getenv("PROXMOX_WINDOWS_TEMPLATE_TAG")
 
 
 @pytest.fixture
@@ -79,23 +87,59 @@ async def auto_sdn_vnet_aliases(
     await sdn_commands.tear_down_sdn_zone_and_vnet(sdn_zone_id)
 
 
+def _get_os_params() -> list[str]:
+    params = ["linux"]
+    if WINDOWS_TEMPLATE_TAG:
+        params.append("windows")
+    return params
+
+
+def _get_os_config(os_name: str) -> ProxmoxSandboxEnvironmentConfig:
+    if os_name == "linux":
+        return ProxmoxSandboxEnvironmentConfig()
+
+    if os_name == "windows":
+        return ProxmoxSandboxEnvironmentConfig(
+            vms_config=(
+                VmConfig(
+                    vm_source_config=VmSourceConfig(
+                        existing_vm_template_tag=WINDOWS_TEMPLATE_TAG
+                    ),
+                    os_type="win11",
+                    uefi_boot=True,
+                    is_sandbox=True,
+                    ram_mb=8192,
+                ),
+            )
+        )
+
+    raise ValueError(f"Unknown OS: {os_name}")
+
+
+@pytest.fixture(params=_get_os_params())
+def sandbox_env_config_by_os(request) -> ProxmoxSandboxEnvironmentConfig:
+    return _get_os_config(request.param)
+
+
 @pytest.fixture(scope="function")
 async def proxmox_sandbox_environment(
-    sandbox_env_config: ProxmoxSandboxEnvironmentConfig,
+    sandbox_env_config_by_os: ProxmoxSandboxEnvironmentConfig,
 ) -> AsyncGenerator[ProxmoxSandboxEnvironment, None]:
     task_name = "from_conftest"
     await ProxmoxSandboxEnvironment.task_init(task_name=task_name, config=None)
     envs_dict = await ProxmoxSandboxEnvironment.sample_init(
         task_name=task_name,
-        config=sandbox_env_config,
+        config=sandbox_env_config_by_os,
         metadata={},
     )
     default_env = envs_dict["default"]
     assert isinstance(default_env, ProxmoxSandboxEnvironment)
+
     yield default_env
+
     await ProxmoxSandboxEnvironment.sample_cleanup(
         task_name=task_name,
-        config=sandbox_env_config,
+        config=sandbox_env_config_by_os,
         environments=envs_dict,
         interrupted=False,
     )

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -1,8 +1,8 @@
 import hashlib
-import subprocess
 from pathlib import Path
 from typing import List
 
+import pytest
 from inspect_ai.util._sandbox.self_check import self_check
 
 from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
@@ -13,22 +13,41 @@ from .proxmox_sandbox_utils import setup_requests_logging
 async def test_exec_10mb_limit(
     proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
 ) -> None:
-    i = (
+    num_chars = (
         pow(2, 20) * 10 - 1000
     )  # 10 MiB - 1000, there are vagaries around the extra from JSON marshalling
-    print(f"Testing exec with {i} characters")
-    exec_string = ["perl", "-E", "print 'a' x " + str(i)]
 
-    expected = subprocess.run(exec_string, stdout=subprocess.PIPE).stdout.decode(
-        "utf-8"
-    )
+    if proxmox_sandbox_environment._is_windows():
+        exec_cmd = [
+            "powershell",
+            "-Command",
+            f"Write-Host -NoNewline ('a' * {num_chars})",
+        ]
+    else:
+        exec_cmd = ["perl", "-E", f"print 'a' x {num_chars}"]
 
-    exec_result = await proxmox_sandbox_environment.exec(exec_string, timeout=60)
-    assert len(exec_result.stdout) == len(expected)
-    assert exec_result.stdout == expected
+    exec_result = await proxmox_sandbox_environment.exec(exec_cmd, timeout=120)
+    assert len(exec_result.stdout) == num_chars
+    assert exec_result.stdout == "a" * num_chars
 
 
 CURRENT_DIR = Path(__file__).parent
+
+
+async def test_write_file_small(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    test_content = b"Hello from test_write_file_small!"
+
+    if proxmox_sandbox_environment._is_windows():
+        dest_path = "C:\\Windows\\Temp\\test_small.txt"
+    else:
+        dest_path = "/tmp/test_small.txt"
+
+    await proxmox_sandbox_environment.write_file(dest_path, test_content)
+    read_back = await proxmox_sandbox_environment.read_file(dest_path, text=False)
+
+    assert read_back == test_content
 
 
 async def test_write_file_large(
@@ -41,21 +60,32 @@ async def test_write_file_large(
         md5.update(file_contents)
         expected_md5 = md5.hexdigest()
         assert expected_md5 == "b6059a0fec3d0e431531abeabff212fe"
-        await proxmox_sandbox_environment.write_file(
-            "oVirtTinyCore64-13.11.ova", file_contents
+
+    if proxmox_sandbox_environment._is_windows():
+        dest_path = "C:\\Windows\\Temp\\test_large_file.ova"
+    else:
+        dest_path = "test_large_file.ova"
+
+    await proxmox_sandbox_environment.write_file(dest_path, file_contents)
+
+    if proxmox_sandbox_environment._is_windows():
+        exec_result = await proxmox_sandbox_environment.exec(
+            ["certutil", "-hashfile", dest_path, "MD5"], timeout=60
         )
-    exec_result = await proxmox_sandbox_environment.exec(
-        ["md5sum", "oVirtTinyCore64-13.11.ova"]
-    )
-    assert (
-        exec_result.stdout
-        == "b6059a0fec3d0e431531abeabff212fe  oVirtTinyCore64-13.11.ova\n"
-    )
+        assert expected_md5 in exec_result.stdout.lower()
+    else:
+        exec_result = await proxmox_sandbox_environment.exec(
+            ["md5sum", dest_path], timeout=60
+        )
+        assert exec_result.stdout.startswith(expected_md5)
 
 
 async def test_self_check(
     proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
 ) -> None:
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("self_check uses Linux-specific paths and commands")
+
     setup_requests_logging()
 
     known_failures: List[str] = [


### PR DESCRIPTION
Implement support for using windows machine as the agent sandbox. 

This requires additions for exec and write_file into the sandbox. 

Also added some more info/debug logging around proxmox eval setup - I know some of these logs are available in Trace level, but it feels like they should be at a higher level than that. 