### PR TITLE
feat: allow_domains egress filtering for sandbox VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,11 @@ sdn_config=SdnConfig(
 )
 ```
 
-Subdomains must be listed explicitly: `"debian.org"` does **not** cover
-`"deb.debian.org"` or `"security.debian.org"` — list each subdomain you need.
-See the `allow_domains` docstring in `schema.py` for full constraints and
-caveats.
+`"debian.org"` covers the apex and all subdomains (`deb.debian.org`,
+`security.debian.org`, etc.) — no wildcard prefix needed.  Subdomain IPs
+are injected dynamically on first DNS query via dnsmasq `nftset=`.
+See the `allow_domains` docstring in `schema.py` for full constraints
+and caveats.
 
 **Costs:** the gateway template (`inspect-gw`) is built once (~5–10 min).  Per-eval
 overhead is ~30–60 s for the gateway clone to boot.

--- a/README.md
+++ b/README.md
@@ -266,8 +266,10 @@ sdn_config=SdnConfig(
 )
 ```
 
-`"debian.org"` covers the apex and all subdomains — no `*.` prefix needed.  See the
-`allow_domains` docstring in `schema.py` for full constraints and caveats.
+Subdomains must be listed explicitly: `"debian.org"` does **not** cover
+`"deb.debian.org"` or `"security.debian.org"` — list each subdomain you need.
+See the `allow_domains` docstring in `schema.py` for full constraints and
+caveats.
 
 **Costs:** the gateway template (`inspect-gw`) is built once (~5–10 min).  Per-eval
 overhead is ~30–60 s for the gateway clone to boot.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,39 @@ sandbox = SandboxEnvironmentSpec(
 
 Static IP address assignment is *not* supported with this feature.
 
+### Egress filtering with allow_domains
+
+Set `allow_domains` on `SdnConfig` to restrict sandbox internet access to specific domains.
+A gateway VM (cloned per eval sample) enforces the allowlist via dnsmasq + nftables.
+Because the gateway is outside the sandbox, root inside the sandbox cannot bypass it.
+
+```python
+sdn_config=SdnConfig(
+    vnet_configs=(
+        VnetConfig(
+            alias="sandbox-net",
+            subnets=(
+                SubnetConfig(
+                    cidr=ip_network("10.10.0.0/24"),
+                    gateway=ip_address("10.10.0.1"),  # overridden internally
+                    snat=True,                        # overridden internally
+                    dhcp_ranges=(DhcpRange(start=ip_address("10.10.0.10"),
+                                          end=ip_address("10.10.0.100")),),
+                ),
+            ),
+        ),
+    ),
+    use_pve_ipam_dnsnmasq=True,
+    allow_domains=("pypi.org", "files.pythonhosted.org"),
+)
+```
+
+`"debian.org"` covers the apex and all subdomains — no `*.` prefix needed.  See the
+`allow_domains` docstring in `schema.py` for full constraints and caveats.
+
+**Costs:** the gateway template (`inspect-gw`) is built once (~5–10 min).  Per-eval
+overhead is ~30–60 s for the gateway clone to boot.
+
 ## Using OVA files
 
 Proxmox supports OVA import but not OVA export. It is possible to extract the disk images of VMs 
@@ -295,17 +328,22 @@ SDN zones have the pattern `[3 letters from eval task name][random 3 digits][z]`
 
 Some resources will persist after the eval is complete:
 
-- the built-in VM feature creates a template VM `inspect-ubuntu24.04`
+- the built-in VM feature creates template VMs: `inspect-ubuntu24.04`, `inspect-debian13`, `inspect-kali2025.3`
+- the `allow_domains` feature creates a gateway VM template `inspect-gw` on first use
 - the built-in VM feature creates a SDN zone called `inspvmz`
 - uploaded OVAs are left in place
 - cloud-init ISOs are left in place
 
 Environment cleanup is partially implemented. There is no way to tag all the resources
-created by a particular eval. Therefore the cleanup process for `inspect sandbox cleanup proxmox` 
+created by a particular eval. Therefore the cleanup process for `inspect sandbox cleanup proxmox`
 will delete:
 
-- all VMs tagged `inspect` 
+- all VMs tagged `inspect`
 - any SDN zones created with names matching the pattern above.
+
+If an eval is interrupted (e.g. Ctrl+C), per-sample cleanup is skipped and VMs are left
+running. This includes any gateway VM clones created for `allow_domains` evals. Run
+`inspect sandbox cleanup proxmox` to collect them.
 
 ## Versioning
 

--- a/docs/decisions/001-dnsmasq-nftset-over-pfsense.md
+++ b/docs/decisions/001-dnsmasq-nftset-over-pfsense.md
@@ -1,0 +1,52 @@
+# ADR-001: dnsmasq nftset over pfSense for domain-based egress filtering
+
+**Status:** Accepted
+**Date:** 2026-03-31
+**Context:** allow_domains egress filtering for sandbox VMs
+
+## Decision
+
+Use dnsmasq's `nftset=` directive to dynamically push resolved IPs into the
+nftables `allowed_ips` set, rather than deploying pfSense/OPNsense as a
+firewall appliance.
+
+## Why this approach
+
+dnsmasq is both the DNS resolver and the nftables set populator. When a
+sandbox VM queries `cdn.example.com`, dnsmasq resolves it, returns the answer
+to the client, and simultaneously pushes the resolved IPs into the nftables
+set. The firewall and DNS resolver share state directly — zero lag, zero
+desync.
+
+This is a **cooperative design**: the DNS resolver and packet filter are on
+the same box and communicate via a shared data structure (the nftables set).
+
+## The alternative not taken
+
+**pfSense/OPNsense FQDN aliases** resolve domains *independently* from the
+client on a 300-second timer via a daemon called `filterdns`. The firewall's
+DNS resolver (unbound) and packet filter (pf) are architecturally separate
+with no shared-state mechanism.
+
+This creates a **resolver desync problem**: if `cdn.example.com` is behind a
+CDN with geo-distributed anycast, pfSense gets IPs {A,B,C} while the sandbox
+VM gets {D,E,F}. Traffic to {D,E,F} is dropped because pfSense only knows
+about {A,B,C}. The pfSense docs explicitly warn about this.
+
+This is an **adversarial design**: two systems independently discover the same
+information and hope they agree.
+
+Additional costs of pfSense:
+- 2-4GB RAM per clone vs ~256MB (10-16x overhead)
+- Full FreeBSD with PHP web UI (large attack surface)
+- 30-60s boot time vs seconds
+- Per-eval isolation requires per-eval clones (expensive) or shared instance
+  (breaks isolation)
+
+## The general principle
+
+**When you control both sides of a data flow, make them share state directly
+instead of having each side independently discover the same information.**
+Any time you're resolving/discovering/computing the same thing in two places
+and hoping they agree, you have an adversarial design that will eventually
+desync.

--- a/src/proxmoxsandbox/_impl/_resources/gateway-cloud-init.yaml
+++ b/src/proxmoxsandbox/_impl/_resources/gateway-cloud-init.yaml
@@ -1,0 +1,42 @@
+#cloud-config
+packages:
+  - qemu-guest-agent
+  - dnsmasq
+  - nftables
+  - iproute2
+  - python3-dnspython
+
+write_files:
+  - path: /etc/nftables.conf
+    permissions: "0644"
+    content: |
+      #!/usr/sbin/nft -f
+      flush ruleset
+      # Fail-closed default: no forwarding until provisioner injects the allowlist.
+      table inet gateway {
+        chain forward {
+          type filter hook forward priority filter; policy drop;
+        }
+      }
+  - path: /etc/dnsmasq.d/base.conf
+    permissions: "0644"
+    content: |
+      # No global upstream — only domains in allowlist.conf are resolved.
+      # Per-domain server= and nftset= entries are injected at provision time.
+      no-resolv
+  - path: /etc/dnsmasq.d/allowlist.conf
+    permissions: "0644"
+    content: |
+      # Placeholder — replaced at provision time with per-eval domain allowlist.
+  - path: /etc/sysctl.d/99-gateway.conf
+    permissions: "0644"
+    content: |
+      net.ipv4.ip_forward = 1
+
+runcmd:
+  - [ systemctl, enable, qemu-guest-agent ]
+  - [ systemctl, start, qemu-guest-agent ]
+  - [ sysctl, -p, /etc/sysctl.d/99-gateway.conf ]
+  - [ systemctl, enable, nftables ]
+  - [ systemctl, enable, dnsmasq ]
+  - [ systemctl, mask, systemd-networkd-wait-online.service ]

--- a/src/proxmoxsandbox/_impl/_resources/pre_resolve.py.template
+++ b/src/proxmoxsandbox/_impl/_resources/pre_resolve.py.template
@@ -1,0 +1,28 @@
+import subprocess
+try:
+    import dns.resolver as _dns
+    _dns_available = True
+except ImportError:
+    # python3-dnspython not installed (old gateway template).
+    # Falls back to system resolver, which may return different IPs than dnsmasq.
+    import socket
+    _dns_available = False
+domains = {domains_repr}
+ips = []
+if _dns_available:
+    resolver = _dns.Resolver()
+    resolver.nameservers = ['8.8.8.8']
+    for d in domains:
+        try:
+            ips.extend(str(r) for r in resolver.resolve(d, 'A'))
+        except Exception:
+            pass
+else:
+    for d in domains:
+        try:
+            ips.extend(r[4][0] for r in socket.getaddrinfo(d, None, socket.AF_INET))
+        except Exception:
+            pass
+if ips:
+    nft_in = 'add element inet gateway allowed_ips { ' + ', '.join(ips) + ' }'
+    subprocess.run(['nft', '-f', '-'], input=nft_in, text=True, check=True)

--- a/src/proxmoxsandbox/_impl/_resources/pre_resolve.py.template
+++ b/src/proxmoxsandbox/_impl/_resources/pre_resolve.py.template
@@ -1,3 +1,4 @@
+import ipaddress
 import subprocess
 try:
     import dns.resolver as _dns
@@ -7,22 +8,43 @@ except ImportError:
     # Falls back to system resolver, which may return different IPs than dnsmasq.
     import socket
     _dns_available = False
+
+_PRIVATE_NETS = (
+    ipaddress.ip_network('10.0.0.0/8'),
+    ipaddress.ip_network('172.16.0.0/12'),
+    ipaddress.ip_network('192.168.0.0/16'),
+    ipaddress.ip_network('127.0.0.0/8'),
+    ipaddress.ip_network('169.254.0.0/16'),
+)
+
+def _is_private(ip_str):
+    addr = ipaddress.ip_address(ip_str)
+    return any(addr in net for net in _PRIVATE_NETS)
+
 domains = {domains_repr}
-ips = []
+raw_ips = []
 if _dns_available:
     resolver = _dns.Resolver()
     resolver.nameservers = ['8.8.8.8']
     for d in domains:
         try:
-            ips.extend(str(r) for r in resolver.resolve(d, 'A'))
+            raw_ips.extend(str(r) for r in resolver.resolve(d, 'A'))
         except Exception:
             pass
 else:
     for d in domains:
         try:
-            ips.extend(r[4][0] for r in socket.getaddrinfo(d, None, socket.AF_INET))
+            raw_ips.extend(r[4][0] for r in socket.getaddrinfo(d, None, socket.AF_INET))
         except Exception:
             pass
+# Filter out RFC1918, loopback, and link-local to prevent DNS
+# rebinding attacks from seeding internal IPs into the nftables set.
+def _safe_public(ip_str):
+    try:
+        return not _is_private(ip_str)
+    except ValueError:
+        return False
+ips = [ip for ip in raw_ips if _safe_public(ip)]
 if ips:
     nft_in = 'add element inet gateway allowed_ips { ' + ', '.join(ips) + ' }'
     subprocess.run(['nft', '-f', '-'], input=nft_in, text=True, check=True)

--- a/src/proxmoxsandbox/_impl/built_in_vm.py
+++ b/src/proxmoxsandbox/_impl/built_in_vm.py
@@ -1,4 +1,5 @@
 import abc
+import importlib.resources
 import os
 import re
 import subprocess
@@ -60,50 +61,11 @@ GATEWAY_VM_TAG = "gateway"
 # reachable from sandbox VMs on the same vnet, so minimising listening services
 # reduces the attack surface a compromised sandbox can reach.  Do not add SSH or
 # other management daemons to this image.
-GATEWAY_CLOUD_INIT = """\
-#cloud-config
-packages:
-  - qemu-guest-agent
-  - dnsmasq
-  - nftables
-  - iproute2
-  - python3-dnspython
-
-write_files:
-  - path: /etc/nftables.conf
-    permissions: "0644"
-    content: |
-      #!/usr/sbin/nft -f
-      flush ruleset
-      # Fail-closed default: no forwarding until provisioner injects the allowlist.
-      table inet gateway {
-        chain forward {
-          type filter hook forward priority filter; policy drop;
-        }
-      }
-  - path: /etc/dnsmasq.d/base.conf
-    permissions: "0644"
-    content: |
-      # No global upstream — only domains in allowlist.conf are resolved.
-      # Per-domain server= and nftset= entries are injected at provision time.
-      no-resolv
-  - path: /etc/dnsmasq.d/allowlist.conf
-    permissions: "0644"
-    content: |
-      # Placeholder — replaced at provision time with per-eval domain allowlist.
-  - path: /etc/sysctl.d/99-gateway.conf
-    permissions: "0644"
-    content: |
-      net.ipv4.ip_forward = 1
-
-runcmd:
-  - [ systemctl, enable, qemu-guest-agent ]
-  - [ systemctl, start, qemu-guest-agent ]
-  - [ sysctl, -p, /etc/sysctl.d/99-gateway.conf ]
-  - [ systemctl, enable, nftables ]
-  - [ systemctl, enable, dnsmasq ]
-  - [ systemctl, mask, systemd-networkd-wait-online.service ]
-"""
+GATEWAY_CLOUD_INIT = (
+    importlib.resources.files("proxmoxsandbox._impl._resources")
+    .joinpath("gateway-cloud-init.yaml")
+    .read_text(encoding="utf-8")
+)
 
 STATIC_VNET_ID = f"{STATIC_SDN_START}v0"
 

--- a/src/proxmoxsandbox/_impl/built_in_vm.py
+++ b/src/proxmoxsandbox/_impl/built_in_vm.py
@@ -205,6 +205,7 @@ runcmd:
         name: e*
       dhcp4: true
       dhcp6: false
+      accept-ra: false
 """,
     ) -> None:
         """
@@ -386,6 +387,7 @@ runcmd:
         name: e*
       dhcp4: true
       dhcp6: false
+      accept-ra: false
 """,
             )
 

--- a/src/proxmoxsandbox/_impl/built_in_vm.py
+++ b/src/proxmoxsandbox/_impl/built_in_vm.py
@@ -42,10 +42,10 @@ DEBIAN_13_URL = "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-g
 KALI_DOWNLOAD_URL = "https://kali.download/cloud-images/kali-2025.3/kali-linux-2025.3-cloud-genericcloud-amd64.tar.xz"
 KALI_DISK_RENAMED = "kali-2025.3-genericcloud-amd64.raw"
 
-# TODO(CAST): confirm whether Alpine Linux is preferred over Debian here.
-# Alpine (~50 MB, ~10 s boot) vs Debian-minimal (~200 MB, ~20 s boot).
-# Functionally equivalent; choice affects familiarity/debuggability.
-# See ticket for context: the gateway VM runs only dnsmasq + nftables.
+# Debian 13: consistent with the existing built-in VMs in this repo and the broader
+# org (Ubuntu/Debian are the only distros used for VM workloads; Alpine appears only
+# in Dockerfiles). Same base image as the debian13 built-in — reuses any already-
+# downloaded source file.
 GATEWAY_VM_URL = DEBIAN_13_URL
 GATEWAY_VM_TAG = "gateway"
 
@@ -78,10 +78,9 @@ write_files:
   - path: /etc/dnsmasq.d/base.conf
     permissions: "0644"
     content: |
-      # Upstream DNS — provisioner will add interface/listen-address at provision time.
+      # No global upstream — only domains in allowlist.conf are resolved.
+      # Per-domain server= and nftset= entries are injected at provision time.
       no-resolv
-      server=8.8.8.8
-      server=8.8.4.4
   - path: /etc/dnsmasq.d/allowlist.conf
     permissions: "0644"
     content: |

--- a/src/proxmoxsandbox/_impl/built_in_vm.py
+++ b/src/proxmoxsandbox/_impl/built_in_vm.py
@@ -55,6 +55,11 @@ GATEWAY_VM_TAG = "gateway"
 # sandbox subnet CIDR and domain list.
 # The template boots in a fail-closed state: nftables drops all forwarded traffic,
 # dnsmasq starts but resolves nothing until the allowlist is written.
+#
+# Security: openssh-server is intentionally NOT installed.  The gateway VM is
+# reachable from sandbox VMs on the same vnet, so minimising listening services
+# reduces the attack surface a compromised sandbox can reach.  Do not add SSH or
+# other management daemons to this image.
 GATEWAY_CLOUD_INIT = """\
 #cloud-config
 packages:
@@ -352,6 +357,11 @@ runcmd:
         It acts as the egress filter for sandbox VMs when allow_domains is set.
         The nftables ruleset and dnsmasq allowlist are injected at provision time;
         the template only provides the packages and a fail-closed default config.
+
+        Performance: template creation is a one-time cost (~5–10 minutes, dominated
+        by package downloads for dnsmasq + nftables).  Subsequent calls return
+        immediately once the template exists.  Per-eval cost (cloning + provisioning
+        the gateway) is ~30–60 s on top of the normal sandbox VM startup time.
         """
         if await self.known_gateway() is not None:
             return

--- a/src/proxmoxsandbox/_impl/built_in_vm.py
+++ b/src/proxmoxsandbox/_impl/built_in_vm.py
@@ -67,6 +67,7 @@ packages:
   - dnsmasq
   - nftables
   - iproute2
+  - python3-dnspython
 
 write_files:
   - path: /etc/nftables.conf

--- a/src/proxmoxsandbox/_impl/built_in_vm.py
+++ b/src/proxmoxsandbox/_impl/built_in_vm.py
@@ -42,6 +42,64 @@ DEBIAN_13_URL = "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-g
 KALI_DOWNLOAD_URL = "https://kali.download/cloud-images/kali-2025.3/kali-linux-2025.3-cloud-genericcloud-amd64.tar.xz"
 KALI_DISK_RENAMED = "kali-2025.3-genericcloud-amd64.raw"
 
+# TODO(CAST): confirm whether Alpine Linux is preferred over Debian here.
+# Alpine (~50 MB, ~10 s boot) vs Debian-minimal (~200 MB, ~20 s boot).
+# Functionally equivalent; choice affects familiarity/debuggability.
+# See ticket for context: the gateway VM runs only dnsmasq + nftables.
+GATEWAY_VM_URL = DEBIAN_13_URL
+GATEWAY_VM_TAG = "gateway"
+
+# Minimal cloud-init for the gateway VM template.
+# Does NOT contain the nftables ruleset or dnsmasq allowlist — those are injected at
+# provision time (via write_file + exec_command) because they depend on the per-eval
+# sandbox subnet CIDR and domain list.
+# The template boots in a fail-closed state: nftables drops all forwarded traffic,
+# dnsmasq starts but resolves nothing until the allowlist is written.
+GATEWAY_CLOUD_INIT = """\
+#cloud-config
+packages:
+  - qemu-guest-agent
+  - dnsmasq
+  - nftables
+  - iproute2
+
+write_files:
+  - path: /etc/nftables.conf
+    permissions: "0644"
+    content: |
+      #!/usr/sbin/nft -f
+      flush ruleset
+      # Fail-closed default: no forwarding until provisioner injects the allowlist.
+      table inet gateway {
+        chain forward {
+          type filter hook forward priority filter; policy drop;
+        }
+      }
+  - path: /etc/dnsmasq.d/base.conf
+    permissions: "0644"
+    content: |
+      # Upstream DNS — provisioner will add interface/listen-address at provision time.
+      no-resolv
+      server=8.8.8.8
+      server=8.8.4.4
+  - path: /etc/dnsmasq.d/allowlist.conf
+    permissions: "0644"
+    content: |
+      # Placeholder — replaced at provision time with per-eval domain allowlist.
+  - path: /etc/sysctl.d/99-gateway.conf
+    permissions: "0644"
+    content: |
+      net.ipv4.ip_forward = 1
+
+runcmd:
+  - [ systemctl, enable, qemu-guest-agent ]
+  - [ systemctl, start, qemu-guest-agent ]
+  - [ sysctl, -p, /etc/sysctl.d/99-gateway.conf ]
+  - [ systemctl, enable, nftables ]
+  - [ systemctl, enable, dnsmasq ]
+  - [ systemctl, mask, systemd-networkd-wait-online.service ]
+"""
+
 STATIC_VNET_ID = f"{STATIC_SDN_START}v0"
 
 
@@ -272,6 +330,175 @@ runcmd:
                 await self.qemu_commands.destroy_vm(vm_id=existing_vms[existing_vm])
 
         await self.task_wrapper.do_action_and_wait_for_tasks(inner_clear_builtins)
+
+    async def known_gateway(self) -> int | None:
+        """Return the VM ID of the gateway template, or None if it does not exist."""
+        existing_vms = await self.qemu_commands.list_vms()
+        for existing_vm in existing_vms:
+            if (
+                "tags" in existing_vm
+                and "template" in existing_vm
+                and existing_vm["template"] == 1
+                and "inspect" in existing_vm["tags"].split(";")
+                and GATEWAY_VM_TAG in existing_vm["tags"].split(";")
+            ):
+                return existing_vm["vmid"]
+        return None
+
+    async def ensure_gateway_exists(self) -> None:
+        """
+        Ensure the gateway VM template exists, creating it if necessary.
+
+        The gateway VM is a minimal Debian VM with dnsmasq + nftables installed.
+        It acts as the egress filter for sandbox VMs when allow_domains is set.
+        The nftables ruleset and dnsmasq allowlist are injected at provision time;
+        the template only provides the packages and a fail-closed default config.
+        """
+        if await self.known_gateway() is not None:
+            return
+
+        await self.ensure_version(9)
+
+        source_image_name = Path(urlparse(GATEWAY_VM_URL).path).name
+        await self.ensure_source_uploaded(
+            GATEWAY_VM_TAG, source_image_name, GATEWAY_VM_URL
+        )
+
+        await self.ensure_static_sdn_exists()
+
+        next_available_vm_id = await self.qemu_commands.find_next_available_vm_id()
+        await self._startup_gateway_vm(next_available_vm_id, source_image_name)
+
+    async def _startup_gateway_vm(
+        self, next_available_vm_id: int, source_image_name: str
+    ) -> None:
+        with trace_action(
+            self.logger,
+            TRACE_NAME,
+            f"create gateway VM template {next_available_vm_id=}",
+        ):
+
+            async def do_create() -> None:
+                await self.async_proxmox.request(
+                    "POST",
+                    f"/nodes/{self.node}/qemu",
+                    json={
+                        "vmid": next_available_vm_id,
+                        "name": "inspect-gateway",
+                        "node": self.node,
+                        "cpu": "host",
+                        "memory": 256,
+                        "cores": 1,
+                        "ostype": "l26",
+                        "scsi0": "local-lvm:0,"
+                        + f"import-from={self.storage}:import/{source_image_name},"
+                        + "format=qcow2,cache=writeback",
+                        "scsihw": "virtio-scsi-single",
+                        "net0": f"virtio,bridge={STATIC_VNET_ID}",
+                        "serial0": "socket",
+                        "start": False,
+                        "agent": "enabled=1",
+                    },
+                )
+
+            await self.task_wrapper.do_action_and_wait_for_tasks(do_create)
+
+            await self.create_and_upload_cloudinit_iso(
+                vm_id=next_available_vm_id,
+                user_data=GATEWAY_CLOUD_INIT,
+                network_config="""network:
+  version: 2
+  ethernets:
+    default:
+      match:
+        name: e*
+      dhcp4: true
+      dhcp6: false
+""",
+            )
+
+            async def update_tags() -> None:
+                await self.async_proxmox.request(
+                    "POST",
+                    f"/nodes/{self.node}/qemu/{next_available_vm_id}/config",
+                    json={"tags": f"inspect,{GATEWAY_VM_TAG}"},
+                )
+
+            await self.task_wrapper.do_action_and_wait_for_tasks(update_tags)
+
+            await self.qemu_commands.start_and_await(
+                vm_id=next_available_vm_id, is_sandbox=True
+            )
+
+            agent_commands = AgentCommands(self.async_proxmox, self.node)
+            res = await agent_commands.exec_command(
+                vm_id=next_available_vm_id,
+                command=["cloud-init", "status", "--wait"],
+            )
+
+            @tenacity.retry(
+                wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
+                stop=tenacity.stop_after_delay(VM_TIMEOUT),
+                retry=tenacity.retry_if_result(lambda x: x is False),
+            )
+            async def wait_for_cloud_init() -> bool:
+                exec_status = await agent_commands.get_agent_exec_status(
+                    vm_id=next_available_vm_id, pid=res["pid"]
+                )
+                if exec_status["exited"] == 1:
+                    if exec_status["out-data"].strip() == "status: done":
+                        return True
+                    else:
+                        raise ValueError(
+                            f"cloud-init failed: {exec_status['out-data']}"
+                        )
+                else:
+                    return False
+
+            await wait_for_cloud_init()
+
+            await self.async_proxmox.request(
+                "POST",
+                f"/nodes/{self.node}/qemu/{next_available_vm_id}/status/shutdown",
+            )
+
+            await self.qemu_commands.await_vm(
+                vm_id=next_available_vm_id,
+                is_sandbox=True,
+                status_for_wait="stopped",
+            )
+
+            await self.async_proxmox.request(
+                "POST",
+                f"/nodes/{self.node}/qemu/{next_available_vm_id}/template",
+            )
+
+            @tenacity.retry(
+                wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
+                stop=tenacity.stop_after_delay(VM_TIMEOUT),
+                retry=tenacity.retry_if_result(lambda x: x is False),
+            )
+            async def is_template() -> bool:
+                current_config = await self.async_proxmox.request(
+                    "GET",
+                    f"/nodes/{self.node}/qemu/{next_available_vm_id}/config?current=1",
+                )
+                return current_config["template"] == 1
+
+            await is_template()
+
+            @tenacity.retry(
+                wait=tenacity.wait_exponential(min=1, exp_base=1.3),
+                stop=tenacity.stop_after_delay(30),
+            )
+            async def remove_cdrom() -> None:
+                await self.async_proxmox.request(
+                    "POST",
+                    f"/nodes/{self.node}/qemu/{next_available_vm_id}/config",
+                    json={"ide2": "none,media=cdrom"},
+                )
+
+            await remove_cdrom()
 
     async def known_builtins(self) -> Dict[str, int]:
         existing_vms = await self.qemu_commands.list_vms()

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -115,25 +115,52 @@ table inet gateway {{
 def _dnsmasq_allowlist_config(gateway_ip: str, allow_domains: Tuple[str, ...]) -> str:
     """Generate the per-eval dnsmasq allowlist config for the gateway VM.
 
-    Each allowed domain gets:
-    - server=/<domain>/8.8.8.8  — forward DNS queries to Google
-    - nftset=/<domain>/4#inet#gateway#allowed_ips  — add resolved IPs to nftables set
+    Each allowed domain gets server=/<domain>/8.8.8.8 so dnsmasq forwards
+    those queries upstream.  dnsmasq's /domain/ syntax matches the apex and
+    all subdomains, so "debian.org" covers mirrors.debian.org too.
 
-    dnsmasq's /domain/ syntax matches the apex domain AND all subdomains, so
-    "debian.org" covers both debian.org and mirrors.debian.org.
+    Without a global server= directive, any unlisted domain gets SERVFAIL.
 
-    Without a global server= directive (removed from base.conf), any domain NOT
-    listed here gets SERVFAIL — dnsmasq has no upstream to ask.
+    listen-address is set to the gateway's sandbox-facing IP only (not
+    127.0.0.1) to avoid conflicting with systemd-resolved on the loopback.
+
+    nftset= is intentionally omitted: Debian 13's dnsmasq package may not be
+    compiled with --enable-nftset.  The nftables allowed_ips set is populated
+    at provision time by _pre_resolve_script instead.
     """
     lines = [
         "# Per-eval allowlist — generated at provision time.",
-        f"listen-address=127.0.0.1,{gateway_ip}",
+        f"listen-address={gateway_ip}",
         "",
     ]
     for domain in allow_domains:
         lines.append(f"server=/{domain}/8.8.8.8")
-        lines.append(f"nftset=/{domain}/4#inet#gateway#allowed_ips")
     return "\n".join(lines) + "\n"
+
+
+def _pre_resolve_script(allow_domains: Tuple[str, ...]) -> str:
+    """Return a Python script that resolves allowed domains and seeds the nftables set.
+
+    Run once at provision time so traffic to those IPs is forwarded even before
+    the first DNS query (and without relying on dnsmasq nftset support).
+    """
+    domains_repr = repr(list(allow_domains))
+    return (
+        "\n".join(
+            [
+                "import socket, subprocess",
+                f"domains = {domains_repr}",
+                "ips = list({{r[4][0] for d in domains"
+                " for r in socket.getaddrinfo(d, None, socket.AF_INET)}})",
+                "if ips:",
+                "    nft_in = 'add element inet gateway allowed_ips { '"
+                " + ', '.join(ips) + ' }'",
+                "    subprocess.run(['nft', '-f', '-'], input=nft_in,"
+                " text=True, check=True)",
+            ]
+        )
+        + "\n"
+    )
 
 
 class InfraCommands(abc.ABC):
@@ -414,6 +441,41 @@ class InfraCommands(abc.ABC):
 
         await wait_for_dnsmasq_restart()
 
+        # Seed the nftables allowed_ips set by resolving the allowed domains now,
+        # rather than waiting for the first DNS query (which requires dnsmasq nftset
+        # support that Debian 13's package may not have compiled in).
+        pre_resolve = _pre_resolve_script(allow_domains)
+        await agent_commands.write_file(
+            vm_id=new_vm_id,
+            content=pre_resolve.encode("utf-8"),
+            filepath="/tmp/pre_resolve.py",
+        )
+        resolve_res = await agent_commands.exec_command(
+            vm_id=new_vm_id,
+            command=["python3", "/tmp/pre_resolve.py"],
+        )
+
+        @tenacity.retry(
+            wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
+            stop=tenacity.stop_after_delay(30),
+            retry=tenacity.retry_if_result(lambda x: x is False),
+        )
+        async def wait_for_pre_resolve() -> bool:
+            status = await agent_commands.get_agent_exec_status(
+                vm_id=new_vm_id, pid=resolve_res["pid"]
+            )
+            if status["exited"] == 1:
+                if status["exitcode"] != 0:
+                    raise ValueError(
+                        f"pre-resolve failed: "
+                        f"stdout={status.get('out-data', '')!r}, "
+                        f"stderr={status.get('err-data', '')!r}"
+                    )
+                return True
+            return False
+
+        await wait_for_pre_resolve()
+
         return new_vm_id
 
     async def create_sdn_and_vms(
@@ -458,9 +520,7 @@ class InfraCommands(abc.ABC):
             sandbox_cidr = str(sdn_config.vnet_configs[0].subnets[0].cidr)
             gateway_ip = _gateway_ip_for_subnet(sandbox_cidr)
             gateway_mac = _gateway_mac(proxmox_ids_start)
-            with trace_action(
-                self.logger, self.TRACE_NAME, "provision gateway VM"
-            ):
+            with trace_action(self.logger, self.TRACE_NAME, "provision gateway VM"):
                 gateway_vm_id = await self._provision_gateway(
                     proxmox_ids_start=proxmox_ids_start,
                     vnet_aliases=vnet_aliases,

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -1,5 +1,6 @@
 import abc
 import hashlib
+import importlib.resources
 import os
 import re
 import sys
@@ -38,8 +39,8 @@ def _gateway_mac(proxmox_ids_start: str) -> str:
     """Derive a unique, deterministic MAC from the per-eval proxmox_ids_start prefix.
 
     Uses the QEMU/KVM OUI (52:54:00) so Proxmox recognises it as a valid virtual NIC.
-    The 3-byte suffix is an MD5 hash of the prefix, giving per-eval uniqueness with
-    zero coordination overhead.
+    The 3-byte suffix is an MD5 hash of the prefix, giving per-eval uniqueness
+    without shared state or synchronisation.
     """
     digest = hashlib.md5(proxmox_ids_start.encode(), usedforsecurity=False).digest()
     return f"52:54:00:{digest[0]:02x}:{digest[1]:02x}:{digest[2]:02x}"
@@ -74,8 +75,10 @@ def _nftables_config(sandbox_cidr: str) -> str:
     - forward: default-drop; only allows traffic to IPs in the allowed_ips set,
       which is seeded at provision time by _pre_resolve_script (resolving the
       allowlist domains and adding their IPs via 'nft add element').  dnsmasq's
-      nftset= directive is intentionally not used — Debian 13's package may not
-      be compiled with --enable-nftset.
+      nftset= directive is intentionally not used.  Although Debian 13's
+      dnsmasq (≥2.87) does support nftset, it only populates the nftables set on DNS
+      query — not at boot.  Pre-resolving at provision time ensures IPs are seeded
+      before the first connection attempt, which is simpler and more predictable.
 
     Known gap — IPv6:
     All rules are IPv4-only.  IPv6 egress from the sandbox is not filtered here.
@@ -137,9 +140,10 @@ def _dnsmasq_allowlist_config(gateway_ip: str, allow_domains: Tuple[str, ...]) -
     exactly the specified IP, so the restart doesn't race with the boot-time
     dnsmasq instance releasing 0.0.0.0:53.
 
-    nftset= is intentionally omitted: Debian 13's dnsmasq package may not be
-    compiled with --enable-nftset.  The nftables allowed_ips set is populated
-    at provision time by _pre_resolve_script instead.
+    nftset= is intentionally omitted.  Although Debian 13's dnsmasq supports it
+    (--enable-nftset has been compiled in since 2.87), nftset only populates
+    allowed_ips on DNS query rather than at boot.  Pre-resolving at provision
+    time (_pre_resolve_script) seeds IPs before the first connection attempt.
     """
     lines = [
         "# Per-eval allowlist — generated at provision time.",
@@ -156,7 +160,7 @@ def _pre_resolve_script(allow_domains: Tuple[str, ...]) -> str:
     """Return a Python script that resolves allowed domains and seeds the nftables set.
 
     Run once at provision time so traffic to those IPs is forwarded even before
-    the first DNS query (and without relying on dnsmasq nftset support).
+    the first DNS query.
 
     Queries 8.8.8.8 directly (via python3-dnspython) to match dnsmasq's upstream,
     avoiding IP mismatch when the gateway's system resolver uses a different DNS
@@ -166,41 +170,15 @@ def _pre_resolve_script(allow_domains: Tuple[str, ...]) -> str:
     Limitation: only apex domains are pre-resolved.  Subdomains of allowed domains
     (e.g. ftp.gnu.org when "gnu.org" is allowed) are resolved at query time by
     dnsmasq but their IPs are NOT added to allowed_ips here — they will be dropped
-    by the FORWARD chain.  The fix is to enable dnsmasq's nftset= support when the
-    installed package supports it (--enable-nftset), which would add IPs dynamically.
+    by the FORWARD chain.  Explicit subdomain listing is required.
     """
     domains_repr = repr(list(allow_domains))
-    # {{ and }} in this f-string produce literal { and } in the emitted Python script.
-    return f"""\
-import subprocess
-try:
-    import dns.resolver as _dns
-    _dns_available = True
-except ImportError:
-    # python3-dnspython not installed (old gateway template).
-    # Falls back to system resolver, which may return different IPs than dnsmasq.
-    import socket
-    _dns_available = False
-domains = {domains_repr}
-ips = []
-if _dns_available:
-    resolver = _dns.Resolver()
-    resolver.nameservers = ['8.8.8.8']
-    for d in domains:
-        try:
-            ips.extend(str(r) for r in resolver.resolve(d, 'A'))
-        except Exception:
-            pass
-else:
-    for d in domains:
-        try:
-            ips.extend(r[4][0] for r in socket.getaddrinfo(d, None, socket.AF_INET))
-        except Exception:
-            pass
-if ips:
-    nft_in = 'add element inet gateway allowed_ips {{ ' + ', '.join(ips) + ' }}'
-    subprocess.run(['nft', '-f', '-'], input=nft_in, text=True, check=True)
-"""
+    template = (
+        importlib.resources.files("proxmoxsandbox._impl._resources")
+        .joinpath("pre_resolve.py.template")
+        .read_text(encoding="utf-8")
+    )
+    return template.replace("{domains_repr}", domains_repr)
 
 
 class InfraCommands(abc.ABC):
@@ -240,8 +218,11 @@ class InfraCommands(abc.ABC):
         """
         if not sdn_config.use_pve_ipam_dnsnmasq:
             raise ValueError(
-                "allow_domains requires use_pve_ipam_dnsnmasq=True "
-                "(the gateway VM uses Proxmox IPAM for its static IP assignment)"
+                "allow_domains requires use_pve_ipam_dnsnmasq=True. "
+                "Proxmox IPAM is still used to reserve sandbox VM IPs and "
+                "assign the gateway VM its address via DHCP. The gateway VM "
+                "runs its own separate dnsmasq instance for DNS filtering only — "
+                "it does not replace Proxmox's dnsmasq for DHCP."
             )
         if len(sdn_config.vnet_configs) != 1:
             raise ValueError(
@@ -278,28 +259,14 @@ class InfraCommands(abc.ABC):
         )
 
         # Pick an external VNet CIDR that doesn't overlap with the sandbox CIDR
-        # or any existing Proxmox CIDRs.  Shuffle to reduce collision risk.
-        try_third_octets = list(range(2, 253))
-        shuffle(try_third_octets)
-        external_vnet = None
-        for third_octet in try_third_octets:
-            candidate = self.sdn_commands.simple_vnet_config(third_octet=third_octet)
-            candidate_cidr = ip_network(str(candidate.subnets[0].cidr))
-            if sandbox_network.overlaps(candidate_cidr):
-                continue
-            try:
-                # Only check the candidate against existing Proxmox CIDRs, not
-                # modified_sandbox_vnet: the sandbox CIDR may appear in a stale
-                # leftover zone from a failed run (which create_sdn will overwrite),
-                # and including it would falsely poison every iteration.
-                await self.sdn_commands.check_cidrs([candidate])
-                external_vnet = candidate
-                break
-            except ValueError:
-                continue
-
-        if external_vnet is None:
-            raise ValueError("Could not find a suitable external VNet CIDR")
+        # or any existing Proxmox CIDRs.
+        # Only exclude the sandbox_network — not modified_sandbox_vnet — because the
+        # sandbox CIDR may appear in a stale leftover Proxmox zone from a failed run
+        # (which create_sdn will overwrite), and including it would falsely poison
+        # every iteration inside find_non_overlapping_vnet_config.
+        external_vnet = await self.sdn_commands.find_non_overlapping_vnet_config(
+            exclude_networks=[sandbox_network],
+        )
 
         # allow_domains is intentionally cleared: this returned config is the
         # internal 2-vnet form (sandbox + external) with the gateway already
@@ -338,8 +305,6 @@ class InfraCommands(abc.ABC):
         6. Inject dnsmasq allowlist config and restart dnsmasq.
         7. Pre-resolve allowed domains into the nftables allowed_ips set.
         """
-        # vnet_aliases[0] = (sandbox_vnet_id, alias)
-        # vnet_aliases[1] = (ext_vnet_id, None)
         sandbox_vnet_id = vnet_aliases[0][0]
         external_vnet_id = vnet_aliases[1][0]
 
@@ -402,14 +367,14 @@ class InfraCommands(abc.ABC):
         # subnet config) wins the ARP race and all sandbox traffic hits the
         # bridge instead of the gateway VM's FORWARD chain.
         prefix_len = ip_network(sandbox_cidr).prefixlen
-        network_file = (
-            "[Match]\n"
-            f"MACAddress={gateway_mac}\n"
-            "\n"
-            "[Network]\n"
-            "DHCP=no\n"
-            f"Address={gateway_ip}/{prefix_len}\n"
-        )
+        network_file = f"""\
+[Match]
+MACAddress={gateway_mac}
+
+[Network]
+DHCP=no
+Address={gateway_ip}/{prefix_len}
+"""
         await agent_commands.write_file(
             vm_id=new_vm_id,
             content=network_file.encode("utf-8"),
@@ -517,8 +482,9 @@ class InfraCommands(abc.ABC):
         await wait_for_dnsmasq_restart()
 
         # Seed the nftables allowed_ips set by resolving the allowed domains now,
-        # rather than waiting for the first DNS query (which requires dnsmasq nftset
-        # support that Debian 13's package may not have compiled in).
+        # before the first DNS query.  nftset= would do this dynamically, but
+        # pre-resolving at provision time is simpler and doesn't require dnsmasq
+        # to stay running before traffic is attempted.
         pre_resolve = _pre_resolve_script(allow_domains)
         await agent_commands.write_file(
             vm_id=new_vm_id,
@@ -569,16 +535,9 @@ class InfraCommands(abc.ABC):
             allow_domains = sdn_config.allow_domains
 
         if allow_domains:
-            # FIXME: the branch below is dead code.  `allow_domains` is only
-            # populated when `isinstance(sdn_config, SdnConfig)` (line above),
-            # so `sdn_config == "auto"` is always False here.  The original
-            # intent was probably to support allow_domains on auto-generated
-            # configs (where the user wants filtering but doesn't care about
-            # specific CIDRs).  That would require either a separate top-level
-            # allow_domains field on ProxmoxSandboxEnvironmentConfig, or a
-            # different code path.  Left for future work.
-            if sdn_config == "auto":
-                sdn_config = await self.sdn_commands.generate_sdn_config()
+            # allow_domains requires an explicit SdnConfig (not "auto").  Supporting
+            # allow_domains with auto-generated CIDRs would require a separate
+            # allow_domains field on ProxmoxSandboxEnvironmentConfig; left for future work.
             assert isinstance(sdn_config, SdnConfig)
             sdn_config = await self._prepare_sdn_for_gateway(sdn_config)
 

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -126,7 +126,7 @@ def _dnsmasq_allowlist_config(gateway_ip: str, allow_domains: Tuple[str, ...]) -
 
     Each allowed domain gets server=/<domain>/8.8.8.8 so dnsmasq forwards
     those queries upstream.  dnsmasq's /domain/ syntax matches the apex and
-    all subdomains, so "debian.org" covers mirrors.debian.org too.
+    all subdomains, so "gnu.org" covers ftp.gnu.org too.
 
     Without a global server= directive, any unlisted domain gets SERVFAIL.
 
@@ -164,7 +164,7 @@ def _pre_resolve_script(allow_domains: Tuple[str, ...]) -> str:
     the system resolver if python3-dnspython is not installed (old gateway template).
 
     Limitation: only apex domains are pre-resolved.  Subdomains of allowed domains
-    (e.g. deb.debian.org when "debian.org" is allowed) are resolved at query time by
+    (e.g. ftp.gnu.org when "gnu.org" is allowed) are resolved at query time by
     dnsmasq but their IPs are NOT added to allowed_ips here — they will be dropped
     by the FORWARD chain.  The fix is to enable dnsmasq's nftset= support when the
     installed package supports it (--enable-nftset), which would add IPs dynamically.

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -80,12 +80,14 @@ def _nftables_config(sandbox_cidr: str) -> str:
       query — not at boot.  Pre-resolving at provision time ensures IPs are seeded
       before the first connection attempt, which is simpler and more predictable.
 
-    Known gap — IPv6:
-    All rules are IPv4-only.  IPv6 egress from the sandbox is not filtered here.
-    In practice, Proxmox SDN "simple" zones do not route IPv6, and sandbox
-    cloud-init configs set dhcp6=false, so IPv6 egress is unlikely to be
-    available.  If that changes, add equivalent ip6 rules and an ip6tables
-    forward-drop default.
+    IPv6:
+    table inet covers both IPv4 and IPv6; policy drop on the forward chain
+    therefore drops IPv6 forwarded through the gateway.  The primary IPv6 risk
+    is direct routing: a sandbox VM that receives a Router Advertisement can
+    get a global IPv6 address and route traffic to the internet without touching
+    the gateway.  This is blocked at the sandbox VM level via accept-ra: false
+    in the cloud-init network config (dhcp6: false alone only disables DHCPv6,
+    not SLAAC).
 
     Intentional omission — INPUT chain:
     There are no INPUT chain rules blocking connections from the sandbox to the
@@ -117,6 +119,7 @@ table inet gateway {{
     chain forward {{
         type filter hook forward priority filter; policy drop;
         ct state established,related counter accept
+        ip saddr {sandbox_cidr} ip dport 853 drop
         ip saddr {sandbox_cidr} ip daddr @allowed_ips counter accept
         counter drop
     }}

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -210,12 +210,15 @@ class InfraCommands(abc.ABC):
         external_vnet = None
         for third_octet in try_third_octets:
             candidate = self.sdn_commands.simple_vnet_config(third_octet=third_octet)
+            candidate_cidr = ip_network(str(candidate.subnets[0].cidr))
+            if sandbox_network.overlaps(candidate_cidr):
+                continue
             try:
-                # check_cidrs validates both new vnets against existing Proxmox
-                # CIDRs AND against each other (find_self_cidr_overlaps).
-                await self.sdn_commands.check_cidrs(
-                    [modified_sandbox_vnet, candidate]
-                )
+                # Only check the candidate against existing Proxmox CIDRs, not
+                # modified_sandbox_vnet: the sandbox CIDR may appear in a stale
+                # leftover zone from a failed run (which create_sdn will overwrite),
+                # and including it would falsely poison every iteration.
+                await self.sdn_commands.check_cidrs([candidate])
                 external_vnet = candidate
                 break
             except ValueError:

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -247,50 +247,23 @@ class InfraCommands(abc.ABC):
         gateway_ip: str,
         gateway_mac: str,
         allow_domains: Tuple[str, ...],
-    ) -> Tuple[int, IpamMapping]:
+    ) -> int:
         """Clone the gateway template and configure it for this eval instance.
 
         Steps:
-        1. Create IPAM mapping (MAC → gateway_ip) so the gateway VM gets a static IP.
-        2. Clone the gateway template (linked clone — fast, small).
-        3. Wire NICs: net0 → sandbox vnet (with the static MAC), net1 → external vnet.
-        4. Start VM and wait for QEMU guest agent.
+        1. Clone the gateway template (linked clone — fast, small).
+        2. Wire NICs: net0 → sandbox vnet (with the static MAC), net1 → external vnet.
+        3. Start VM and wait for QEMU guest agent.
+        4. Set static IP on the sandbox NIC via the agent (avoids Proxmox IPAM: the
+           subnet's gateway IP is already claimed by Proxmox as a topology entry with
+           no MAC, blocking any MAC-based DHCP reservation for the same address).
         5. Inject nftables ruleset and apply it.
         6. Inject dnsmasq allowlist config and restart dnsmasq.
-
-        Returns:
-            Tuple of (gateway VM ID, the IPAM mapping created for it).
-            The caller must include the IPAM mapping in the teardown list so that
-            if VM deletion fails, the IPAM entry can still be explicitly cleared
-            (an orphaned entry would block subnet/zone deletion).
         """
         # vnet_aliases[0] = (sandbox_vnet_id, alias)
         # vnet_aliases[1] = (ext_vnet_id, None)
         sandbox_vnet_id = vnet_aliases[0][0]
         external_vnet_id = vnet_aliases[1][0]
-
-        # IPAM mapping must be created before the VM boots so Proxmox dnsmasq
-        # serves the right IP to the gateway's MAC address.
-        gateway_ipam = IpamMapping(
-            vnet_id=sandbox_vnet_id,
-            zone_id=sdn_zone_id,
-            mac=gateway_mac,
-            ipv4=ip_address(gateway_ip),
-        )
-        # A stale entry at this IP can remain from a previous failed run whose
-        # cleanup didn't complete. It would block creation of a fresh mapping, so
-        # we delete any existing entry for this IP+vnet before proceeding.
-        # Safe: the entry is a static reservation, not a live lease — no running
-        # VM holds it at this point since we haven't started the gateway VM yet.
-        existing_ipam = await self.sdn_commands.read_all_ipam_mappings()
-        stale = [
-            e.to_ipam_mapping()
-            for e in existing_ipam
-            if e.ip == gateway_ip and e.vnet == sandbox_vnet_id
-        ]
-        if stale:
-            await self.sdn_commands.tear_down_sdn_ip_allocations(stale)
-        await self.sdn_commands.create_ipam_mapping(gateway_ipam)
 
         gateway_template_id = await self.built_in_vm.known_gateway()
         if gateway_template_id is None:
@@ -337,6 +310,44 @@ class InfraCommands(abc.ABC):
         await self.qemu_commands.start_and_await(vm_id=new_vm_id, is_sandbox=True)
 
         agent_commands = AgentCommands(self.async_proxmox, self.node)
+
+        # Set static IP on the sandbox NIC. The VM booted with DHCP; we override
+        # it here because Proxmox auto-claims the subnet's gateway IP as a topology
+        # entry (mac=None) in IPAM, making a MAC-based DHCP reservation impossible.
+        # We find the sandbox interface by its route, flush the DHCP address, then
+        # assign the static IP. The DHCP lease won't renew within the VM's lifetime.
+        prefix_len = ip_network(sandbox_cidr).prefixlen
+        set_ip_res = await agent_commands.exec_command(
+            vm_id=new_vm_id,
+            command=[
+                "bash",
+                "-c",
+                f"iface=$(ip -4 route | awk '$1==\"{sandbox_cidr}\" {{print $3}}');"
+                f" ip addr flush dev $iface;"
+                f" ip addr add {gateway_ip}/{prefix_len} dev $iface",
+            ],
+        )
+
+        @tenacity.retry(
+            wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
+            stop=tenacity.stop_after_delay(30),
+            retry=tenacity.retry_if_result(lambda x: x is False),
+        )
+        async def wait_for_set_ip() -> bool:
+            status = await agent_commands.get_agent_exec_status(
+                vm_id=new_vm_id, pid=set_ip_res["pid"]
+            )
+            if status["exited"] == 1:
+                if status["exitcode"] != 0:
+                    raise ValueError(
+                        f"set static IP failed: "
+                        f"stdout={status.get('out-data', '')!r}, "
+                        f"stderr={status.get('err-data', '')!r}"
+                    )
+                return True
+            return False
+
+        await wait_for_set_ip()
 
         # Inject and apply nftables config
         nft_config = _nftables_config(sandbox_cidr)
@@ -403,7 +414,7 @@ class InfraCommands(abc.ABC):
 
         await wait_for_dnsmasq_restart()
 
-        return new_vm_id, gateway_ipam
+        return new_vm_id
 
     async def create_sdn_and_vms(
         self,
@@ -440,7 +451,6 @@ class InfraCommands(abc.ABC):
         )
 
         gateway_vm_id: int | None = None
-        gateway_ipam: IpamMapping | None = None
         if allow_domains and sdn_zone_id is not None:
             # sdn_config was reassigned to a SdnConfig by _prepare_sdn_for_gateway
             # above; assert helps mypy narrow the type.
@@ -451,7 +461,7 @@ class InfraCommands(abc.ABC):
             with trace_action(
                 self.logger, self.TRACE_NAME, "provision gateway VM"
             ):
-                gateway_vm_id, gateway_ipam = await self._provision_gateway(
+                gateway_vm_id = await self._provision_gateway(
                     proxmox_ids_start=proxmox_ids_start,
                     vnet_aliases=vnet_aliases,
                     sdn_zone_id=sdn_zone_id,
@@ -463,9 +473,7 @@ class InfraCommands(abc.ABC):
 
         known_builtins = await self.built_in_vm.known_builtins()
 
-        # Gateway IPAM is prepended so it is torn down before the zone is deleted,
-        # matching the behaviour of VM-level IPAM entries in create_ipam_mappings.
-        ipam_mappings: List[IpamMapping] = [gateway_ipam] if gateway_ipam else []
+        ipam_mappings: List[IpamMapping] = []
 
         for vm_config in vms_config:
             # We have to create the IPAM entries before booting the VMs

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -224,7 +224,7 @@ class InfraCommands(abc.ABC):
         gateway_ip: str,
         gateway_mac: str,
         allow_domains: Tuple[str, ...],
-    ) -> int:
+    ) -> Tuple[int, IpamMapping]:
         """Clone the gateway template and configure it for this eval instance.
 
         Steps:
@@ -236,7 +236,10 @@ class InfraCommands(abc.ABC):
         6. Inject dnsmasq allowlist config and restart dnsmasq.
 
         Returns:
-            The new VM ID of the gateway clone.
+            Tuple of (gateway VM ID, the IPAM mapping created for it).
+            The caller must include the IPAM mapping in the teardown list so that
+            if VM deletion fails, the IPAM entry can still be explicitly cleared
+            (an orphaned entry would block subnet/zone deletion).
         """
         # vnet_aliases[0] = (sandbox_vnet_id, alias)
         # vnet_aliases[1] = (ext_vnet_id, None)
@@ -364,7 +367,7 @@ class InfraCommands(abc.ABC):
 
         await wait_for_dnsmasq_restart()
 
-        return new_vm_id
+        return new_vm_id, gateway_ipam
 
     async def create_sdn_and_vms(
         self,
@@ -382,8 +385,14 @@ class InfraCommands(abc.ABC):
             allow_domains = sdn_config.allow_domains
 
         if allow_domains:
-            # Resolve "auto" before transforming, since _prepare_sdn_for_gateway
-            # needs a concrete SdnConfig to read and modify.
+            # FIXME: the branch below is dead code.  `allow_domains` is only
+            # populated when `isinstance(sdn_config, SdnConfig)` (line above),
+            # so `sdn_config == "auto"` is always False here.  The original
+            # intent was probably to support allow_domains on auto-generated
+            # configs (where the user wants filtering but doesn't care about
+            # specific CIDRs).  That would require either a separate top-level
+            # allow_domains field on ProxmoxSandboxEnvironmentConfig, or a
+            # different code path.  Left for future work.
             if sdn_config == "auto":
                 sdn_config = await self.sdn_commands.generate_sdn_config()
             assert isinstance(sdn_config, SdnConfig)
@@ -395,6 +404,7 @@ class InfraCommands(abc.ABC):
         )
 
         gateway_vm_id: int | None = None
+        gateway_ipam: IpamMapping | None = None
         if allow_domains and sdn_zone_id is not None:
             # sdn_config was reassigned to a SdnConfig by _prepare_sdn_for_gateway
             # above; assert helps mypy narrow the type.
@@ -405,7 +415,7 @@ class InfraCommands(abc.ABC):
             with trace_action(
                 self.logger, self.TRACE_NAME, "provision gateway VM"
             ):
-                gateway_vm_id = await self._provision_gateway(
+                gateway_vm_id, gateway_ipam = await self._provision_gateway(
                     proxmox_ids_start=proxmox_ids_start,
                     vnet_aliases=vnet_aliases,
                     sdn_zone_id=sdn_zone_id,
@@ -417,7 +427,9 @@ class InfraCommands(abc.ABC):
 
         known_builtins = await self.built_in_vm.known_builtins()
 
-        ipam_mappings = []
+        # Gateway IPAM is prepended so it is torn down before the zone is deleted,
+        # matching the behaviour of VM-level IPAM entries in create_ipam_mappings.
+        ipam_mappings: List[IpamMapping] = [gateway_ipam] if gateway_ipam else []
 
         for vm_config in vms_config:
             # We have to create the IPAM entries before booting the VMs

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -119,7 +119,8 @@ table inet gateway {{
     chain forward {{
         type filter hook forward priority filter; policy drop;
         ct state established,related counter accept
-        ip saddr {sandbox_cidr} ip dport 853 drop
+        ip saddr {sandbox_cidr} tcp dport 853 drop
+        ip saddr {sandbox_cidr} udp dport 853 drop
         ip saddr {sandbox_cidr} ip daddr @allowed_ips counter accept
         counter drop
     }}

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -1,16 +1,20 @@
 import abc
+import hashlib
 import os
 import re
 import sys
+from ipaddress import ip_address, ip_network
 from logging import getLogger
-from random import randint
+from random import randint, shuffle
 from typing import Collection, List, Sequence, Set, Tuple
 
+import tenacity
 from inspect_ai.util import trace_action
 from rich import box, print
 from rich.prompt import Confirm
 from rich.table import Table
 
+from proxmoxsandbox._impl.agent_commands import AgentCommands
 from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI
 from proxmoxsandbox._impl.built_in_vm import BuiltInVM
 from proxmoxsandbox._impl.qemu_commands import QemuCommands
@@ -22,9 +26,99 @@ from proxmoxsandbox._impl.sdn_commands import (
 )
 from proxmoxsandbox._impl.task_wrapper import TaskWrapper
 from proxmoxsandbox.schema import (
+    SdnConfig,
     SdnConfigType,
+    SubnetConfig,
     VmConfig,
+    VnetConfig,
 )
+
+
+def _gateway_mac(proxmox_ids_start: str) -> str:
+    """Derive a unique, deterministic MAC from the per-eval proxmox_ids_start prefix.
+
+    Uses the QEMU/KVM OUI (52:54:00) so Proxmox recognises it as a valid virtual NIC.
+    The 3-byte suffix is an MD5 hash of the prefix, giving per-eval uniqueness with
+    zero coordination overhead.
+    """
+    digest = hashlib.md5(proxmox_ids_start.encode(), usedforsecurity=False).digest()
+    return f"52:54:00:{digest[0]:02x}:{digest[1]:02x}:{digest[2]:02x}"
+
+
+def _gateway_ip_for_subnet(subnet_cidr: str) -> str:
+    """Return the .2 host in the subnet — the gateway VM's sandbox-facing IP.
+
+    .1 is the Proxmox SDN gateway entry (advertised by the zone's dnsmasq as the
+    subnet gateway before the gateway VM takes over).  We use .2 so both can
+    co-exist without conflict.
+    """
+    network = ip_network(subnet_cidr)
+    return str(network.network_address + 2)
+
+
+def _nftables_config(sandbox_cidr: str) -> str:
+    """Generate nftables ruleset for the gateway VM.
+
+    Three chains:
+    - prerouting_nat: intercepts all DNS from the sandbox and redirects it to
+      the gateway's dnsmasq, so sandbox VMs cannot bypass the allowlist by
+      using an alternative DNS server.
+    - postrouting_nat: masquerades forwarded sandbox traffic as the gateway's
+      external IP, so return traffic is routed back correctly.
+    - forward: default-drop; only allows traffic to IPs that dnsmasq has
+      resolved from the allowlist (populated into the nftables set via nftset).
+    """
+    return f"""\
+#!/usr/sbin/nft -f
+flush ruleset
+table inet gateway {{
+    set allowed_ips {{
+        type ipv4_addr
+        flags interval
+    }}
+
+    chain prerouting_nat {{
+        type nat hook prerouting priority dstnat;
+        ip saddr {sandbox_cidr} udp dport 53 redirect to :53
+        ip saddr {sandbox_cidr} tcp dport 53 redirect to :53
+    }}
+
+    chain postrouting_nat {{
+        type nat hook postrouting priority srcnat;
+        ip saddr {sandbox_cidr} masquerade
+    }}
+
+    chain forward {{
+        type filter hook forward priority filter; policy drop;
+        ct state established,related accept
+        ip saddr {sandbox_cidr} ip daddr @allowed_ips accept
+    }}
+}}
+"""
+
+
+def _dnsmasq_allowlist_config(gateway_ip: str, allow_domains: Tuple[str, ...]) -> str:
+    """Generate the per-eval dnsmasq allowlist config for the gateway VM.
+
+    Each allowed domain gets:
+    - server=/<domain>/8.8.8.8  — forward DNS queries to Google
+    - nftset=/<domain>/4#inet#gateway#allowed_ips  — add resolved IPs to nftables set
+
+    dnsmasq's /domain/ syntax matches the apex domain AND all subdomains, so
+    "debian.org" covers both debian.org and mirrors.debian.org.
+
+    Without a global server= directive (removed from base.conf), any domain NOT
+    listed here gets SERVFAIL — dnsmasq has no upstream to ask.
+    """
+    lines = [
+        "# Per-eval allowlist — generated at provision time.",
+        f"listen-address=127.0.0.1,{gateway_ip}",
+        "",
+    ]
+    for domain in allow_domains:
+        lines.append(f"server=/{domain}/8.8.8.8")
+        lines.append(f"nftset=/{domain}/4#inet#gateway#allowed_ips")
+    return "\n".join(lines) + "\n"
 
 
 class InfraCommands(abc.ABC):
@@ -47,16 +141,279 @@ class InfraCommands(abc.ABC):
         self.built_in_vm = BuiltInVM(async_proxmox, node)
         self.node = node
 
+    async def _prepare_sdn_for_gateway(self, sdn_config: SdnConfig) -> SdnConfig:
+        """Transform a SdnConfig to route sandbox egress through a gateway VM.
+
+        Modifies the first (and only) vnet:
+        - gateway IP changed to network .2 (the gateway VM's sandbox-facing IP)
+        - snat set to False (gateway VM does NAT, not Proxmox)
+        - alias set to "sandbox" if unset (needed so gateway's NIC can reference it)
+
+        Adds an external vnet (snat=True) for the gateway VM's internet-facing
+        interface, with a non-overlapping CIDR picked automatically.
+
+        Raises:
+            ValueError: if sdn_config has more than one vnet, if use_pve_ipam_dnsnmasq
+                is False, or if no suitable external CIDR can be found.
+        """
+        if not sdn_config.use_pve_ipam_dnsnmasq:
+            raise ValueError(
+                "allow_domains requires use_pve_ipam_dnsnmasq=True "
+                "(the gateway VM uses Proxmox IPAM for its static IP assignment)"
+            )
+        if len(sdn_config.vnet_configs) != 1:
+            raise ValueError(
+                f"allow_domains requires exactly one vnet_config, "
+                f"got {len(sdn_config.vnet_configs)}"
+            )
+        sandbox_vnet = sdn_config.vnet_configs[0]
+        if len(sandbox_vnet.subnets) != 1:
+            raise ValueError(
+                f"allow_domains requires exactly one subnet per vnet, "
+                f"got {len(sandbox_vnet.subnets)}"
+            )
+
+        sandbox_subnet = sandbox_vnet.subnets[0]
+        sandbox_network = ip_network(str(sandbox_subnet.cidr))
+        gateway_ip = ip_address(sandbox_network.network_address + 2)
+
+        modified_subnet = SubnetConfig(
+            cidr=sandbox_subnet.cidr,
+            gateway=gateway_ip,
+            snat=False,
+            dhcp_ranges=sandbox_subnet.dhcp_ranges,
+        )
+        modified_sandbox_vnet = VnetConfig(
+            alias=sandbox_vnet.alias if sandbox_vnet.alias is not None else "sandbox",
+            subnets=(modified_subnet,),
+        )
+
+        # Pick an external VNet CIDR that doesn't overlap with the sandbox CIDR
+        # or any existing Proxmox CIDRs.  Shuffle to reduce collision risk.
+        try_third_octets = list(range(2, 253))
+        shuffle(try_third_octets)
+        external_vnet = None
+        for third_octet in try_third_octets:
+            candidate = self.sdn_commands.simple_vnet_config(third_octet=third_octet)
+            try:
+                # check_cidrs validates both new vnets against existing Proxmox
+                # CIDRs AND against each other (find_self_cidr_overlaps).
+                await self.sdn_commands.check_cidrs(
+                    [modified_sandbox_vnet, candidate]
+                )
+                external_vnet = candidate
+                break
+            except ValueError:
+                continue
+
+        if external_vnet is None:
+            raise ValueError("Could not find a suitable external VNet CIDR")
+
+        return SdnConfig(
+            vnet_configs=(modified_sandbox_vnet, external_vnet),
+            use_pve_ipam_dnsnmasq=sdn_config.use_pve_ipam_dnsnmasq,
+            allow_domains=sdn_config.allow_domains,
+        )
+
+    async def _provision_gateway(
+        self,
+        proxmox_ids_start: str,
+        vnet_aliases: VnetAliases,
+        sdn_zone_id: str,
+        sandbox_cidr: str,
+        gateway_ip: str,
+        gateway_mac: str,
+        allow_domains: Tuple[str, ...],
+    ) -> int:
+        """Clone the gateway template and configure it for this eval instance.
+
+        Steps:
+        1. Create IPAM mapping (MAC → gateway_ip) so the gateway VM gets a static IP.
+        2. Clone the gateway template (linked clone — fast, small).
+        3. Wire NICs: net0 → sandbox vnet (with the static MAC), net1 → external vnet.
+        4. Start VM and wait for QEMU guest agent.
+        5. Inject nftables ruleset and apply it.
+        6. Inject dnsmasq allowlist config and restart dnsmasq.
+
+        Returns:
+            The new VM ID of the gateway clone.
+        """
+        # vnet_aliases[0] = (sandbox_vnet_id, alias)
+        # vnet_aliases[1] = (ext_vnet_id, None)
+        sandbox_vnet_id = vnet_aliases[0][0]
+        external_vnet_id = vnet_aliases[1][0]
+
+        # IPAM mapping must be created before the VM boots so Proxmox dnsmasq
+        # serves the right IP to the gateway's MAC address.
+        gateway_ipam = IpamMapping(
+            vnet_id=sandbox_vnet_id,
+            zone_id=sdn_zone_id,
+            mac=gateway_mac,
+            ipv4=ip_address(gateway_ip),
+        )
+        await self.sdn_commands.create_ipam_mapping(gateway_ipam)
+
+        gateway_template_id = await self.built_in_vm.known_gateway()
+        if gateway_template_id is None:
+            raise ValueError(
+                "Gateway VM template not found — call ensure_gateway_exists() first"
+            )
+
+        new_vm_id = await self.qemu_commands.find_next_available_vm_id()
+
+        async def create_clone() -> None:
+            await self.async_proxmox.request(
+                "POST",
+                f"/nodes/{self.node}/qemu/{gateway_template_id}/clone",
+                json={
+                    "newid": new_vm_id,
+                    "full": 0,
+                    "name": f"inspect-gw-{proxmox_ids_start}",
+                },
+            )
+            await self.qemu_commands.register_created_vm(new_vm_id)
+
+        with trace_action(
+            self.logger, self.TRACE_NAME, f"clone gateway VM {new_vm_id=}"
+        ):
+            await self.task_wrapper.do_action_and_wait_for_tasks(create_clone)
+
+        async def configure_gw() -> None:
+            # Replace net0 (was static boot VNet from template) with sandbox VNet,
+            # and add net1 for the external (internet-facing) VNet.
+            # Tags: "inspect" only — "gateway" is reserved for the template.
+            await self.async_proxmox.request(
+                "POST",
+                f"/nodes/{self.node}/qemu/{new_vm_id}/config",
+                json={
+                    "net0": f"virtio,bridge={sandbox_vnet_id}"
+                    f",macaddr={gateway_mac.upper()}",
+                    "net1": f"virtio,bridge={external_vnet_id}",
+                    "tags": "inspect",
+                },
+            )
+
+        await self.task_wrapper.do_action_and_wait_for_tasks(configure_gw)
+
+        await self.qemu_commands.start_and_await(vm_id=new_vm_id, is_sandbox=True)
+
+        agent_commands = AgentCommands(self.async_proxmox, self.node)
+
+        # Inject and apply nftables config
+        nft_config = _nftables_config(sandbox_cidr)
+        await agent_commands.write_file(
+            vm_id=new_vm_id,
+            content=nft_config.encode("utf-8"),
+            filepath="/etc/nftables.conf",
+        )
+        nft_res = await agent_commands.exec_command(
+            vm_id=new_vm_id,
+            command=["nft", "-f", "/etc/nftables.conf"],
+        )
+
+        @tenacity.retry(
+            wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
+            stop=tenacity.stop_after_delay(30),
+            retry=tenacity.retry_if_result(lambda x: x is False),
+        )
+        async def wait_for_nft() -> bool:
+            status = await agent_commands.get_agent_exec_status(
+                vm_id=new_vm_id, pid=nft_res["pid"]
+            )
+            if status["exited"] == 1:
+                if status["exitcode"] != 0:
+                    raise ValueError(
+                        f"nft -f failed: stdout={status.get('out-data', '')!r}, "
+                        f"stderr={status.get('err-data', '')!r}"
+                    )
+                return True
+            return False
+
+        await wait_for_nft()
+
+        # Inject dnsmasq allowlist and restart dnsmasq
+        dnsmasq_config = _dnsmasq_allowlist_config(gateway_ip, allow_domains)
+        await agent_commands.write_file(
+            vm_id=new_vm_id,
+            content=dnsmasq_config.encode("utf-8"),
+            filepath="/etc/dnsmasq.d/allowlist.conf",
+        )
+        dnsmasq_res = await agent_commands.exec_command(
+            vm_id=new_vm_id,
+            command=["systemctl", "restart", "dnsmasq"],
+        )
+
+        @tenacity.retry(
+            wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
+            stop=tenacity.stop_after_delay(30),
+            retry=tenacity.retry_if_result(lambda x: x is False),
+        )
+        async def wait_for_dnsmasq_restart() -> bool:
+            status = await agent_commands.get_agent_exec_status(
+                vm_id=new_vm_id, pid=dnsmasq_res["pid"]
+            )
+            if status["exited"] == 1:
+                if status["exitcode"] != 0:
+                    raise ValueError(
+                        f"dnsmasq restart failed: "
+                        f"stdout={status.get('out-data', '')!r}, "
+                        f"stderr={status.get('err-data', '')!r}"
+                    )
+                return True
+            return False
+
+        await wait_for_dnsmasq_restart()
+
+        return new_vm_id
+
     async def create_sdn_and_vms(
         self,
         proxmox_ids_start: str,
         sdn_config: SdnConfigType,
         vms_config: Tuple[VmConfig, ...],
-    ) -> Tuple[Tuple[Tuple[int, VmConfig], ...], str | None, Tuple[IpamMapping, ...]]:
+    ) -> Tuple[
+        Tuple[Tuple[int, VmConfig], ...],
+        str | None,
+        Tuple[IpamMapping, ...],
+        int | None,
+    ]:
+        allow_domains: Tuple[str, ...] = ()
+        if isinstance(sdn_config, SdnConfig):
+            allow_domains = sdn_config.allow_domains
+
+        if allow_domains:
+            # Resolve "auto" before transforming, since _prepare_sdn_for_gateway
+            # needs a concrete SdnConfig to read and modify.
+            if sdn_config == "auto":
+                sdn_config = await self.sdn_commands.generate_sdn_config()
+            assert isinstance(sdn_config, SdnConfig)
+            sdn_config = await self._prepare_sdn_for_gateway(sdn_config)
+
         vm_configs_with_ids = []
         sdn_zone_id, vnet_aliases = await self.sdn_commands.create_sdn(
             proxmox_ids_start, sdn_config
         )
+
+        gateway_vm_id: int | None = None
+        if allow_domains and sdn_zone_id is not None:
+            # sdn_config was reassigned to a SdnConfig by _prepare_sdn_for_gateway
+            # above; assert helps mypy narrow the type.
+            assert isinstance(sdn_config, SdnConfig)
+            sandbox_cidr = str(sdn_config.vnet_configs[0].subnets[0].cidr)
+            gateway_ip = _gateway_ip_for_subnet(sandbox_cidr)
+            gateway_mac = _gateway_mac(proxmox_ids_start)
+            with trace_action(
+                self.logger, self.TRACE_NAME, "provision gateway VM"
+            ):
+                gateway_vm_id = await self._provision_gateway(
+                    proxmox_ids_start=proxmox_ids_start,
+                    vnet_aliases=vnet_aliases,
+                    sdn_zone_id=sdn_zone_id,
+                    sandbox_cidr=sandbox_cidr,
+                    gateway_ip=gateway_ip,
+                    gateway_mac=gateway_mac,
+                    allow_domains=allow_domains,
+                )
 
         known_builtins = await self.built_in_vm.known_builtins()
 
@@ -85,7 +442,12 @@ class InfraCommands(abc.ABC):
                 vm_configs_with_id[0], vm_configs_with_id[1].is_sandbox
             )
 
-        return tuple(vm_configs_with_ids), sdn_zone_id, tuple(ipam_mappings)
+        return (
+            tuple(vm_configs_with_ids),
+            sdn_zone_id,
+            tuple(ipam_mappings),
+            gateway_vm_id,
+        )
 
     async def delete_sdn_and_vms(
         self,

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -61,12 +61,27 @@ def _nftables_config(sandbox_cidr: str) -> str:
 
     Three chains:
     - prerouting_nat: intercepts all DNS from the sandbox and redirects it to
-      the gateway's dnsmasq, so sandbox VMs cannot bypass the allowlist by
-      using an alternative DNS server.
+      the gateway's dnsmasq (via `redirect to :53`, which DNAT's to 127.0.0.1),
+      so sandbox VMs cannot bypass the allowlist by configuring an alternative
+      DNS server.  conntrack reverses this for replies.
     - postrouting_nat: masquerades forwarded sandbox traffic as the gateway's
       external IP, so return traffic is routed back correctly.
     - forward: default-drop; only allows traffic to IPs that dnsmasq has
       resolved from the allowlist (populated into the nftables set via nftset).
+
+    Known gap — IPv6:
+    All rules are IPv4-only.  IPv6 egress from the sandbox is not filtered here.
+    In practice, Proxmox SDN "simple" zones do not route IPv6, and sandbox
+    cloud-init configs set dhcp6=false, so IPv6 egress is unlikely to be
+    available.  If that changes, add equivalent ip6 rules and an ip6tables
+    forward-drop default.
+
+    Intentional omission — INPUT chain:
+    There are no INPUT chain rules blocking connections from the sandbox to the
+    gateway VM's own ports.  Sandbox VMs can reach port 53 (dnsmasq, by design)
+    and any other listening service.  The gateway cloud-init intentionally does
+    NOT install openssh-server to keep this surface minimal.  Do not add SSH or
+    other management services to the gateway VM image.
     """
     return f"""\
 #!/usr/sbin/nft -f

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -224,10 +224,15 @@ class InfraCommands(abc.ABC):
         if external_vnet is None:
             raise ValueError("Could not find a suitable external VNet CIDR")
 
+        # allow_domains is intentionally cleared: this returned config is the
+        # internal 2-vnet form (sandbox + external) with the gateway already
+        # embedded. The caller captures allow_domains before calling this method
+        # and uses it directly; carrying it here would re-trigger the schema
+        # validator that enforces "exactly one vnet when allow_domains is set".
         return SdnConfig(
             vnet_configs=(modified_sandbox_vnet, external_vnet),
             use_pve_ipam_dnsnmasq=sdn_config.use_pve_ipam_dnsnmasq,
-            allow_domains=sdn_config.allow_domains,
+            allow_domains=(),
         )
 
     async def _provision_gateway(

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -35,14 +35,18 @@ from proxmoxsandbox.schema import (
 )
 
 
-def _gateway_mac(proxmox_ids_start: str) -> str:
-    """Derive a unique, deterministic MAC from the per-eval proxmox_ids_start prefix.
+def _gateway_mac(proxmox_ids_start: str, vnet_index: int = 0) -> str:
+    """Derive a unique, deterministic MAC from per-eval prefix and vnet index.
 
-    Uses the QEMU/KVM OUI (52:54:00) so Proxmox recognises it as a valid virtual NIC.
-    The 3-byte suffix is an MD5 hash of the prefix, giving per-eval uniqueness
-    without shared state or synchronisation.
+    Uses the QEMU/KVM OUI (52:54:00) so Proxmox recognises it as a valid
+    virtual NIC.  The 3-byte suffix is an MD5 hash of the prefix + vnet_index,
+    giving per-eval and per-NIC uniqueness without shared state.
+
+    Multi-vnet callers pass a different vnet_index for each sandbox NIC so
+    each gets a distinct MAC.  Single-vnet callers use the default (0).
     """
-    digest = hashlib.md5(proxmox_ids_start.encode(), usedforsecurity=False).digest()
+    key = f"{proxmox_ids_start}:{vnet_index}"
+    digest = hashlib.md5(key.encode(), usedforsecurity=False).digest()
     return f"52:54:00:{digest[0]:02x}:{digest[1]:02x}:{digest[2]:02x}"
 
 
@@ -62,119 +66,138 @@ def _gateway_ip_for_subnet(subnet_cidr: str) -> str:
     return str(network.network_address + 2)
 
 
-def _nftables_config(sandbox_cidr: str) -> str:
+def _nftables_config(sandbox_cidrs: Tuple[str, ...]) -> str:
     """Generate nftables ruleset for the gateway VM.
 
+    Uses a named set ``sandbox_nets`` containing all sandbox CIDRs, referenced
+    via ``ip saddr @sandbox_nets`` in all chains.  Scales cleanly to N vnets
+    without duplicating rules per CIDR.
+
     Three chains:
-    - prerouting_nat: intercepts all DNS from the sandbox and redirects it to
-      the gateway's dnsmasq (via `redirect to :53`, which DNAT's to 127.0.0.1),
-      so sandbox VMs cannot bypass the allowlist by configuring an alternative
-      DNS server.  conntrack reverses this for replies.
+    - prerouting_nat: intercepts all DNS from sandbox nets and redirects it to
+      the gateway's dnsmasq (via ``redirect to :53``), so sandbox VMs cannot
+      bypass the allowlist by configuring an alternative DNS server.
     - postrouting_nat: masquerades forwarded sandbox traffic as the gateway's
       external IP, so return traffic is routed back correctly.
     - forward: default-drop; only allows traffic to IPs in the allowed_ips set,
-      which is seeded at provision time by _pre_resolve_script (resolving the
-      allowlist domains and adding their IPs via 'nft add element').  dnsmasq's
-      nftset= directive is intentionally not used.  Although Debian 13's
-      dnsmasq (≥2.87) does support nftset, it only populates the nftables set on DNS
-      query — not at boot.  Pre-resolving at provision time ensures IPs are seeded
-      before the first connection attempt, which is simpler and more predictable.
+      which is seeded at provision time by _pre_resolve_script.
 
     IPv6:
     table inet covers both IPv4 and IPv6; policy drop on the forward chain
-    therefore drops IPv6 forwarded through the gateway.  The primary IPv6 risk
-    is direct routing: a sandbox VM that receives a Router Advertisement can
-    get a global IPv6 address and route traffic to the internet without touching
-    the gateway.  This is blocked at the sandbox VM level via accept-ra: false
-    in the cloud-init network config (dhcp6: false alone only disables DHCPv6,
-    not SLAAC).
+    therefore drops IPv6 forwarded through the gateway.
 
-    Intentional omission — INPUT chain:
-    There are no INPUT chain rules blocking connections from the sandbox to the
-    gateway VM's own ports.  Sandbox VMs can reach port 53 (dnsmasq, by design)
-    and any other listening service.  The gateway cloud-init intentionally does
-    NOT install openssh-server to keep this surface minimal.  Do not add SSH or
-    other management services to the gateway VM image.
+    INPUT chain:
+    Only allows port 53 (TCP/UDP) from sandbox CIDRs and loopback.
+    Defence-in-depth: limits gateway attack surface even if dnsmasq
+    has a vulnerability (CVE on a listening port).
     """
+    elements = ", ".join(sandbox_cidrs)
     return f"""\
 #!/usr/sbin/nft -f
 flush ruleset
 table inet gateway {{
-    set allowed_ips {{
+    set sandbox_nets {{
         type ipv4_addr
         flags interval
+        elements = {{ {elements} }}
+    }}
+
+    set allowed_ips {{
+        type ipv4_addr
+        flags interval, timeout
+        timeout 1h  # stale IPs expire; established connections survive via ct state
+    }}
+
+    chain input {{
+        type filter hook input priority filter; policy drop;
+        ct state established,related accept
+        iif lo accept
+        ip saddr @sandbox_nets udp dport 53 accept
+        ip saddr @sandbox_nets tcp dport 53 accept
+        counter drop
     }}
 
     chain prerouting_nat {{
         type nat hook prerouting priority dstnat;
-        ip saddr {sandbox_cidr} udp dport 53 redirect to :53
-        ip saddr {sandbox_cidr} tcp dport 53 redirect to :53
+        ip saddr @sandbox_nets udp dport 53 redirect to :53
+        ip saddr @sandbox_nets tcp dport 53 redirect to :53
     }}
 
     chain postrouting_nat {{
         type nat hook postrouting priority srcnat;
-        ip saddr {sandbox_cidr} masquerade
+        ip saddr @sandbox_nets masquerade
     }}
 
     chain forward {{
         type filter hook forward priority filter; policy drop;
         ct state established,related counter accept
-        ip saddr {sandbox_cidr} tcp dport 853 drop
-        ip saddr {sandbox_cidr} udp dport 853 drop
-        ip saddr {sandbox_cidr} ip daddr @allowed_ips counter accept
+        ip saddr @sandbox_nets tcp dport 853 drop
+        ip saddr @sandbox_nets udp dport 853 drop
+        ip saddr @sandbox_nets tcp daddr @allowed_ips counter accept
+        ip saddr @sandbox_nets udp daddr @allowed_ips counter accept
         counter drop
     }}
 }}
 """
 
 
-def _dnsmasq_allowlist_config(gateway_ip: str, allow_domains: Tuple[str, ...]) -> str:
+def _dnsmasq_allowlist_config(
+    gateway_ips: Tuple[str, ...],
+    allow_domains: Tuple[str, ...],
+) -> str:
     """Generate the per-eval dnsmasq allowlist config for the gateway VM.
 
-    Each allowed domain gets server=/<domain>/8.8.8.8 so dnsmasq forwards
-    those queries upstream.  dnsmasq's /domain/ syntax matches the apex and
-    all subdomains, so "gnu.org" covers ftp.gnu.org too.
+    Each allowed domain gets:
+    - server=/<domain>/8.8.8.8 — forward queries upstream
+    - nftset=/<domain>/4#inet#gateway#allowed_ips — on every
+      DNS response, push resolved IPs directly into the nftables
+      allowed_ips set.  This is the cooperative design: dnsmasq
+      is both the resolver and the source of truth for the
+      firewall's allow-set, so there is zero resolver-desync.
 
-    Without a global server= directive, any unlisted domain gets SERVFAIL.
+    dnsmasq's /domain/ syntax matches the apex and all subdomains,
+    so "gnu.org" covers ftp.gnu.org too — both for DNS forwarding
+    and for nftset IP injection.
 
-    listen-address is set to the gateway's sandbox-facing IP only.
-    bind-interfaces is required alongside listen-address: without it, dnsmasq
-    binds to 0.0.0.0:53 regardless of listen-address (listen-address only
-    affects filtering, not binding).  bind-interfaces makes dnsmasq bind to
-    exactly the specified IP, so the restart doesn't race with the boot-time
-    dnsmasq instance releasing 0.0.0.0:53.
+    Without a global server= directive, any unlisted domain gets
+    SERVFAIL.
 
-    nftset= is intentionally omitted.  Although Debian 13's dnsmasq supports it
-    (--enable-nftset has been compiled in since 2.87), nftset only populates
-    allowed_ips on DNS query rather than at boot.  Pre-resolving at provision
-    time (_pre_resolve_script) seeds IPs before the first connection attempt.
+    listen-address is set to each gateway sandbox-facing IP (one
+    per vnet). bind-interfaces is required alongside
+    listen-address: without it, dnsmasq binds to 0.0.0.0:53
+    regardless of listen-address.
     """
     lines = [
         "# Per-eval allowlist — generated at provision time.",
         "bind-interfaces",
-        f"listen-address={gateway_ip}",
-        "",
     ]
+    for gw_ip in gateway_ips:
+        lines.append(f"listen-address={gw_ip}")
+    lines.append("")
     for domain in allow_domains:
         lines.append(f"server=/{domain}/8.8.8.8")
+        lines.append(
+            f"nftset=/{domain}"
+            f"/4#inet#gateway#allowed_ips"
+        )
     return "\n".join(lines) + "\n"
 
 
 def _pre_resolve_script(allow_domains: Tuple[str, ...]) -> str:
-    """Return a Python script that resolves allowed domains and seeds the nftables set.
+    """Return a Python script that pre-seeds the nftables allowed_ips set.
 
-    Run once at provision time so traffic to those IPs is forwarded even before
-    the first DNS query.
+    Belt-and-suspenders: dnsmasq's nftset= directive dynamically
+    adds IPs on every DNS response, but this script seeds the set
+    at provision time so the very first TCP SYN (before any DNS
+    query) can reach allowed IPs.  After boot, nftset= is the
+    primary mechanism and this seed is redundant.
 
-    Queries 8.8.8.8 directly (via python3-dnspython) to match dnsmasq's upstream,
-    avoiding IP mismatch when the gateway's system resolver uses a different DNS
-    (e.g., a corporate nameserver with different geoDNS targets).  Falls back to
-    the system resolver if python3-dnspython is not installed (old gateway template).
+    Queries 8.8.8.8 directly (via python3-dnspython) to match
+    dnsmasq's upstream.  Falls back to the system resolver if
+    python3-dnspython is not installed (old gateway template).
 
-    Limitation: only apex domains are pre-resolved.  Subdomains of allowed domains
-    (e.g. ftp.gnu.org when "gnu.org" is allowed) are resolved at query time by
-    dnsmasq but their IPs are NOT added to allowed_ips here — they will be dropped
-    by the FORWARD chain.  Explicit subdomain listing is required.
+    Filters out RFC1918/loopback/link-local IPs to prevent DNS
+    rebinding attacks from seeding internal addresses.
     """
     domains_repr = repr(list(allow_domains))
     template = (
@@ -205,80 +228,88 @@ class InfraCommands(abc.ABC):
         self.built_in_vm = BuiltInVM(async_proxmox, node)
         self.node = node
 
-    async def _prepare_sdn_for_gateway(self, sdn_config: SdnConfig) -> SdnConfig:
+    async def _prepare_sdn_for_gateway(
+        self, sdn_config: SdnConfig
+    ) -> SdnConfig:
         """Transform a SdnConfig to route sandbox egress through a gateway VM.
 
-        Modifies the first (and only) vnet:
+        For each user-supplied vnet:
         - gateway IP changed to network .2 (the gateway VM's sandbox-facing IP)
         - snat set to False (gateway VM does NAT, not Proxmox)
-        - alias set to "sandbox" if unset (needed so gateway's NIC can reference it)
+        - alias set to "sandbox-{i}" if unset
 
-        Adds an external vnet (snat=True) for the gateway VM's internet-facing
-        interface, with a non-overlapping CIDR picked automatically.
+        Adds an external vnet (snat=True) as the last element for the gateway
+        VM's internet-facing interface.
 
-        Raises:
-            ValueError: if sdn_config has more than one vnet, if use_pve_ipam_dnsnmasq
-                is False, or if no suitable external CIDR can be found.
+        Convention: sandbox vnets = vnet_configs[:-1],
+                    external vnet = vnet_configs[-1].
         """
         if not sdn_config.use_pve_ipam_dnsnmasq:
             raise ValueError(
                 "allow_domains requires use_pve_ipam_dnsnmasq=True. "
-                "Proxmox IPAM is still used to reserve sandbox VM IPs and "
-                "assign the gateway VM its address via DHCP. The gateway VM "
-                "runs its own separate dnsmasq instance for DNS filtering only — "
-                "it does not replace Proxmox's dnsmasq for DHCP."
+                "Proxmox IPAM is still used to reserve sandbox VM IPs "
+                "and assign the gateway VM its address via DHCP. The "
+                "gateway VM runs its own separate dnsmasq instance for "
+                "DNS filtering only — it does not replace Proxmox's "
+                "dnsmasq for DHCP."
             )
-        if len(sdn_config.vnet_configs) != 1:
+        if len(sdn_config.vnet_configs) < 1:
             raise ValueError(
-                f"allow_domains requires exactly one vnet_config, "
+                "allow_domains requires at least one vnet_config, "
                 f"got {len(sdn_config.vnet_configs)}"
             )
-        sandbox_vnet = sdn_config.vnet_configs[0]
-        if len(sandbox_vnet.subnets) != 1:
-            raise ValueError(
-                f"allow_domains requires exactly one subnet per vnet, "
-                f"got {len(sandbox_vnet.subnets)}"
+
+        modified_sandbox_vnets: list[VnetConfig] = []
+        sandbox_networks = []
+        for i, sandbox_vnet in enumerate(sdn_config.vnet_configs):
+            if len(sandbox_vnet.subnets) != 1:
+                raise ValueError(
+                    "allow_domains requires exactly one subnet "
+                    f"per vnet, got {len(sandbox_vnet.subnets)} "
+                    f"in vnet {i}"
+                )
+
+            sandbox_subnet = sandbox_vnet.subnets[0]
+            sandbox_network = ip_network(str(sandbox_subnet.cidr))
+            sandbox_networks.append(sandbox_network)
+            gateway_ip = ip_address(
+                sandbox_network.network_address + 2
             )
 
-        sandbox_subnet = sandbox_vnet.subnets[0]
-        sandbox_network = ip_network(str(sandbox_subnet.cidr))
-        gateway_ip = ip_address(sandbox_network.network_address + 2)
+            modified_subnet = SubnetConfig(
+                cidr=sandbox_subnet.cidr,
+                gateway=gateway_ip,
+                snat=False,
+                dhcp_ranges=sandbox_subnet.dhcp_ranges,
+            )
+            if len(sdn_config.vnet_configs) == 1:
+                default_alias = "sandbox"
+            else:
+                default_alias = f"sandbox-{i}"
+            alias = (
+                sandbox_vnet.alias
+                if sandbox_vnet.alias is not None
+                else default_alias
+            )
+            modified_sandbox_vnets.append(
+                VnetConfig(
+                    alias=alias,
+                    subnets=(modified_subnet,),
+                )
+            )
 
-        modified_subnet = SubnetConfig(
-            cidr=sandbox_subnet.cidr,
-            # Proxmox's gateway field controls BOTH the SDN bridge device's IP AND
-            # the DHCP option-3 (router) advertised to VMs — they cannot be set
-            # independently.  Setting it to .2 makes sandbox VMs route to the gateway
-            # VM, but also causes the Proxmox bridge to claim .2, creating an ARP
-            # conflict with the gateway VM's sandbox-facing NIC.  That conflict is
-            # resolved in create_sdn_and_vms by injecting a permanent ARP entry on
-            # each sandbox VM pointing .2 → the gateway VM's MAC.
-            gateway=gateway_ip,
-            snat=False,
-            dhcp_ranges=sandbox_subnet.dhcp_ranges,
-        )
-        modified_sandbox_vnet = VnetConfig(
-            alias=sandbox_vnet.alias if sandbox_vnet.alias is not None else "sandbox",
-            subnets=(modified_subnet,),
-        )
-
-        # Pick an external VNet CIDR that doesn't overlap with the sandbox CIDR
-        # or any existing Proxmox CIDRs.
-        # Only exclude the sandbox_network — not modified_sandbox_vnet — because the
-        # sandbox CIDR may appear in a stale leftover Proxmox zone from a failed run
-        # (which create_sdn will overwrite), and including it would falsely poison
-        # every iteration inside find_non_overlapping_vnet_config.
-        external_vnet = await self.sdn_commands.find_non_overlapping_vnet_config(
-            exclude_networks=[sandbox_network],
+        external_vnet = (
+            await self.sdn_commands.find_non_overlapping_vnet_config(
+                exclude_networks=sandbox_networks,
+            )
         )
 
-        # allow_domains is intentionally cleared: this returned config is the
-        # internal 2-vnet form (sandbox + external) with the gateway already
-        # embedded. The caller captures allow_domains before calling this method
-        # and uses it directly; carrying it here would re-trigger the schema
-        # validator that enforces "exactly one vnet when allow_domains is set".
+        # allow_domains is intentionally cleared: this returned
+        # config is the internal N+1-vnet form with the gateway
+        # already embedded.  Carrying it would re-trigger the
+        # schema validator.
         return SdnConfig(
-            vnet_configs=(modified_sandbox_vnet, external_vnet),
+            vnet_configs=(*modified_sandbox_vnets, external_vnet),
             use_pve_ipam_dnsnmasq=sdn_config.use_pve_ipam_dnsnmasq,
             allow_domains=(),
         )
@@ -288,29 +319,19 @@ class InfraCommands(abc.ABC):
         proxmox_ids_start: str,
         vnet_aliases: VnetAliases,
         sdn_zone_id: str,
-        sandbox_cidr: str,
-        gateway_ip: str,
-        gateway_mac: str,
+        sandbox_cidrs: Tuple[str, ...],
+        gateway_ips: Tuple[str, ...],
+        gateway_macs: Tuple[str, ...],
         allow_domains: Tuple[str, ...],
     ) -> int:
-        """Clone the gateway template and configure it for this eval instance.
+        """Clone the gateway template and configure it for this eval.
 
-        Steps:
-        1. Clone the gateway template (linked clone — fast, small).
-        2. Wire NICs: net0 → sandbox vnet (with the static MAC), net1 → external vnet.
-        3. Start VM and wait for QEMU guest agent.
-        4. Write a systemd-networkd .network file to assign a static IP (.2) to the
-           sandbox NIC.  A DHCP reservation is impossible here because Proxmox claims
-           the subnet's gateway IP as a MAC-less topology entry in IPAM.  Using
-           networkd config (rather than 'ip addr add') ensures the address is
-           persistent — networkd would otherwise flush a manually-added address when
-           it re-applies its own DHCP config.
-        5. Inject nftables ruleset and apply it.
-        6. Inject dnsmasq allowlist config and restart dnsmasq.
-        7. Pre-resolve allowed domains into the nftables allowed_ips set.
+        Supports N sandbox vnets.  The gateway VM gets N+1 NICs:
+        net0..net{N-1} for sandbox vnets (each with a deterministic
+        MAC), net{N} for the external internet-facing vnet.
         """
-        sandbox_vnet_id = vnet_aliases[0][0]
-        external_vnet_id = vnet_aliases[1][0]
+        num_sandbox = len(sandbox_cidrs)
+        external_vnet_id = vnet_aliases[num_sandbox][0]
 
         gateway_template_id = await self.built_in_vm.known_gateway()
         if gateway_template_id is None:
@@ -338,51 +359,61 @@ class InfraCommands(abc.ABC):
             await self.task_wrapper.do_action_and_wait_for_tasks(create_clone)
 
         async def configure_gw() -> None:
-            # Replace net0 (was static boot VNet from template) with sandbox VNet,
-            # and add net1 for the external (internet-facing) VNet.
-            # Tags: "inspect" only — "gateway" is reserved for the template.
+            # Wire N sandbox NICs + 1 external NIC.
+            # net0..net{N-1} = sandbox vnets (each with its MAC),
+            # net{N} = external internet-facing vnet.
+            # Tags: "inspect" only — "gateway" is reserved for the
+            # template.
+            nic_json: dict[str, str] = {}
+            for i in range(num_sandbox):
+                sb_vnet_id = vnet_aliases[i][0]
+                nic_json[f"net{i}"] = (
+                    f"virtio,bridge={sb_vnet_id}"
+                    f",macaddr={gateway_macs[i].upper()}"
+                )
+            nic_json[f"net{num_sandbox}"] = (
+                f"virtio,bridge={external_vnet_id}"
+            )
+            nic_json["tags"] = "inspect"
             await self.async_proxmox.request(
                 "POST",
                 f"/nodes/{self.node}/qemu/{new_vm_id}/config",
-                json={
-                    "net0": f"virtio,bridge={sandbox_vnet_id}"
-                    f",macaddr={gateway_mac.upper()}",
-                    "net1": f"virtio,bridge={external_vnet_id}",
-                    "tags": "inspect",
-                },
+                json=nic_json,
             )
 
         await self.task_wrapper.do_action_and_wait_for_tasks(configure_gw)
 
-        await self.qemu_commands.start_and_await(vm_id=new_vm_id, is_sandbox=True)
+        await self.qemu_commands.start_and_await(
+            vm_id=new_vm_id, is_sandbox=True
+        )
 
         agent_commands = AgentCommands(self.async_proxmox, self.node)
 
-        # Configure a static IP on the sandbox-facing NIC via systemd-networkd.
-        # Writing a .network file (matched by MAC, 00- prefix beats cloud-init's
-        # 10-cloud-init-*.network) makes networkd the source of truth so the
-        # address survives DHCP renewals and link state changes.
-        #
-        # Why not 'ip addr flush; ip addr add'? networkd manages the interface
-        # with DHCP; a manually-added address is transient — networkd flushes
-        # it when it re-applies its DHCP config, sometimes within seconds. By
-        # the time sandbox VMs boot and ARP for .2, the Proxmox SDN bridge
-        # (which also holds .2 as its own IP, because we set gateway=.2 in the
-        # subnet config) wins the ARP race and all sandbox traffic hits the
-        # bridge instead of the gateway VM's FORWARD chain.
-        prefix_len = ip_network(sandbox_cidr).prefixlen
-        network_file = f"""\
+        # Configure a static IP on each sandbox-facing NIC via
+        # systemd-networkd.  One .network file per NIC, matched by
+        # MAC (00- prefix beats cloud-init's 10-cloud-init-*.network).
+        for i in range(num_sandbox):
+            prefix_len = ip_network(sandbox_cidrs[i]).prefixlen
+            network_file = f"""\
 [Match]
-MACAddress={gateway_mac}
+MACAddress={gateway_macs[i]}
 
 [Network]
 DHCP=no
-Address={gateway_ip}/{prefix_len}
+Address={gateway_ips[i]}/{prefix_len}
 """
-        await agent_commands.write_file(
-            vm_id=new_vm_id,
-            content=network_file.encode("utf-8"),
-            filepath="/etc/systemd/network/00-sandbox-static.network",
+            await agent_commands.write_file(
+                vm_id=new_vm_id,
+                content=network_file.encode("utf-8"),
+                filepath=(
+                    f"/etc/systemd/network/00-sandbox-{i}.network"
+                ),
+            )
+
+        # Build a grep check that waits for ALL gateway IPs to appear.
+        ip_checks = " && ".join(
+            f"ip -4 addr show | grep -qF '{gip}'"
+            for gip in gateway_ips
         )
         set_ip_res = await agent_commands.exec_command(
             vm_id=new_vm_id,
@@ -391,7 +422,7 @@ Address={gateway_ip}/{prefix_len}
                 "-c",
                 f"networkctl reload && "
                 f"for i in $(seq 1 15); do "
-                f"  ip -4 addr show | grep -qF '{gateway_ip}'"
+                f"  {ip_checks}"
                 f"    && {{ echo IP_OK; exit 0; }}; "
                 f"  sleep 1; "
                 f"done; "
@@ -411,9 +442,10 @@ Address={gateway_ip}/{prefix_len}
             if status["exited"] == 1:
                 if status["exitcode"] != 0:
                     raise ValueError(
-                        f"Failed to configure static IP {gateway_ip}: "
-                        f"stdout={status.get('out-data', '')!r}, "
-                        f"stderr={status.get('err-data', '')!r}"
+                        "Failed to configure static IPs: "
+                        f"stdout={status.get('out-data', '')!r}"
+                        f", stderr="
+                        f"{status.get('err-data', '')!r}"
                     )
                 return True
             return False
@@ -421,7 +453,7 @@ Address={gateway_ip}/{prefix_len}
         await wait_for_set_ip()
 
         # Inject and apply nftables config
-        nft_config = _nftables_config(sandbox_cidr)
+        nft_config = _nftables_config(sandbox_cidrs)
         await agent_commands.write_file(
             vm_id=new_vm_id,
             content=nft_config.encode("utf-8"),
@@ -444,8 +476,10 @@ Address={gateway_ip}/{prefix_len}
             if status["exited"] == 1:
                 if status["exitcode"] != 0:
                     raise ValueError(
-                        f"nft -f failed: stdout={status.get('out-data', '')!r}, "
-                        f"stderr={status.get('err-data', '')!r}"
+                        "nft -f failed: "
+                        f"stdout={status.get('out-data', '')!r}"
+                        f", stderr="
+                        f"{status.get('err-data', '')!r}"
                     )
                 return True
             return False
@@ -453,7 +487,9 @@ Address={gateway_ip}/{prefix_len}
         await wait_for_nft()
 
         # Inject dnsmasq allowlist and restart dnsmasq
-        dnsmasq_config = _dnsmasq_allowlist_config(gateway_ip, allow_domains)
+        dnsmasq_config = _dnsmasq_allowlist_config(
+            gateway_ips, allow_domains
+        )
         await agent_commands.write_file(
             vm_id=new_vm_id,
             content=dnsmasq_config.encode("utf-8"),
@@ -476,19 +512,18 @@ Address={gateway_ip}/{prefix_len}
             if status["exited"] == 1:
                 if status["exitcode"] != 0:
                     raise ValueError(
-                        f"dnsmasq restart failed: "
-                        f"stdout={status.get('out-data', '')!r}, "
-                        f"stderr={status.get('err-data', '')!r}"
+                        "dnsmasq restart failed: "
+                        f"stdout={status.get('out-data', '')!r}"
+                        f", stderr="
+                        f"{status.get('err-data', '')!r}"
                     )
                 return True
             return False
 
         await wait_for_dnsmasq_restart()
 
-        # Seed the nftables allowed_ips set by resolving the allowed domains now,
-        # before the first DNS query.  nftset= would do this dynamically, but
-        # pre-resolving at provision time is simpler and doesn't require dnsmasq
-        # to stay running before traffic is attempted.
+        # Seed the nftables allowed_ips set by resolving the allowed
+        # domains now, before the first DNS query.
         pre_resolve = _pre_resolve_script(allow_domains)
         await agent_commands.write_file(
             vm_id=new_vm_id,
@@ -512,9 +547,10 @@ Address={gateway_ip}/{prefix_len}
             if status["exited"] == 1:
                 if status["exitcode"] != 0:
                     raise ValueError(
-                        f"pre-resolve failed: "
-                        f"stdout={status.get('out-data', '')!r}, "
-                        f"stderr={status.get('err-data', '')!r}"
+                        "pre-resolve failed: "
+                        f"stdout={status.get('out-data', '')!r}"
+                        f", stderr="
+                        f"{status.get('err-data', '')!r}"
                     )
                 return True
             return False
@@ -555,17 +591,29 @@ Address={gateway_ip}/{prefix_len}
             # sdn_config was reassigned to a SdnConfig by _prepare_sdn_for_gateway
             # above; assert helps mypy narrow the type.
             assert isinstance(sdn_config, SdnConfig)
-            sandbox_cidr = str(sdn_config.vnet_configs[0].subnets[0].cidr)
-            gateway_ip = _gateway_ip_for_subnet(sandbox_cidr)
-            gateway_mac = _gateway_mac(proxmox_ids_start)
-            with trace_action(self.logger, self.TRACE_NAME, "provision gateway VM"):
+            sandbox_vnets = sdn_config.vnet_configs[:-1]
+            sandbox_cidrs = tuple(
+                str(v.subnets[0].cidr) for v in sandbox_vnets
+            )
+            gateway_ips_t = tuple(
+                _gateway_ip_for_subnet(c) for c in sandbox_cidrs
+            )
+            gateway_macs_t = tuple(
+                _gateway_mac(proxmox_ids_start, i)
+                for i in range(len(sandbox_vnets))
+            )
+            with trace_action(
+                self.logger,
+                self.TRACE_NAME,
+                "provision gateway VM",
+            ):
                 gateway_vm_id = await self._provision_gateway(
                     proxmox_ids_start=proxmox_ids_start,
                     vnet_aliases=vnet_aliases,
                     sdn_zone_id=sdn_zone_id,
-                    sandbox_cidr=sandbox_cidr,
-                    gateway_ip=gateway_ip,
-                    gateway_mac=gateway_mac,
+                    sandbox_cidrs=sandbox_cidrs,
+                    gateway_ips=gateway_ips_t,
+                    gateway_macs=gateway_macs_t,
                     allow_domains=allow_domains,
                 )
 
@@ -612,49 +660,84 @@ Address={gateway_ip}/{prefix_len}
         # precedence over dynamic ARP replies, eliminating the race entirely.
         if gateway_vm_id is not None:
             assert isinstance(sdn_config, SdnConfig)
-            gw_sandbox_cidr = str(sdn_config.vnet_configs[0].subnets[0].cidr)
-            gw_ip = _gateway_ip_for_subnet(gw_sandbox_cidr)
-            gw_mac = _gateway_mac(proxmox_ids_start)
-            agent_commands = AgentCommands(self.async_proxmox, self.node)
+            sandbox_vnets = sdn_config.vnet_configs[:-1]
+            arp_triples = [
+                (
+                    str(v.subnets[0].cidr),
+                    _gateway_ip_for_subnet(str(v.subnets[0].cidr)),
+                    _gateway_mac(proxmox_ids_start, i),
+                )
+                for i, v in enumerate(sandbox_vnets)
+            ]
+            agent_commands = AgentCommands(
+                self.async_proxmox, self.node
+            )
             for vm_id, vm_config in vm_configs_with_ids:
                 if not vm_config.is_sandbox:
                     continue
-                inject_res = await agent_commands.exec_command(
-                    vm_id=vm_id,
-                    command=[
-                        "bash",
-                        "-c",
-                        f"iface=$(ip -4 route"
-                        f" | awk '$1==\"{gw_sandbox_cidr}\" {{print $3}}');"
-                        f" ip neigh replace {gw_ip} lladdr {gw_mac}"
-                        f" dev $iface nud permanent",
-                    ],
-                )
-
-                @tenacity.retry(
-                    wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
-                    stop=tenacity.stop_after_delay(30),
-                    retry=tenacity.retry_if_result(lambda x: x is False),
-                )
-                async def wait_for_arp_inject() -> bool:
-                    status = await agent_commands.get_agent_exec_status(
-                        vm_id=vm_id, pid=inject_res["pid"]
+                for cidr, gw_ip, gw_mac in arp_triples:
+                    # The VM may only be connected to one of
+                    # the sandbox vnets.  The [ -n "$iface" ]
+                    # guard skips vnets this VM isn't on.
+                    inject_res = await agent_commands.exec_command(
+                        vm_id=vm_id,
+                        command=[
+                            "bash",
+                            "-c",
+                            f"iface=$(ip -4 route"
+                            f" | awk "
+                            f"'$1==\"{cidr}\""
+                            f" {{print $3}}');"
+                            f" [ -n \"$iface\" ] && "
+                            f"ip neigh replace {gw_ip}"
+                            f" lladdr {gw_mac}"
+                            f" dev $iface nud permanent"
+                            f" || true",
+                        ],
                     )
-                    if status["exited"] == 1:
-                        if status["exitcode"] != 0:
-                            raise ValueError(
-                                f"ARP injection on sandbox VM {vm_id} failed: "
-                                f"stdout={status.get('out-data', '')!r}, "
-                                f"stderr={status.get('err-data', '')!r}"
-                            )
-                        self.logger.info(
-                            f"Injected permanent ARP {gw_ip} → {gw_mac} "
-                            f"on sandbox VM {vm_id}"
-                        )
-                        return True
-                    return False
 
-                await wait_for_arp_inject()
+                    # Closure-safe: bind vm_id and pid via
+                    # default args to avoid late-binding bugs.
+                    @tenacity.retry(
+                        wait=tenacity.wait_exponential(
+                            min=0.1, exp_base=1.3
+                        ),
+                        stop=tenacity.stop_after_delay(30),
+                        retry=tenacity.retry_if_result(
+                            lambda x: x is False
+                        ),
+                    )
+                    async def wait_for_arp_inject(
+                        _vm_id: int = vm_id,
+                        _pid: int = inject_res["pid"],
+                        _gw_ip: str = gw_ip,
+                        _gw_mac: str = gw_mac,
+                    ) -> bool:
+                        status = (
+                            await agent_commands
+                            .get_agent_exec_status(
+                                vm_id=_vm_id, pid=_pid
+                            )
+                        )
+                        if status["exited"] == 1:
+                            if status["exitcode"] != 0:
+                                raise ValueError(
+                                    "ARP injection on "
+                                    f"sandbox VM {_vm_id}"
+                                    " failed: stdout="
+                                    f"{status.get('out-data', '')!r}"
+                                    ", stderr="
+                                    f"{status.get('err-data', '')!r}"
+                                )
+                            self.logger.info(
+                                "Injected permanent ARP"
+                                f" {_gw_ip} -> {_gw_mac}"
+                                f" on sandbox VM {_vm_id}"
+                            )
+                            return True
+                        return False
+
+                    await wait_for_arp_inject()
 
         return (
             tuple(vm_configs_with_ids),

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -274,6 +274,19 @@ class InfraCommands(abc.ABC):
             mac=gateway_mac,
             ipv4=ip_address(gateway_ip),
         )
+        # A stale entry at this IP can remain from a previous failed run whose
+        # cleanup didn't complete. It would block creation of a fresh mapping, so
+        # we delete any existing entry for this IP+vnet before proceeding.
+        # Safe: the entry is a static reservation, not a live lease — no running
+        # VM holds it at this point since we haven't started the gateway VM yet.
+        existing_ipam = await self.sdn_commands.read_all_ipam_mappings()
+        stale = [
+            e.to_ipam_mapping()
+            for e in existing_ipam
+            if e.ip == gateway_ip and e.vnet == sandbox_vnet_id
+        ]
+        if stale:
+            await self.sdn_commands.tear_down_sdn_ip_allocations(stale)
         await self.sdn_commands.create_ipam_mapping(gateway_ipam)
 
         gateway_template_id = await self.built_in_vm.known_gateway()

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -48,9 +48,14 @@ def _gateway_mac(proxmox_ids_start: str) -> str:
 def _gateway_ip_for_subnet(subnet_cidr: str) -> str:
     """Return the .2 host in the subnet — the gateway VM's sandbox-facing IP.
 
-    .1 is the Proxmox SDN gateway entry (advertised by the zone's dnsmasq as the
-    subnet gateway before the gateway VM takes over).  We use .2 so both can
-    co-exist without conflict.
+    .1 is permanently reserved by Proxmox SDN as the bridge device's IP for
+    that subnet; it cannot be reassigned.  We use .2 to avoid a conflict with it.
+
+    _prepare_sdn_for_gateway sets the SDN subnet's gateway field to .2 so that
+    Proxmox's dnsmasq advertises .2 as the DHCP router to sandbox VMs.  A side
+    effect is that the Proxmox SDN bridge device also claims .2, creating an ARP
+    conflict with the gateway VM's sandbox-facing NIC.  That conflict is resolved
+    in create_sdn_and_vms by injecting a permanent ARP entry on each sandbox VM.
     """
     network = ip_network(subnet_cidr)
     return str(network.network_address + 2)
@@ -66,8 +71,11 @@ def _nftables_config(sandbox_cidr: str) -> str:
       DNS server.  conntrack reverses this for replies.
     - postrouting_nat: masquerades forwarded sandbox traffic as the gateway's
       external IP, so return traffic is routed back correctly.
-    - forward: default-drop; only allows traffic to IPs that dnsmasq has
-      resolved from the allowlist (populated into the nftables set via nftset).
+    - forward: default-drop; only allows traffic to IPs in the allowed_ips set,
+      which is seeded at provision time by _pre_resolve_script (resolving the
+      allowlist domains and adding their IPs via 'nft add element').  dnsmasq's
+      nftset= directive is intentionally not used — Debian 13's package may not
+      be compiled with --enable-nftset.
 
     Known gap — IPv6:
     All rules are IPv4-only.  IPv6 egress from the sandbox is not filtered here.
@@ -105,8 +113,9 @@ table inet gateway {{
 
     chain forward {{
         type filter hook forward priority filter; policy drop;
-        ct state established,related accept
-        ip saddr {sandbox_cidr} ip daddr @allowed_ips accept
+        ct state established,related counter accept
+        ip saddr {sandbox_cidr} ip daddr @allowed_ips counter accept
+        counter drop
     }}
 }}
 """
@@ -121,8 +130,12 @@ def _dnsmasq_allowlist_config(gateway_ip: str, allow_domains: Tuple[str, ...]) -
 
     Without a global server= directive, any unlisted domain gets SERVFAIL.
 
-    listen-address is set to the gateway's sandbox-facing IP only (not
-    127.0.0.1) to avoid conflicting with systemd-resolved on the loopback.
+    listen-address is set to the gateway's sandbox-facing IP only.
+    bind-interfaces is required alongside listen-address: without it, dnsmasq
+    binds to 0.0.0.0:53 regardless of listen-address (listen-address only
+    affects filtering, not binding).  bind-interfaces makes dnsmasq bind to
+    exactly the specified IP, so the restart doesn't race with the boot-time
+    dnsmasq instance releasing 0.0.0.0:53.
 
     nftset= is intentionally omitted: Debian 13's dnsmasq package may not be
     compiled with --enable-nftset.  The nftables allowed_ips set is populated
@@ -130,6 +143,7 @@ def _dnsmasq_allowlist_config(gateway_ip: str, allow_domains: Tuple[str, ...]) -
     """
     lines = [
         "# Per-eval allowlist — generated at provision time.",
+        "bind-interfaces",
         f"listen-address={gateway_ip}",
         "",
     ]
@@ -143,24 +157,50 @@ def _pre_resolve_script(allow_domains: Tuple[str, ...]) -> str:
 
     Run once at provision time so traffic to those IPs is forwarded even before
     the first DNS query (and without relying on dnsmasq nftset support).
+
+    Queries 8.8.8.8 directly (via python3-dnspython) to match dnsmasq's upstream,
+    avoiding IP mismatch when the gateway's system resolver uses a different DNS
+    (e.g., a corporate nameserver with different geoDNS targets).  Falls back to
+    the system resolver if python3-dnspython is not installed (old gateway template).
+
+    Limitation: only apex domains are pre-resolved.  Subdomains of allowed domains
+    (e.g. deb.debian.org when "debian.org" is allowed) are resolved at query time by
+    dnsmasq but their IPs are NOT added to allowed_ips here — they will be dropped
+    by the FORWARD chain.  The fix is to enable dnsmasq's nftset= support when the
+    installed package supports it (--enable-nftset), which would add IPs dynamically.
     """
     domains_repr = repr(list(allow_domains))
-    return (
-        "\n".join(
-            [
-                "import socket, subprocess",
-                f"domains = {domains_repr}",
-                "ips = list({{r[4][0] for d in domains"
-                " for r in socket.getaddrinfo(d, None, socket.AF_INET)}})",
-                "if ips:",
-                "    nft_in = 'add element inet gateway allowed_ips { '"
-                " + ', '.join(ips) + ' }'",
-                "    subprocess.run(['nft', '-f', '-'], input=nft_in,"
-                " text=True, check=True)",
-            ]
-        )
-        + "\n"
-    )
+    # {{ and }} in this f-string produce literal { and } in the emitted Python script.
+    return f"""\
+import subprocess
+try:
+    import dns.resolver as _dns
+    _dns_available = True
+except ImportError:
+    # python3-dnspython not installed (old gateway template).
+    # Falls back to system resolver, which may return different IPs than dnsmasq.
+    import socket
+    _dns_available = False
+domains = {domains_repr}
+ips = []
+if _dns_available:
+    resolver = _dns.Resolver()
+    resolver.nameservers = ['8.8.8.8']
+    for d in domains:
+        try:
+            ips.extend(str(r) for r in resolver.resolve(d, 'A'))
+        except Exception:
+            pass
+else:
+    for d in domains:
+        try:
+            ips.extend(r[4][0] for r in socket.getaddrinfo(d, None, socket.AF_INET))
+        except Exception:
+            pass
+if ips:
+    nft_in = 'add element inet gateway allowed_ips {{ ' + ', '.join(ips) + ' }}'
+    subprocess.run(['nft', '-f', '-'], input=nft_in, text=True, check=True)
+"""
 
 
 class InfraCommands(abc.ABC):
@@ -221,6 +261,13 @@ class InfraCommands(abc.ABC):
 
         modified_subnet = SubnetConfig(
             cidr=sandbox_subnet.cidr,
+            # Proxmox's gateway field controls BOTH the SDN bridge device's IP AND
+            # the DHCP option-3 (router) advertised to VMs — they cannot be set
+            # independently.  Setting it to .2 makes sandbox VMs route to the gateway
+            # VM, but also causes the Proxmox bridge to claim .2, creating an ARP
+            # conflict with the gateway VM's sandbox-facing NIC.  That conflict is
+            # resolved in create_sdn_and_vms by injecting a permanent ARP entry on
+            # each sandbox VM pointing .2 → the gateway VM's MAC.
             gateway=gateway_ip,
             snat=False,
             dhcp_ranges=sandbox_subnet.dhcp_ranges,
@@ -281,11 +328,15 @@ class InfraCommands(abc.ABC):
         1. Clone the gateway template (linked clone — fast, small).
         2. Wire NICs: net0 → sandbox vnet (with the static MAC), net1 → external vnet.
         3. Start VM and wait for QEMU guest agent.
-        4. Set static IP on the sandbox NIC via the agent (avoids Proxmox IPAM: the
-           subnet's gateway IP is already claimed by Proxmox as a topology entry with
-           no MAC, blocking any MAC-based DHCP reservation for the same address).
+        4. Write a systemd-networkd .network file to assign a static IP (.2) to the
+           sandbox NIC.  A DHCP reservation is impossible here because Proxmox claims
+           the subnet's gateway IP as a MAC-less topology entry in IPAM.  Using
+           networkd config (rather than 'ip addr add') ensures the address is
+           persistent — networkd would otherwise flush a manually-added address when
+           it re-applies its own DHCP config.
         5. Inject nftables ruleset and apply it.
         6. Inject dnsmasq allowlist config and restart dnsmasq.
+        7. Pre-resolve allowed domains into the nftables allowed_ips set.
         """
         # vnet_aliases[0] = (sandbox_vnet_id, alias)
         # vnet_aliases[1] = (ext_vnet_id, None)
@@ -338,20 +389,44 @@ class InfraCommands(abc.ABC):
 
         agent_commands = AgentCommands(self.async_proxmox, self.node)
 
-        # Set static IP on the sandbox NIC. The VM booted with DHCP; we override
-        # it here because Proxmox auto-claims the subnet's gateway IP as a topology
-        # entry (mac=None) in IPAM, making a MAC-based DHCP reservation impossible.
-        # We find the sandbox interface by its route, flush the DHCP address, then
-        # assign the static IP. The DHCP lease won't renew within the VM's lifetime.
+        # Configure a static IP on the sandbox-facing NIC via systemd-networkd.
+        # Writing a .network file (matched by MAC, 00- prefix beats cloud-init's
+        # 10-cloud-init-*.network) makes networkd the source of truth so the
+        # address survives DHCP renewals and link state changes.
+        #
+        # Why not 'ip addr flush; ip addr add'? networkd manages the interface
+        # with DHCP; a manually-added address is transient — networkd flushes
+        # it when it re-applies its DHCP config, sometimes within seconds. By
+        # the time sandbox VMs boot and ARP for .2, the Proxmox SDN bridge
+        # (which also holds .2 as its own IP, because we set gateway=.2 in the
+        # subnet config) wins the ARP race and all sandbox traffic hits the
+        # bridge instead of the gateway VM's FORWARD chain.
         prefix_len = ip_network(sandbox_cidr).prefixlen
+        network_file = (
+            "[Match]\n"
+            f"MACAddress={gateway_mac}\n"
+            "\n"
+            "[Network]\n"
+            "DHCP=no\n"
+            f"Address={gateway_ip}/{prefix_len}\n"
+        )
+        await agent_commands.write_file(
+            vm_id=new_vm_id,
+            content=network_file.encode("utf-8"),
+            filepath="/etc/systemd/network/00-sandbox-static.network",
+        )
         set_ip_res = await agent_commands.exec_command(
             vm_id=new_vm_id,
             command=[
                 "bash",
                 "-c",
-                f"iface=$(ip -4 route | awk '$1==\"{sandbox_cidr}\" {{print $3}}');"
-                f" ip addr flush dev $iface;"
-                f" ip addr add {gateway_ip}/{prefix_len} dev $iface",
+                f"networkctl reload && "
+                f"for i in $(seq 1 15); do "
+                f"  ip -4 addr show | grep -qF '{gateway_ip}'"
+                f"    && {{ echo IP_OK; exit 0; }}; "
+                f"  sleep 1; "
+                f"done; "
+                f"echo IP_MISSING; exit 1",
             ],
         )
 
@@ -367,7 +442,7 @@ class InfraCommands(abc.ABC):
             if status["exited"] == 1:
                 if status["exitcode"] != 0:
                     raise ValueError(
-                        f"set static IP failed: "
+                        f"Failed to configure static IP {gateway_ip}: "
                         f"stdout={status.get('out-data', '')!r}, "
                         f"stderr={status.get('err-data', '')!r}"
                     )
@@ -557,6 +632,66 @@ class InfraCommands(abc.ABC):
             await self.qemu_commands.await_vm(
                 vm_configs_with_id[0], vm_configs_with_id[1].is_sandbox
             )
+
+        # Inject a permanent ARP entry for the gateway VM on every sandbox VM.
+        #
+        # Root cause of the ARP conflict: setting gateway=.2 in the SDN subnet
+        # config causes Proxmox to assign .2 to the SDN bridge on the Proxmox
+        # host (needed so dnsmasq advertises .2 as the DHCP router option).
+        # The bridge therefore ALSO responds to ARP for .2, racing with the
+        # gateway VM's ens18.  If the bridge wins, sandbox traffic hits the
+        # bridge instead of the gateway VM's FORWARD chain — all packets are
+        # silently dropped (snat=False, no route to the internet from the bridge
+        # without NAT).
+        #
+        # Fix: inject a `nud permanent` ARP entry pointing .2 → gateway VM MAC
+        # on each sandbox VM after it boots.  Permanent entries take unconditional
+        # precedence over dynamic ARP replies, eliminating the race entirely.
+        if gateway_vm_id is not None:
+            assert isinstance(sdn_config, SdnConfig)
+            gw_sandbox_cidr = str(sdn_config.vnet_configs[0].subnets[0].cidr)
+            gw_ip = _gateway_ip_for_subnet(gw_sandbox_cidr)
+            gw_mac = _gateway_mac(proxmox_ids_start)
+            agent_commands = AgentCommands(self.async_proxmox, self.node)
+            for vm_id, vm_config in vm_configs_with_ids:
+                if not vm_config.is_sandbox:
+                    continue
+                inject_res = await agent_commands.exec_command(
+                    vm_id=vm_id,
+                    command=[
+                        "bash",
+                        "-c",
+                        f"iface=$(ip -4 route"
+                        f" | awk '$1==\"{gw_sandbox_cidr}\" {{print $3}}');"
+                        f" ip neigh replace {gw_ip} lladdr {gw_mac}"
+                        f" dev $iface nud permanent",
+                    ],
+                )
+
+                @tenacity.retry(
+                    wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
+                    stop=tenacity.stop_after_delay(30),
+                    retry=tenacity.retry_if_result(lambda x: x is False),
+                )
+                async def wait_for_arp_inject() -> bool:
+                    status = await agent_commands.get_agent_exec_status(
+                        vm_id=vm_id, pid=inject_res["pid"]
+                    )
+                    if status["exited"] == 1:
+                        if status["exitcode"] != 0:
+                            raise ValueError(
+                                f"ARP injection on sandbox VM {vm_id} failed: "
+                                f"stdout={status.get('out-data', '')!r}, "
+                                f"stderr={status.get('err-data', '')!r}"
+                            )
+                        self.logger.info(
+                            f"Injected permanent ARP {gw_ip} → {gw_mac} "
+                            f"on sandbox VM {vm_id}"
+                        )
+                        return True
+                    return False
+
+                await wait_for_arp_inject()
 
         return (
             tuple(vm_configs_with_ids),

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -400,9 +400,10 @@ class QemuCommands(abc.ABC):
                     # there are any defined in sdn_vnet_aliases
                     if sdn_vnet_aliases and len(sdn_vnet_aliases) > 0:
                         first_vnet_id = sdn_vnet_aliases[0][0]
-                        network_update_json["net0"] = (
-                            f"{nic_prefix},bridge={first_vnet_id}"
-                        )
+                        netx = f"{nic_prefix},bridge={first_vnet_id}"
+                        if vm_config.firewall:
+                            netx += ",firewall=1"
+                        network_update_json["net0"] = netx
                     # otherwise do nothing - no networks will be added
                 # for other vm_source_configs, we *do not touch* networking config
             else:
@@ -435,6 +436,8 @@ class QemuCommands(abc.ABC):
                     netx = f"{nic_prefix},bridge={bridge_name}"
                     if nic.mac:
                         netx += f",macaddr={str(nic.mac).upper()}"
+                    if vm_config.firewall:
+                        netx += ",firewall=1"
                     network_update_json[f"net{i}"] = netx
 
             if network_update_json:

--- a/src/proxmoxsandbox/_impl/sdn_commands.py
+++ b/src/proxmoxsandbox/_impl/sdn_commands.py
@@ -1,7 +1,7 @@
 import abc
 import re
 from contextvars import ContextVar
-from ipaddress import ip_address, ip_network
+from ipaddress import IPv4Network, IPv6Network, ip_address, ip_network
 from logging import getLogger
 from random import shuffle
 from typing import Collection, List, Optional, Sequence, Set, Tuple, TypeAlias
@@ -153,6 +153,46 @@ class SdnCommands(abc.ABC):
             alias=alias,
         )
 
+    async def find_non_overlapping_vnet_config(
+        self,
+        exclude_networks: Optional[List[IPv4Network | IPv6Network]] = None,
+        alias: Optional[str] = None,
+    ) -> VnetConfig:
+        """Find a free 192.168.x.0/24 CIDR that doesn't conflict with existing ones.
+
+        Shuffles the third-octet space (2–252) to spread allocations randomly,
+        skips any candidate that overlaps with `exclude_networks`, and rejects
+        candidates that clash with CIDRs already registered in Proxmox.
+
+        Args:
+            exclude_networks: additional networks the result must not overlap with
+                (e.g. the sandbox CIDR when picking an external VNet CIDR).
+            alias: optional alias to assign to the returned VnetConfig.
+
+        Returns:
+            A VnetConfig whose CIDR doesn't overlap with `exclude_networks` or
+            any existing Proxmox simple-zone CIDR.
+
+        Raises:
+            ValueError: if no suitable CIDR can be found after exhausting all
+                third-octet candidates.
+        """
+        exclude = exclude_networks or []
+        try_third_octets = list(range(2, 253))
+        # Deliberately randomize the IP address range to avoid brittle evals.
+        shuffle(try_third_octets)
+        for third_octet in try_third_octets:
+            candidate = self.simple_vnet_config(third_octet=third_octet, alias=alias)
+            candidate_cidr = ip_network(str(candidate.subnets[0].cidr))
+            if any(candidate_cidr.overlaps(net) for net in exclude):
+                continue
+            try:
+                await self.check_cidrs([candidate])
+                return candidate
+            except ValueError:
+                continue
+        raise ValueError("Could not find a suitable IP range for the SDN")
+
     async def generate_sdn_config(
         self, aliases: Tuple[Optional[str], ...] = ()
     ) -> SdnConfig:
@@ -161,24 +201,8 @@ class SdnCommands(abc.ABC):
 
         vnet_configs: List[VnetConfig] = []
         for alias in aliases:
-            try_third_octets = list(range(2, 253))
-            # Deliberately randomize the IP address range you get if you don't specify
-            # one. This is to avoid brittle evals.
-            shuffle(try_third_octets)
-            ok_vnet_config = None
-            for third_octet in try_third_octets:
-                try_vnet_config = self.simple_vnet_config(
-                    third_octet=third_octet, alias=alias
-                )
-                try:
-                    await self.check_cidrs(vnet_configs=[try_vnet_config])
-                    ok_vnet_config = try_vnet_config
-                    vnet_configs.append(ok_vnet_config)
-                    break
-                except ValueError:
-                    continue
-            if ok_vnet_config is None:
-                raise ValueError("Could not find a suitable IP range for the SDN")
+            vnet_config = await self.find_non_overlapping_vnet_config(alias=alias)
+            vnet_configs.append(vnet_config)
             # There is obviously a race condition here. Another eval could sneak in and
             # create a clashing IP range.
             # We could use a 10.*/24 range instead, which would give us many more ranges
@@ -280,15 +304,19 @@ class SdnCommands(abc.ABC):
                 )
 
                 for subnet in vnet_config.subnets:
+                    subnet_json: dict = {
+                        "subnet": str(subnet.cidr),
+                        "type": "subnet",
+                        "vnet": vnet_id,
+                        "snat": subnet.snat,
+                    }
+                    if subnet.gateway is not None:
+                        subnet_json["gateway"] = str(subnet.gateway)
                     await self.async_proxmox.request(
                         "POST",
                         f"/cluster/sdn/vnets/{vnet_id}/subnets",
                         json={
-                            "subnet": str(subnet.cidr),
-                            "type": "subnet",
-                            "vnet": vnet_id,
-                            "gateway": str(subnet.gateway),
-                            "snat": subnet.snat,
+                            **subnet_json,
                             "dhcp-range": list(
                                 dhcp_range._to_proxmox_format()
                                 for dhcp_range in subnet.dhcp_ranges

--- a/src/proxmoxsandbox/_impl/sdn_commands.py
+++ b/src/proxmoxsandbox/_impl/sdn_commands.py
@@ -397,9 +397,18 @@ class SdnCommands(abc.ABC):
                     await self.async_proxmox.request(
                         "DELETE", f"/cluster/sdn/vnets/{vnet}"
                     )
-                await self.async_proxmox.request(
-                    "DELETE", f"/cluster/sdn/zones/{sdn_zone_id}"
-                )
+                try:
+                    await self.async_proxmox.request(
+                        "DELETE", f"/cluster/sdn/zones/{sdn_zone_id}"
+                    )
+                except Exception as e:
+                    # Zone may have already been deleted (e.g. via the Proxmox UI),
+                    # leaving orphaned IPAM entries that still show up in our zone
+                    # scan.  Treat as already-gone.
+                    self.logger.warning(
+                        f"Could not delete SDN zone {sdn_zone_id!r} "
+                        f"(may already be gone): {e}"
+                    )
 
         await self.do_update_all_sdn()
 

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -31,6 +31,7 @@ from proxmoxsandbox._impl.sdn_commands import IpamMapping
 from proxmoxsandbox._impl.task_wrapper import TaskWrapper
 from proxmoxsandbox.schema import (
     ProxmoxSandboxEnvironmentConfig,
+    SdnConfig,
     SdnConfigType,
 )
 
@@ -150,6 +151,8 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 built_in_names.add(vm_config.vm_source_config.built_in)
         for built_in_name in built_in_names:
             await built_in_vm.ensure_exists(built_in_name)
+        if isinstance(config.sdn_config, SdnConfig) and config.sdn_config.allow_domains:
+            await built_in_vm.ensure_gateway_exists()
 
     @classmethod
     @override
@@ -205,6 +208,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 vm_configs_with_ids,
                 sdn_zone_id,
                 ipam_mappings,
+                gateway_vm_id,
             ) = await infra_commands.create_sdn_and_vms(
                 proxmox_ids_start,
                 sdn_config=config.sdn_config,
@@ -216,6 +220,11 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         vm_ids = tuple(
             vm_configs_with_id[0] for vm_configs_with_id in vm_configs_with_ids
         )
+        # Gateway VM (if provisioned) must be included in all_vm_ids so it gets
+        # torn down during sample_cleanup, but it is NOT added to the sandboxes
+        # dict — it's infrastructure, not an eval target.
+        if gateway_vm_id is not None:
+            vm_ids = vm_ids + (gateway_vm_id,)
 
         found_default = False
 

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -38,7 +38,7 @@ class SubnetConfig(BaseModel, frozen=True):
     """
 
     cidr: IPvAnyNetwork
-    gateway: IPvAnyAddress
+    gateway: Optional[IPvAnyAddress] = None
     snat: bool
     dhcp_ranges: Tuple[DhcpRange, ...]
 
@@ -76,16 +76,16 @@ class SdnConfig(BaseModel, frozen=True):
             nftables (IP-level). The gateway VM is outside the sandbox VM, so root
             inside the sandbox cannot bypass it.
 
-            Wildcard subdomains are supported: "debian.org" covers both debian.org and
-            all *.debian.org subdomains — no "*."-prefix needed. Leave empty (the
+            Subdomains must be listed explicitly: "gnu.org" does NOT cover
+            "ftp.gnu.org" — list each subdomain you need. Leave empty (the
             default) for unrestricted internet access.
 
             When allow_domains is non-empty:
             - snat on sandbox subnets is set to False (the gateway VM does NAT)
             - An extra internal VNet is created for the gateway VM's external interface
             - Sandbox VMs learn the gateway as their default router via DHCP
-            - The gateway IP in SubnetConfig is overridden to network-address+2; any
-              value you specify there will be silently replaced.
+            - The gateway IP in SubnetConfig must not be set (leave it as its default).
+              Setting it explicitly will raise a ValueError at construction time.
 
             Constraints (validated at construction time):
             - use_pve_ipam_dnsnmasq must be True
@@ -159,6 +159,13 @@ class SdnConfig(BaseModel, frozen=True):
                     f"the DHCP range {dhcp_range.start}–{dhcp_range.end}. "
                     "Adjust the DHCP range to exclude it (e.g. start at .10 or higher)."
                 )
+        if subnet.gateway is not None and ip_address(str(subnet.gateway)) != ip_address(gateway_vm_ip):
+            raise ValueError(
+                f"allow_domains: do not set the gateway in SubnetConfig manually. "
+                f"It will be automatically set to {gateway_vm_ip} (network-address+2). "
+                f"You specified {subnet.gateway}; either remove the gateway field or "
+                f"set it to {gateway_vm_ip}."
+            )
         return self
 
 
@@ -255,6 +262,9 @@ class VmConfig(BaseModel, frozen=True):
             This is applied to all virtual network interfaces.
         os_type: The OS type. If unset, defaults to "l26". Only for OVA. See
             https://pve.proxmox.com/wiki/Manual:_qm.conf for more details
+        firewall: if True, enables the Proxmox VM-level firewall on all NICs.
+            Proxmox firewall rules must be configured separately (e.g. via the UI or
+            Proxmox API). Defaults to False.
 
     Note on nics configuration:
     - If set, the VM will be connected to these VNets (one interface per VNet)
@@ -273,6 +283,7 @@ class VmConfig(BaseModel, frozen=True):
     nics: Optional[Tuple[VmNicConfig, ...]] = None
     is_sandbox: bool = True
     uefi_boot: bool = False
+    firewall: bool = False
     disk_controller: Optional[Literal["scsi", "ide"]] = None
     nic_controller: Optional[Literal["virtio", "e1000"]] = None
     os_type: Optional[

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -110,10 +110,17 @@ class SdnConfig(BaseModel, frozen=True):
               those IPs are NOT added to the filter — traffic will be dropped.
               This affects apt-get, pip, and similar tools that use subdomains.
               A future improvement is to enable dnsmasq's nftset= support.
-            - IPv6 egress is not filtered.  Proxmox SDN simple zones do not
-              route IPv6 and sandbox cloud-init sets dhcp6=false, so IPv6 egress
-              is generally unavailable.  If your Proxmox has IPv6 on the bridge,
-              IPv6 traffic will bypass the filter.
+            - IPv6 is blocked at two layers: sandbox VMs provisioned from
+              built-in templates have accept-ra: false in their cloud-init
+              network config (preventing SLAAC address assignment); custom VM
+              sources (OVA, existing_vm_template_tag) must configure this
+              independently.  The gateway's nftables inet forward chain drops
+              any IPv6 that routes through it.  Note: dhcp6: false alone only
+              disables DHCPv6; accept-ra is needed to block SLAAC.
+            - DNS-over-TLS (port 853) is dropped at the gateway.
+              DNS-over-HTTPS (port 443) is not intercepted but is blocked by
+              the IP-level filter unless a DoH provider happens to share an IP
+              with an explicitly allowed domain (unlikely in practice).
     """
 
     vnet_configs: Tuple[VnetConfig, ...]

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -107,7 +107,7 @@ class SdnConfig(BaseModel, frozen=True):
 
     @model_validator(mode="after")
     def _validate_allow_domains_constraints(self) -> "SdnConfig":
-        """Fail fast on configurations that are statically incompatible with allow_domains.
+        """Fail fast on configs statically incompatible with allow_domains.
 
         Dynamic constraints (e.g. no free external CIDR) can only be checked at
         provision time; these are the structural ones that can be caught now.

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -1,5 +1,6 @@
 """Data models and schemas for the Proxmox sandbox configuration."""
 
+from ipaddress import ip_address, ip_network
 from os import getenv
 from pathlib import Path
 from typing import Annotated, Literal, Optional, Tuple, TypeAlias, Union
@@ -99,6 +100,20 @@ class SdnConfig(BaseModel, frozen=True):
             DNS upstream: Google (8.8.8.8) is hardcoded inside the gateway VM.
             Environments that block outbound port 53 to 8.8.8.8 will not be able to
             resolve allowed domains.
+
+            Known limitations:
+            - Filtering is IP-level, not URL-level.  All TCP/UDP ports to an
+              allowed domain's IPs are permitted, not just HTTP/HTTPS.
+            - Only apex domain IPs are pre-seeded in the nftables filter at
+              provision time.  Subdomains (e.g. deb.debian.org when "debian.org"
+              is allowed) have their IPs resolved by dnsmasq at query time, but
+              those IPs are NOT added to the filter — traffic will be dropped.
+              This affects apt-get, pip, and similar tools that use subdomains.
+              A future improvement is to enable dnsmasq's nftset= support.
+            - IPv6 egress is not filtered.  Proxmox SDN simple zones do not
+              route IPv6 and sandbox cloud-init sets dhcp6=false, so IPv6 egress
+              is generally unavailable.  If your Proxmox has IPv6 on the bridge,
+              IPv6 traffic will bypass the filter.
     """
 
     vnet_configs: Tuple[VnetConfig, ...]
@@ -132,8 +147,6 @@ class SdnConfig(BaseModel, frozen=True):
             )
         # The gateway VM is assigned network-address+2.  Validate that the DHCP
         # pool does not include that address, which would cause an IPAM conflict.
-        from ipaddress import ip_address, ip_network
-
         subnet = subnet_list[0]
         gateway_vm_ip = ip_network(str(subnet.cidr)).network_address + 2
         for dhcp_range in subnet.dhcp_ranges:

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -69,10 +69,25 @@ class SdnConfig(BaseModel, frozen=True):
         use_pve_ipam_dnsnmasq: Whether to use Proxmox VE's built-in IPAM and DNSmasq
             Set to False if you are using e.g. your own pfsense instance for IPAM
             (recommended)
+        allow_domains: Allowlist of domains that sandbox VMs may reach. All other
+            egress is blocked. When non-empty, a gateway VM is automatically provisioned
+            per eval sample; it enforces the allowlist using dnsmasq (DNS-level) +
+            nftables (IP-level). The gateway VM is outside the sandbox VM, so root
+            inside the sandbox cannot bypass it.
+
+            Wildcard subdomains are supported: "debian.org" covers both debian.org and
+            all *.debian.org subdomains. Leave empty (the default) for unrestricted
+            internet access.
+
+            When allow_domains is non-empty:
+            - snat on sandbox subnets is set to False (the gateway VM does NAT)
+            - An extra internal VNet is created for the gateway VM's external interface
+            - Sandbox VMs learn the gateway as their default router via DHCP
     """
 
     vnet_configs: Tuple[VnetConfig, ...]
     use_pve_ipam_dnsnmasq: bool = True
+    allow_domains: Tuple[str, ...] = ()
 
 
 SdnConfigType: TypeAlias = Union[SdnConfig, Literal["auto"], None]

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -76,18 +76,77 @@ class SdnConfig(BaseModel, frozen=True):
             inside the sandbox cannot bypass it.
 
             Wildcard subdomains are supported: "debian.org" covers both debian.org and
-            all *.debian.org subdomains. Leave empty (the default) for unrestricted
-            internet access.
+            all *.debian.org subdomains — no "*."-prefix needed. Leave empty (the
+            default) for unrestricted internet access.
 
             When allow_domains is non-empty:
             - snat on sandbox subnets is set to False (the gateway VM does NAT)
             - An extra internal VNet is created for the gateway VM's external interface
             - Sandbox VMs learn the gateway as their default router via DHCP
+            - The gateway IP in SubnetConfig is overridden to network-address+2; any
+              value you specify there will be silently replaced.
+
+            Constraints (validated at construction time):
+            - use_pve_ipam_dnsnmasq must be True
+            - exactly one vnet_config must be provided
+            - that vnet must have exactly one subnet
+            - the subnet's DHCP range must not include network-address+2
+
+            Requires Proxmox 9+. The gateway VM template is built once on first use
+            (one-time cost: ~5–10 minutes). Per-eval overhead is ~30–60 s for the
+            gateway clone startup before the sandbox VM boots.
+
+            DNS upstream: Google (8.8.8.8) is hardcoded inside the gateway VM.
+            Environments that block outbound port 53 to 8.8.8.8 will not be able to
+            resolve allowed domains.
     """
 
     vnet_configs: Tuple[VnetConfig, ...]
     use_pve_ipam_dnsnmasq: bool = True
     allow_domains: Tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_allow_domains_constraints(self) -> "SdnConfig":
+        """Fail fast on configurations that are statically incompatible with allow_domains.
+
+        Dynamic constraints (e.g. no free external CIDR) can only be checked at
+        provision time; these are the structural ones that can be caught now.
+        """
+        if not self.allow_domains:
+            return self
+        if not self.use_pve_ipam_dnsnmasq:
+            raise ValueError(
+                "allow_domains requires use_pve_ipam_dnsnmasq=True "
+                "(the gateway VM uses Proxmox IPAM for its static IP assignment)"
+            )
+        if len(self.vnet_configs) != 1:
+            raise ValueError(
+                f"allow_domains requires exactly one vnet_config, "
+                f"got {len(self.vnet_configs)}"
+            )
+        subnet_list = self.vnet_configs[0].subnets
+        if len(subnet_list) != 1:
+            raise ValueError(
+                f"allow_domains requires exactly one subnet per vnet, "
+                f"got {len(subnet_list)}"
+            )
+        # The gateway VM is assigned network-address+2.  Validate that the DHCP
+        # pool does not include that address, which would cause an IPAM conflict.
+        from ipaddress import ip_address, ip_network
+
+        subnet = subnet_list[0]
+        gateway_vm_ip = ip_network(str(subnet.cidr)).network_address + 2
+        for dhcp_range in subnet.dhcp_ranges:
+            start = ip_address(str(dhcp_range.start))
+            end = ip_address(str(dhcp_range.end))
+            if start <= ip_address(gateway_vm_ip) <= end:
+                raise ValueError(
+                    f"allow_domains: gateway VM will be assigned {gateway_vm_ip} "
+                    f"(subnet network address +2), but that address falls within "
+                    f"the DHCP range {dhcp_range.start}–{dhcp_range.end}. "
+                    "Adjust the DHCP range to exclude it (e.g. start at .10 or higher)."
+                )
+        return self
 
 
 SdnConfigType: TypeAlias = Union[SdnConfig, Literal["auto"], None]

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -1,17 +1,17 @@
 """Data models and schemas for the Proxmox sandbox configuration."""
 
+import re
 from ipaddress import ip_address, ip_network
 from os import getenv
 from pathlib import Path
 from typing import Annotated, Literal, Optional, Tuple, TypeAlias, Union
-
-import re
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic.networks import IPvAnyAddress, IPvAnyNetwork
 from pydantic_extra_types.mac_address import MacAddress
 
 _DOMAIN_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$")
+_BARE_IP_RE = re.compile(r"^\d+(\.\d+)+$")
 
 
 class DhcpRange(BaseModel, frozen=True):
@@ -93,9 +93,9 @@ class SdnConfig(BaseModel, frozen=True):
 
             Constraints (validated at construction time):
             - use_pve_ipam_dnsnmasq must be True
-            - exactly one vnet_config must be provided
-            - that vnet must have exactly one subnet
-            - the subnet's DHCP range must not include network-address+2
+            - one or more vnet_configs must be provided
+            - each vnet must have exactly one subnet
+            - each subnet's DHCP range must not include network-address+2
 
             Requires Proxmox 9+. The gateway VM template is built once on first use
             (one-time cost: ~5–10 minutes). Per-eval overhead is ~30–60 s for the
@@ -108,12 +108,16 @@ class SdnConfig(BaseModel, frozen=True):
             Known limitations:
             - Filtering is IP-level, not URL-level.  All TCP/UDP ports to an
               allowed domain's IPs are permitted, not just HTTP/HTTPS.
-            - Only apex domain IPs are pre-seeded in the nftables filter at
-              provision time.  Subdomains (e.g. ftp.gnu.org when "gnu.org"
-              is allowed) have their IPs resolved by dnsmasq at query time, but
-              those IPs are NOT added to the filter — traffic will be dropped.
-              This affects apt-get, pip, and similar tools that use subdomains.
-              A future improvement is to enable dnsmasq's nftset= support.
+              ICMP is blocked (forward chain allows TCP/UDP only).
+            - Subdomain coverage: "gnu.org" covers ftp.gnu.org at
+              both DNS level (dnsmasq server=) and IP level (dnsmasq
+              nftset= pushes resolved IPs into the nftables set on
+              every query).  However, listing "gnu.org" only
+              pre-seeds the apex IPs at provision time; subdomain
+              IPs are added dynamically on first DNS query.  If a
+              subdomain resolves to IPs not shared by the apex,
+              the very first TCP SYN may be dropped (before dnsmasq
+              has seen a query for it).  A retry will succeed.
             - IPv6 is blocked at two layers: sandbox VMs provisioned from
               built-in templates have accept-ra: false in their cloud-init
               network config (preventing SLAAC address assignment); custom VM
@@ -135,10 +139,16 @@ class SdnConfig(BaseModel, frozen=True):
     @classmethod
     def _validate_domain_strings(cls, v: Tuple[str, ...]) -> Tuple[str, ...]:
         for domain in v:
+            if _BARE_IP_RE.match(domain):
+                raise ValueError(
+                    f"{domain!r} looks like an IP address, not a "
+                    f"domain name. allow_domains only accepts "
+                    f"hostnames."
+                )
             if not _DOMAIN_RE.match(domain) or ".." in domain:
                 raise ValueError(
-                    f"Invalid domain {domain!r}: must be a valid hostname "
-                    f"(alphanumeric, hyphens, dots only)"
+                    f"Invalid domain {domain!r}: must be a valid "
+                    f"hostname (alphanumeric, hyphens, dots only)"
                 )
         return v
 
@@ -156,38 +166,57 @@ class SdnConfig(BaseModel, frozen=True):
                 "allow_domains requires use_pve_ipam_dnsnmasq=True "
                 "(the gateway VM uses Proxmox IPAM for its static IP assignment)"
             )
-        if len(self.vnet_configs) != 1:
+        if len(self.vnet_configs) < 1:
             raise ValueError(
-                f"allow_domains requires exactly one vnet_config, "
+                "allow_domains requires at least one vnet_config, "
                 f"got {len(self.vnet_configs)}"
             )
-        subnet_list = self.vnet_configs[0].subnets
-        if len(subnet_list) != 1:
-            raise ValueError(
-                f"allow_domains requires exactly one subnet per vnet, "
-                f"got {len(subnet_list)}"
-            )
-        # The gateway VM is assigned network-address+2.  Validate that the DHCP
-        # pool does not include that address, which would cause an IPAM conflict.
-        subnet = subnet_list[0]
-        gateway_vm_ip = ip_network(str(subnet.cidr)).network_address + 2
-        for dhcp_range in subnet.dhcp_ranges:
-            start = ip_address(str(dhcp_range.start))
-            end = ip_address(str(dhcp_range.end))
-            if start <= ip_address(gateway_vm_ip) <= end:
+        for vnet_idx, vnet in enumerate(self.vnet_configs):
+            subnet_list = vnet.subnets
+            if len(subnet_list) != 1:
                 raise ValueError(
-                    f"allow_domains: gateway VM will be assigned {gateway_vm_ip} "
-                    f"(subnet network address +2), but that address falls within "
-                    f"the DHCP range {dhcp_range.start}–{dhcp_range.end}. "
-                    "Adjust the DHCP range to exclude it (e.g. start at .10 or higher)."
+                    "allow_domains requires exactly one subnet "
+                    f"per vnet, got {len(subnet_list)} in "
+                    f"vnet {vnet_idx}"
                 )
-        if subnet.gateway is not None and ip_address(str(subnet.gateway)) != ip_address(gateway_vm_ip):
-            raise ValueError(
-                f"allow_domains: do not set the gateway in SubnetConfig manually. "
-                f"It will be automatically set to {gateway_vm_ip} (network-address+2). "
-                f"You specified {subnet.gateway}; either remove the gateway field or "
-                f"set it to {gateway_vm_ip}."
+            # The gateway VM is assigned network-address+2.
+            # Validate that the DHCP pool does not include that
+            # address (IPAM conflict).
+            subnet = subnet_list[0]
+            gateway_vm_ip = (
+                ip_network(str(subnet.cidr)).network_address + 2
             )
+            for dhcp_range in subnet.dhcp_ranges:
+                start = ip_address(str(dhcp_range.start))
+                end = ip_address(str(dhcp_range.end))
+                if start <= ip_address(gateway_vm_ip) <= end:
+                    raise ValueError(
+                        "allow_domains: gateway VM will be "
+                        f"assigned {gateway_vm_ip} "
+                        "(subnet network address +2) in "
+                        f"vnet {vnet_idx}, but that address "
+                        "falls within the DHCP range "
+                        f"{dhcp_range.start}\u2013"
+                        f"{dhcp_range.end}. Adjust the DHCP "
+                        "range to exclude it "
+                        "(e.g. start at .10 or higher)."
+                    )
+            gw_set = subnet.gateway is not None
+            gw_mismatch = gw_set and (
+                ip_address(str(subnet.gateway))
+                != ip_address(gateway_vm_ip)
+            )
+            if gw_mismatch:
+                raise ValueError(
+                    "allow_domains: do not set the gateway "
+                    "in SubnetConfig manually. It will be "
+                    f"automatically set to {gateway_vm_ip} "
+                    "(network-address+2) in vnet "
+                    f"{vnet_idx}. You specified "
+                    f"{subnet.gateway}; either remove the "
+                    "gateway field or set it to "
+                    f"{gateway_vm_ip}."
+                )
         return self
 
 

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -105,7 +105,7 @@ class SdnConfig(BaseModel, frozen=True):
             - Filtering is IP-level, not URL-level.  All TCP/UDP ports to an
               allowed domain's IPs are permitted, not just HTTP/HTTPS.
             - Only apex domain IPs are pre-seeded in the nftables filter at
-              provision time.  Subdomains (e.g. deb.debian.org when "debian.org"
+              provision time.  Subdomains (e.g. ftp.gnu.org when "gnu.org"
               is allowed) have their IPs resolved by dnsmasq at query time, but
               those IPs are NOT added to the filter — traffic will be dropped.
               This affects apt-get, pip, and similar tools that use subdomains.

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -80,9 +80,12 @@ class SdnConfig(BaseModel, frozen=True):
             nftables (IP-level). The gateway VM is outside the sandbox VM, so root
             inside the sandbox cannot bypass it.
 
-            Subdomains must be listed explicitly: "gnu.org" does NOT cover
-            "ftp.gnu.org" — list each subdomain you need. Leave empty (the
-            default) for unrestricted internet access.
+            Subdomain coverage: "gnu.org" covers ftp.gnu.org
+            automatically — dnsmasq's server= and nftset= directives
+            both match the apex and all subdomains.  Subdomain IPs
+            are injected into the nftables set dynamically on first
+            DNS query (not pre-seeded at provision time).  Leave
+            empty (the default) for unrestricted internet access.
 
             When allow_domains is non-empty:
             - snat on sandbox subnets is set to False (the gateway VM does NAT)
@@ -109,15 +112,12 @@ class SdnConfig(BaseModel, frozen=True):
             - Filtering is IP-level, not URL-level.  All TCP/UDP ports to an
               allowed domain's IPs are permitted, not just HTTP/HTTPS.
               ICMP is blocked (forward chain allows TCP/UDP only).
-            - Subdomain coverage: "gnu.org" covers ftp.gnu.org at
-              both DNS level (dnsmasq server=) and IP level (dnsmasq
-              nftset= pushes resolved IPs into the nftables set on
-              every query).  However, listing "gnu.org" only
-              pre-seeds the apex IPs at provision time; subdomain
-              IPs are added dynamically on first DNS query.  If a
-              subdomain resolves to IPs not shared by the apex,
-              the very first TCP SYN may be dropped (before dnsmasq
-              has seen a query for it).  A retry will succeed.
+            - Only apex domain IPs are pre-seeded at provision time.
+              Subdomain IPs are injected dynamically by dnsmasq's
+              nftset= on first DNS query.  If a client connects to
+              a subdomain IP without a prior DNS query (hardcoded
+              IP), the first SYN is dropped.  Normal DNS-based
+              access works on first attempt.
             - IPv6 is blocked at two layers: sandbox VMs provisioned from
               built-in templates have accept-ra: false in their cloud-init
               network config (preventing SLAAC address assignment); custom VM

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -5,9 +5,13 @@ from os import getenv
 from pathlib import Path
 from typing import Annotated, Literal, Optional, Tuple, TypeAlias, Union
 
-from pydantic import BaseModel, Field, model_validator
+import re
+
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic.networks import IPvAnyAddress, IPvAnyNetwork
 from pydantic_extra_types.mac_address import MacAddress
+
+_DOMAIN_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$")
 
 
 class DhcpRange(BaseModel, frozen=True):
@@ -126,6 +130,17 @@ class SdnConfig(BaseModel, frozen=True):
     vnet_configs: Tuple[VnetConfig, ...]
     use_pve_ipam_dnsnmasq: bool = True
     allow_domains: Tuple[str, ...] = ()
+
+    @field_validator("allow_domains")
+    @classmethod
+    def _validate_domain_strings(cls, v: Tuple[str, ...]) -> Tuple[str, ...]:
+        for domain in v:
+            if not _DOMAIN_RE.match(domain) or ".." in domain:
+                raise ValueError(
+                    f"Invalid domain {domain!r}: must be a valid hostname "
+                    f"(alphanumeric, hyphens, dots only)"
+                )
+        return v
 
     @model_validator(mode="after")
     def _validate_allow_domains_constraints(self) -> "SdnConfig":

--- a/tests/proxmoxsandboxtest/test_allow_domains_manual.py
+++ b/tests/proxmoxsandboxtest/test_allow_domains_manual.py
@@ -1,0 +1,245 @@
+"""Manual test coverage for allow_domains gaps not covered by test_allow_domains.
+
+Covers:
+1. Proxmox host IP is blocked  — the host's RFC1918 IP is never in allowed_ips,
+   so a sandbox VM cannot reach the Proxmox API directly.
+2. Subdomain gap (apex only) — specifying "gnu.org" does NOT give access to
+   ftp.gnu.org because subdomain IPs are not pre-seeded.
+3. Subdomain explicit listing — adding the subdomain explicitly does work.
+4. Non-HTTP ports to allowed IPs — all ports are permitted (IP-level filter).
+
+Pre-requisites:
+    A running Proxmox instance configured as described in README.md.
+    Environment variables set (see README.md "Requirements" section):
+        PROXMOX_HOST, PROXMOX_PORT, PROXMOX_USER, PROXMOX_REALM,
+        PROXMOX_PASSWORD, PROXMOX_NODE, PROXMOX_VERIFY_TLS
+
+Run with:
+    set -a; source .env; set +a
+    uv run pytest tests/proxmoxsandboxtest/test_allow_domains_manual.py -v -s
+
+Note: each test uses a distinct /24 subnet (10.77.10–13.0/24) so tests do not
+conflict with each other or with stale zones from interrupted previous runs.
+If CIDR conflicts are still reported, run `inspect sandbox cleanup proxmox` first.
+"""
+
+import os
+from ipaddress import ip_address, ip_network
+from typing import Dict
+
+from inspect_ai.util import SandboxEnvironment
+
+from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
+from proxmoxsandbox.schema import (
+    DhcpRange,
+    ProxmoxSandboxEnvironmentConfig,
+    SdnConfig,
+    SubnetConfig,
+    VmConfig,
+    VmSourceConfig,
+    VnetConfig,
+)
+
+from .proxmox_sandbox_utils import setup_sandbox
+
+PROXMOX_HOST_IP = os.environ.get("PROXMOX_HOST", "")
+
+
+def _base_config(
+    allow_domains: tuple[str, ...], third_octet: int
+) -> ProxmoxSandboxEnvironmentConfig:
+    """Build a test config using 10.77.<third_octet>.0/24.
+
+    Each test passes a distinct third_octet (10–13) so concurrent or sequential
+    runs do not collide on the same CIDR.  The gateway VM is assigned .2 by the
+    provisioning logic; DHCP runs from .50–.100, safely clear of .2.
+    """
+    base = f"10.77.{third_octet}"
+    return ProxmoxSandboxEnvironmentConfig(
+        sdn_config=SdnConfig(
+            vnet_configs=(
+                VnetConfig(
+                    alias="manual-test",
+                    subnets=(
+                        SubnetConfig(
+                            cidr=ip_network(f"{base}.0/24"),
+                            gateway=ip_address(f"{base}.1"),
+                            snat=True,
+                            dhcp_ranges=(
+                                DhcpRange(
+                                    start=ip_address(f"{base}.50"),
+                                    end=ip_address(f"{base}.100"),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            use_pve_ipam_dnsnmasq=True,
+            allow_domains=allow_domains,
+        ),
+        vms_config=(
+            VmConfig(
+                name="manual-test-vm",
+                vm_source_config=VmSourceConfig(built_in="ubuntu24.04"),
+                ram_mb=512,
+                vcpus=1,
+            ),
+        ),
+    )
+
+
+async def test_proxmox_host_ip_is_blocked() -> None:
+    """Sandbox cannot reach the Proxmox host's RFC1918 IP directly.
+
+    The host IP is never added to allowed_ips (it's not a DNS response for any
+    allowed domain), so it must be blocked by the FORWARD chain's default drop.
+    This closes the VM→Proxmox→other-VM lateral escape path.
+    """
+    assert PROXMOX_HOST_IP, "PROXMOX_HOST env var not set"
+
+    envs_dict: Dict[str, SandboxEnvironment] = {}
+    config = _base_config(allow_domains=("cloudflare.com",), third_octet=10)
+    task_name = "tphiblocked"
+    try:
+        _, envs_dict = await setup_sandbox(task_name, config)
+        sandbox = envs_dict["default"]
+
+        result = await sandbox.exec(
+            ["curl", "--fail", "--max-time", "5", f"http://{PROXMOX_HOST_IP}"],
+            timeout=10,
+        )
+        assert not result.success, (
+            f"curl to Proxmox host {PROXMOX_HOST_IP} should be blocked "
+            f"by the gateway FORWARD chain, but succeeded: {result=}"
+        )
+    finally:
+        if envs_dict:
+            await ProxmoxSandboxEnvironment.sample_cleanup(
+                task_name=task_name,
+                config=config,
+                environments=envs_dict,
+                interrupted=False,
+            )
+
+
+async def test_subdomain_blocked_when_only_apex_listed() -> None:
+    """Subdomain IPs are not pre-seeded; only apex domain IPs are.
+
+    "gnu.org" in the allowlist lets dnsmasq resolve ftp.gnu.org (DNS works),
+    but the returned IP (.20) was never added to allowed_ips (only gnu.org's .116
+    was pre-seeded), so the FORWARD chain drops the traffic.
+
+    Note: domains that share CDN IPs (e.g. debian.org and deb.debian.org both
+    resolve to the same Fastly anycast IPs from 8.8.8.8) do NOT demonstrate this
+    gap — allowing the apex inadvertently allows the subdomain.  gnu.org and
+    ftp.gnu.org use distinct, non-CDN IPs, making the gap observable.
+    """
+    envs_dict: Dict[str, SandboxEnvironment] = {}
+    config = _base_config(allow_domains=("gnu.org",), third_octet=11)
+    task_name = "tsubblocked"
+    try:
+        _, envs_dict = await setup_sandbox(task_name, config)
+        sandbox = envs_dict["default"]
+
+        # DNS resolves (dnsmasq forwards subdomain queries for allowed apex).
+        # Query the gateway VM directly — it is always at network-address+2.
+        dns_result = await sandbox.exec(
+            ["bash", "-c", "dig +short ftp.gnu.org @10.77.11.2 | head -3"],
+            timeout=15,
+        )
+        print(f"\n[subdomain DNS] ftp.gnu.org: {dns_result.stdout.strip()!r}")
+
+        # But HTTP connection is dropped — ftp.gnu.org's IP is not in allowed_ips
+        curl_result = await sandbox.exec(
+            ["curl", "--fail", "--max-time", "5", "http://ftp.gnu.org"],
+            timeout=10,
+        )
+        assert not curl_result.success, (
+            "curl to ftp.gnu.org should be blocked (subdomain IPs not pre-seeded), "
+            f"but succeeded: {curl_result=}"
+        )
+    finally:
+        if envs_dict:
+            await ProxmoxSandboxEnvironment.sample_cleanup(
+                task_name=task_name,
+                config=config,
+                environments=envs_dict,
+                interrupted=False,
+            )
+
+
+async def test_subdomain_allowed_when_listed_explicitly() -> None:
+    """Explicitly listing a subdomain in allow_domains pre-seeds its IPs correctly.
+
+    Paired with test_subdomain_blocked_when_only_apex_listed: adding ftp.gnu.org
+    explicitly causes its IP (.20) to be pre-seeded alongside gnu.org's (.116),
+    so HTTP to ftp.gnu.org succeeds.
+    """
+    envs_dict: Dict[str, SandboxEnvironment] = {}
+    config = _base_config(allow_domains=("gnu.org", "ftp.gnu.org"), third_octet=12)
+    task_name = "tsuballow"
+    try:
+        _, envs_dict = await setup_sandbox(task_name, config)
+        sandbox = envs_dict["default"]
+
+        curl_result = await sandbox.exec(
+            ["curl", "--fail", "--max-time", "15", "http://ftp.gnu.org"],
+            timeout=20,
+        )
+        assert curl_result.success, (
+            "curl to ftp.gnu.org should succeed when explicitly listed "
+            f"in allow_domains: {curl_result=}"
+        )
+    finally:
+        if envs_dict:
+            await ProxmoxSandboxEnvironment.sample_cleanup(
+                task_name=task_name,
+                config=config,
+                environments=envs_dict,
+                interrupted=False,
+            )
+
+
+async def test_all_ports_open_to_allowed_ips() -> None:
+    """Filtering is IP-level: all TCP ports to allowed-domain IPs are reachable.
+
+    cloudflare.com listens on port 443 (HTTPS) and port 80 (HTTP).
+    We test port 443 directly via TCP connect (not HTTPS handshake) to confirm
+    the FORWARD chain does not restrict by port.
+    """
+    envs_dict: Dict[str, SandboxEnvironment] = {}
+    config = _base_config(allow_domains=("cloudflare.com",), third_octet=13)
+    task_name = "tallports"
+    try:
+        _, envs_dict = await setup_sandbox(task_name, config)
+        sandbox = envs_dict["default"]
+
+        # TCP connect to port 443 — allowed because cloudflare.com IPs are in set
+        nc_result = await sandbox.exec(
+            ["bash", "-c", "nc -zw5 cloudflare.com 443 && echo OPEN || echo CLOSED"],
+            timeout=15,
+        )
+        assert "OPEN" in nc_result.stdout, (
+            f"TCP port 443 to cloudflare.com (allowed domain) should be reachable: "
+            f"{nc_result=}"
+        )
+
+        # TCP connect to a blocked domain's port 443 — should fail
+        nc_blocked = await sandbox.exec(
+            ["bash", "-c", "nc -zw5 google.com 443 && echo OPEN || echo CLOSED"],
+            timeout=10,
+        )
+        # nc can't resolve google.com (SERVFAIL from dnsmasq) so it fails
+        assert "OPEN" not in nc_blocked.stdout, (
+            f"TCP port 443 to google.com (blocked) should not be reachable: "
+            f"{nc_blocked=}"
+        )
+    finally:
+        if envs_dict:
+            await ProxmoxSandboxEnvironment.sample_cleanup(
+                task_name=task_name,
+                config=config,
+                environments=envs_dict,
+                interrupted=False,
+            )

--- a/tests/proxmoxsandboxtest/test_allow_domains_manual.py
+++ b/tests/proxmoxsandboxtest/test_allow_domains_manual.py
@@ -11,8 +11,11 @@ Covers:
    IPv6 address is assigned, so IPv6 cannot be used to bypass the gateway.
 6. DNS-over-TLS (port 853) blocked — the gateway nftables forward chain drops
    port 853 traffic even to allowed-domain IPs, closing the DoT bypass path.
+7. Multi-vnet egress filtering — 2 vnets with distinct CIDRs, 1 VM each on a
+   different vnet. Allowed domain reachable from both VMs, blocked domain fails
+   from both.
 
-Note: each test uses a distinct /24 subnet (10.77.10–15.0/24) so tests do not
+Note: each test uses a distinct /24 subnet (10.77.10–19.0/24) so tests do not
 conflict with each other or with stale zones from interrupted previous runs.
 If CIDR conflicts are still reported, run `inspect sandbox cleanup proxmox` first.
 """
@@ -30,6 +33,7 @@ from proxmoxsandbox.schema import (
     SdnConfig,
     SubnetConfig,
     VmConfig,
+    VmNicConfig,
     VmSourceConfig,
     VnetConfig,
 )
@@ -37,6 +41,26 @@ from proxmoxsandbox.schema import (
 from .proxmox_sandbox_utils import setup_sandbox
 
 PROXMOX_HOST_IP = os.environ.get("PROXMOX_HOST", "")
+
+
+def _make_vnet(alias: str, third_octet: int) -> VnetConfig:
+    """Build a VnetConfig with 10.77.<third_octet>.0/24, DHCP .50-.100."""
+    base = f"10.77.{third_octet}"
+    return VnetConfig(
+        alias=alias,
+        subnets=(
+            SubnetConfig(
+                cidr=ip_network(f"{base}.0/24"),
+                snat=True,
+                dhcp_ranges=(
+                    DhcpRange(
+                        start=ip_address(f"{base}.50"),
+                        end=ip_address(f"{base}.100"),
+                    ),
+                ),
+            ),
+        ),
+    )
 
 
 def _base_config(
@@ -348,6 +372,88 @@ async def test_dns_over_tls_port_853_blocked() -> None:
             f"Port 853 to cloudflare IP {cloudflare_ip} should be blocked "
             f"by the tcp/udp dport 853 drop rule, but got: {nc_853=}"
         )
+    finally:
+        if envs_dict:
+            await ProxmoxSandboxEnvironment.sample_cleanup(
+                task_name=task_name,
+                config=config,
+                environments=envs_dict,
+                interrupted=False,
+            )
+
+
+async def test_multi_vnet_egress_filtering() -> None:
+    """Two vnets with distinct CIDRs share the same allowlist via one gateway.
+
+    VM-A on vnet 16, VM-B on vnet 17.  Both should reach cloudflare.com
+    (allowed) and both should fail to reach google.com (blocked).
+
+    This is the core CAST requirement: multiple sandbox vnets sharing a
+    single gateway VM with a shared domain allowlist.
+    """
+    envs_dict: Dict[str, SandboxEnvironment] = {}
+    config = ProxmoxSandboxEnvironmentConfig(
+        sdn_config=SdnConfig(
+            vnet_configs=(
+                _make_vnet("multi-a", 16),
+                _make_vnet("multi-b", 17),
+            ),
+            use_pve_ipam_dnsnmasq=True,
+            allow_domains=("cloudflare.com",),
+        ),
+        vms_config=(
+            VmConfig(
+                name="multi-vm-a",
+                vm_source_config=VmSourceConfig(built_in="ubuntu24.04"),
+                ram_mb=512,
+                vcpus=1,
+                nics=(VmNicConfig(vnet_alias="multi-a"),),
+            ),
+            VmConfig(
+                name="multi-vm-b",
+                vm_source_config=VmSourceConfig(built_in="ubuntu24.04"),
+                ram_mb=512,
+                vcpus=1,
+                nics=(VmNicConfig(vnet_alias="multi-b"),),
+            ),
+        ),
+    )
+    task_name = "tmultivnet"
+    try:
+        _, envs_dict = await setup_sandbox(task_name, config)
+        sandboxes = list(envs_dict.values())
+        assert len(sandboxes) == 2, (
+            f"Expected 2 sandbox envs, got {len(sandboxes)}"
+        )
+
+        for i, sandbox in enumerate(sandboxes):
+            label = f"VM-{i}"
+
+            # Allowed domain should be reachable
+            curl_allowed = await sandbox.exec(
+                [
+                    "curl", "--fail", "--max-time", "15",
+                    "http://cloudflare.com",
+                ],
+                timeout=20,
+            )
+            assert curl_allowed.success, (
+                f"{label}: curl to cloudflare.com (allowed) "
+                f"should succeed: {curl_allowed=}"
+            )
+
+            # Blocked domain should fail
+            curl_blocked = await sandbox.exec(
+                [
+                    "curl", "--fail", "--max-time", "5",
+                    "http://google.com",
+                ],
+                timeout=10,
+            )
+            assert not curl_blocked.success, (
+                f"{label}: curl to google.com (blocked) "
+                f"should fail: {curl_blocked=}"
+            )
     finally:
         if envs_dict:
             await ProxmoxSandboxEnvironment.sample_cleanup(

--- a/tests/proxmoxsandboxtest/test_allow_domains_manual.py
+++ b/tests/proxmoxsandboxtest/test_allow_domains_manual.py
@@ -7,8 +7,12 @@ Covers:
    ftp.gnu.org because subdomain IPs are not pre-seeded.
 3. Subdomain explicit listing — adding the subdomain explicitly does work.
 4. Non-HTTP ports to allowed IPs — all ports are permitted (IP-level filter).
+5. IPv6 SLAAC blocked — built-in VM templates have accept-ra: false; no global
+   IPv6 address is assigned, so IPv6 cannot be used to bypass the gateway.
+6. DNS-over-TLS (port 853) blocked — the gateway nftables forward chain drops
+   port 853 traffic even to allowed-domain IPs, closing the DoT bypass path.
 
-Note: each test uses a distinct /24 subnet (10.77.10–13.0/24) so tests do not
+Note: each test uses a distinct /24 subnet (10.77.10–15.0/24) so tests do not
 conflict with each other or with stale zones from interrupted previous runs.
 If CIDR conflicts are still reported, run `inspect sandbox cleanup proxmox` first.
 """
@@ -53,7 +57,6 @@ def _base_config(
                     subnets=(
                         SubnetConfig(
                             cidr=ip_network(f"{base}.0/24"),
-                            gateway=ip_address(f"{base}.1"),
                             snat=True,
                             dhcp_ranges=(
                                 DhcpRange(
@@ -224,6 +227,125 @@ async def test_all_ports_open_to_allowed_ips() -> None:
         assert "OPEN" not in nc_blocked.stdout, (
             f"TCP port 443 to google.com (blocked) should not be reachable: "
             f"{nc_blocked=}"
+        )
+    finally:
+        if envs_dict:
+            await ProxmoxSandboxEnvironment.sample_cleanup(
+                task_name=task_name,
+                config=config,
+                environments=envs_dict,
+                interrupted=False,
+            )
+
+
+async def test_ipv6_slaac_blocked() -> None:
+    """Built-in VM templates cannot acquire a global IPv6 address via SLAAC.
+
+    cloud-init sets accept-ra: false on all built-in VM network configs (both
+    sandbox and gateway).  dhcp6: false alone only disables DHCPv6; accept-ra
+    is also needed to block SLAAC (stateless address autoconfiguration via
+    Router Advertisements).
+
+    This test verifies the protection holds end-to-end:
+    1. No global-scope IPv6 address is assigned (SLAAC is blocked).
+    2. IPv6 curl to an allowed domain fails (no IPv6 egress path).
+
+    Note: a link-local address (fe80::) is normal and expected — it does not
+    provide internet reachability.  Only global-scope addresses are a concern.
+
+    Custom VM sources (OVA, existing_vm_template_tag) must configure
+    accept-ra: false independently; that is documented as a known limitation
+    in schema.py and is not tested here.
+    """
+    envs_dict: Dict[str, SandboxEnvironment] = {}
+    config = _base_config(allow_domains=("cloudflare.com",), third_octet=14)
+    task_name = "tipv6slaac"
+    try:
+        _, envs_dict = await setup_sandbox(task_name, config)
+        sandbox = envs_dict["default"]
+
+        # Check for global-scope IPv6 addresses — should be none.
+        addr_result = await sandbox.exec(
+            ["ip", "-6", "addr", "show", "scope", "global"],
+            timeout=10,
+        )
+        assert addr_result.stdout.strip() == "", (
+            "Sandbox VM should have no global-scope IPv6 address (SLAAC blocked "
+            f"by accept-ra: false), but got: {addr_result.stdout.strip()!r}"
+        )
+
+        # Belt-and-braces: IPv6 curl to an allowed domain should also fail.
+        # cloudflare.com has AAAA records; without a global IPv6 address the
+        # connect will fail before even reaching the gateway.
+        curl6_result = await sandbox.exec(
+            ["curl", "--fail", "--max-time", "5", "--ipv6", "http://cloudflare.com"],
+            timeout=10,
+        )
+        assert not curl6_result.success, (
+            "IPv6 curl to cloudflare.com should fail (no global IPv6 address), "
+            f"but succeeded: {curl6_result=}"
+        )
+    finally:
+        if envs_dict:
+            await ProxmoxSandboxEnvironment.sample_cleanup(
+                task_name=task_name,
+                config=config,
+                environments=envs_dict,
+                interrupted=False,
+            )
+
+
+async def test_dns_over_tls_port_853_blocked() -> None:
+    """Gateway nftables drops port 853 even to allowed-domain IPs.
+
+    The forward chain rule `ip saddr {sandbox_cidr} ip dport 853 drop` runs
+    before the `@allowed_ips accept` rule, so port 853 is blocked regardless
+    of whether the destination IP is in the allowed set.  This closes the
+    DNS-over-TLS bypass path (a sandbox could otherwise send encrypted DNS
+    queries directly to a DoT resolver, bypassing the dnsmasq allowlist).
+
+    Cloudflare (1.1.1.1) is both an allowed domain AND a DoT resolver.
+    This test exploits that: port 443 to cloudflare.com succeeds (proving
+    the IP is in the allowed set), but port 853 to the same IP fails
+    (proving the port-853 drop rule fires before the IP accept rule).
+    """
+    envs_dict: Dict[str, SandboxEnvironment] = {}
+    config = _base_config(allow_domains=("cloudflare.com",), third_octet=15)
+    task_name = "tdot853"
+    try:
+        _, envs_dict = await setup_sandbox(task_name, config)
+        sandbox = envs_dict["default"]
+
+        # Resolve cloudflare.com to an IP so we can hit the same IP on two ports.
+        # We use the gateway's dnsmasq directly to get the pre-seeded IP.
+        resolve_result = await sandbox.exec(
+            ["bash", "-c", "dig +short cloudflare.com @10.77.15.2 | head -1"],
+            timeout=15,
+        )
+        cloudflare_ip = resolve_result.stdout.strip()
+        assert cloudflare_ip, (
+            f"Could not resolve cloudflare.com via gateway dnsmasq: {resolve_result=}"
+        )
+        print(f"\n[DoT test] cloudflare.com resolved to: {cloudflare_ip!r}")
+
+        # Port 443 to the same IP — should be OPEN (IP is in the allowed set).
+        nc_443 = await sandbox.exec(
+            ["bash", "-c", f"nc -zw5 {cloudflare_ip} 443 && echo OPEN || echo CLOSED"],
+            timeout=15,
+        )
+        assert "OPEN" in nc_443.stdout, (
+            f"Port 443 to cloudflare IP {cloudflare_ip} should be reachable "
+            f"(IP is in allowed set): {nc_443=}"
+        )
+
+        # Port 853 to the same IP — should be CLOSED (drop rule fires first).
+        nc_853 = await sandbox.exec(
+            ["bash", "-c", f"nc -zw5 {cloudflare_ip} 853 && echo OPEN || echo CLOSED"],
+            timeout=15,
+        )
+        assert "OPEN" not in nc_853.stdout, (
+            f"Port 853 to cloudflare IP {cloudflare_ip} should be blocked "
+            f"by the ip dport 853 drop rule, but got: {nc_853=}"
         )
     finally:
         if envs_dict:

--- a/tests/proxmoxsandboxtest/test_allow_domains_manual.py
+++ b/tests/proxmoxsandboxtest/test_allow_domains_manual.py
@@ -298,11 +298,12 @@ async def test_ipv6_slaac_blocked() -> None:
 async def test_dns_over_tls_port_853_blocked() -> None:
     """Gateway nftables drops port 853 even to allowed-domain IPs.
 
-    The forward chain rule `ip saddr {sandbox_cidr} ip dport 853 drop` runs
-    before the `@allowed_ips accept` rule, so port 853 is blocked regardless
-    of whether the destination IP is in the allowed set.  This closes the
-    DNS-over-TLS bypass path (a sandbox could otherwise send encrypted DNS
-    queries directly to a DoT resolver, bypassing the dnsmasq allowlist).
+    The forward chain rules `tcp dport 853 drop` and `udp dport 853 drop`
+    run before the `@allowed_ips accept` rule, so port 853 is blocked
+    regardless of whether the destination IP is in the allowed set.  This
+    closes DNS-over-TLS and DNS-over-QUIC bypass paths (a sandbox could
+    otherwise send encrypted DNS queries directly to a resolver, bypassing
+    the dnsmasq allowlist).
 
     Cloudflare (1.1.1.1) is both an allowed domain AND a DoT resolver.
     This test exploits that: port 443 to cloudflare.com succeeds (proving
@@ -345,7 +346,7 @@ async def test_dns_over_tls_port_853_blocked() -> None:
         )
         assert "OPEN" not in nc_853.stdout, (
             f"Port 853 to cloudflare IP {cloudflare_ip} should be blocked "
-            f"by the ip dport 853 drop rule, but got: {nc_853=}"
+            f"by the tcp/udp dport 853 drop rule, but got: {nc_853=}"
         )
     finally:
         if envs_dict:

--- a/tests/proxmoxsandboxtest/test_allow_domains_manual.py
+++ b/tests/proxmoxsandboxtest/test_allow_domains_manual.py
@@ -8,16 +8,6 @@ Covers:
 3. Subdomain explicit listing — adding the subdomain explicitly does work.
 4. Non-HTTP ports to allowed IPs — all ports are permitted (IP-level filter).
 
-Pre-requisites:
-    A running Proxmox instance configured as described in README.md.
-    Environment variables set (see README.md "Requirements" section):
-        PROXMOX_HOST, PROXMOX_PORT, PROXMOX_USER, PROXMOX_REALM,
-        PROXMOX_PASSWORD, PROXMOX_NODE, PROXMOX_VERIFY_TLS
-
-Run with:
-    set -a; source .env; set +a
-    uv run pytest tests/proxmoxsandboxtest/test_allow_domains_manual.py -v -s
-
 Note: each test uses a distinct /24 subnet (10.77.10–13.0/24) so tests do not
 conflict with each other or with stale zones from interrupted previous runs.
 If CIDR conflicts are still reported, run `inspect sandbox cleanup proxmox` first.

--- a/tests/proxmoxsandboxtest/test_allow_domains_manual.py
+++ b/tests/proxmoxsandboxtest/test_allow_domains_manual.py
@@ -140,41 +140,47 @@ async def test_proxmox_host_ip_is_blocked() -> None:
             )
 
 
-async def test_subdomain_blocked_when_only_apex_listed() -> None:
-    """Subdomain IPs are not pre-seeded; only apex domain IPs are.
+async def test_subdomain_reachable_when_apex_listed() -> None:
+    """Subdomains are covered dynamically via dnsmasq nftset=.
 
-    "gnu.org" in the allowlist lets dnsmasq resolve ftp.gnu.org (DNS works),
-    but the returned IP (.20) was never added to allowed_ips (only gnu.org's .116
-    was pre-seeded), so the FORWARD chain drops the traffic.
+    "gnu.org" in the allowlist causes dnsmasq to forward DNS queries
+    for ftp.gnu.org (subdomain) AND inject the resolved IPs into the
+    nftables allowed_ips set via nftset=.  Both DNS and IP-level
+    access work.
 
-    Note: domains that share CDN IPs (e.g. debian.org and deb.debian.org both
-    resolve to the same Fastly anycast IPs from 8.8.8.8) do NOT demonstrate this
-    gap — allowing the apex inadvertently allows the subdomain.  gnu.org and
-    ftp.gnu.org use distinct, non-CDN IPs, making the gap observable.
+    gnu.org and ftp.gnu.org use distinct, non-CDN IPs, confirming
+    this is dynamic nftset injection (not shared-IP coincidence).
     """
     envs_dict: Dict[str, SandboxEnvironment] = {}
     config = _base_config(allow_domains=("gnu.org",), third_octet=11)
-    task_name = "tsubblocked"
+    task_name = "tsubdyn"
     try:
         _, envs_dict = await setup_sandbox(task_name, config)
         sandbox = envs_dict["default"]
 
-        # DNS resolves (dnsmasq forwards subdomain queries for allowed apex).
-        # Query the gateway VM directly — it is always at network-address+2.
+        # DNS resolves — dnsmasq forwards subdomain queries and
+        # nftset= injects resolved IPs into allowed_ips.
         dns_result = await sandbox.exec(
-            ["bash", "-c", "dig +short ftp.gnu.org @10.77.11.2 | head -3"],
+            ["bash", "-c",
+             "dig +short ftp.gnu.org @10.77.11.2 | head -3"],
             timeout=15,
         )
-        print(f"\n[subdomain DNS] ftp.gnu.org: {dns_result.stdout.strip()!r}")
-
-        # But HTTP connection is dropped — ftp.gnu.org's IP is not in allowed_ips
-        curl_result = await sandbox.exec(
-            ["curl", "--fail", "--max-time", "5", "http://ftp.gnu.org"],
-            timeout=10,
+        print(
+            f"\n[subdomain DNS] ftp.gnu.org:"
+            f" {dns_result.stdout.strip()!r}"
         )
-        assert not curl_result.success, (
-            "curl to ftp.gnu.org should be blocked (subdomain IPs not pre-seeded), "
-            f"but succeeded: {curl_result=}"
+
+        # HTTP succeeds — nftset= injected ftp.gnu.org's IP when
+        # dnsmasq resolved the subdomain query above.
+        curl_result = await sandbox.exec(
+            ["curl", "--fail", "--max-time", "10",
+             "http://ftp.gnu.org"],
+            timeout=15,
+        )
+        assert curl_result.success, (
+            "curl to ftp.gnu.org should succeed "
+            "(nftset= injects subdomain IPs dynamically)"
+            f", but failed: {curl_result=}"
         )
     finally:
         if envs_dict:
@@ -187,11 +193,12 @@ async def test_subdomain_blocked_when_only_apex_listed() -> None:
 
 
 async def test_subdomain_allowed_when_listed_explicitly() -> None:
-    """Explicitly listing a subdomain in allow_domains pre-seeds its IPs correctly.
+    """Explicitly listing a subdomain in allow_domains also works.
 
-    Paired with test_subdomain_blocked_when_only_apex_listed: adding ftp.gnu.org
-    explicitly causes its IP (.20) to be pre-seeded alongside gnu.org's (.116),
-    so HTTP to ftp.gnu.org succeeds.
+    Paired with test_subdomain_reachable_when_apex_listed: that test shows
+    listing only the apex is sufficient (dnsmasq nftset= covers subdomains
+    automatically).  This test confirms that explicitly listing both the apex
+    and the subdomain is also fine — no conflict or duplicate-IP issues.
     """
     envs_dict: Dict[str, SandboxEnvironment] = {}
     config = _base_config(allow_domains=("gnu.org", "ftp.gnu.org"), third_octet=12)

--- a/tests/proxmoxsandboxtest/test_allow_domains_multi_vnet.py
+++ b/tests/proxmoxsandboxtest/test_allow_domains_multi_vnet.py
@@ -1,0 +1,234 @@
+"""Unit tests for multi-vnet allow_domains support.
+
+Tests the schema validation changes (accepting N vnets), the nftables config
+generator (sandbox_nets named set), and the dnsmasq config generator (multiple
+listen-address lines).  All pure/unit — no Proxmox connection needed.
+"""
+
+from ipaddress import ip_address, ip_network
+
+import pytest
+from pydantic import ValidationError
+
+from proxmoxsandbox._impl.infra_commands import (
+    _dnsmasq_allowlist_config,
+    _gateway_mac,
+    _nftables_config,
+)
+from proxmoxsandbox.schema import (
+    DhcpRange,
+    SdnConfig,
+    SubnetConfig,
+    VnetConfig,
+)
+
+
+def _make_vnet(third_octet: int) -> VnetConfig:
+    """Helper: build a VnetConfig with 10.77.<third_octet>.0/24, DHCP .50-.100."""
+    base = f"10.77.{third_octet}"
+    return VnetConfig(
+        alias=f"test-{third_octet}",
+        subnets=(
+            SubnetConfig(
+                cidr=ip_network(f"{base}.0/24"),
+                snat=True,
+                dhcp_ranges=(
+                    DhcpRange(
+                        start=ip_address(f"{base}.50"),
+                        end=ip_address(f"{base}.100"),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+# --- Schema validation ---
+
+
+class TestSdnConfigMultiVnet:
+    def test_single_vnet_accepted(self) -> None:
+        """Backward compat: single vnet + allow_domains still works."""
+        config = SdnConfig(
+            vnet_configs=(_make_vnet(10),),
+            allow_domains=("example.com",),
+        )
+        assert len(config.vnet_configs) == 1
+
+    def test_two_vnets_accepted(self) -> None:
+        config = SdnConfig(
+            vnet_configs=(_make_vnet(10), _make_vnet(11)),
+            allow_domains=("example.com",),
+        )
+        assert len(config.vnet_configs) == 2
+
+    def test_six_vnets_accepted(self) -> None:
+        """CAST needs 6+ vnets."""
+        vnets = tuple(_make_vnet(i) for i in range(10, 16))
+        config = SdnConfig(
+            vnet_configs=vnets,
+            allow_domains=("example.com",),
+        )
+        assert len(config.vnet_configs) == 6
+
+    def test_zero_vnets_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="at least one vnet_config"):
+            SdnConfig(
+                vnet_configs=(),
+                allow_domains=("example.com",),
+            )
+
+    def test_dhcp_range_conflict_caught_on_second_vnet(self) -> None:
+        """DHCP range conflict is caught for any vnet, not just the first."""
+        ok_vnet = _make_vnet(10)
+        # This vnet's DHCP range includes .2 (gateway IP)
+        bad_base = "10.77.11"
+        bad_vnet = VnetConfig(
+            alias="bad",
+            subnets=(
+                SubnetConfig(
+                    cidr=ip_network(f"{bad_base}.0/24"),
+                    snat=True,
+                    dhcp_ranges=(
+                        DhcpRange(
+                            start=ip_address(f"{bad_base}.1"),
+                            end=ip_address(f"{bad_base}.10"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        with pytest.raises(ValidationError, match="vnet 1"):
+            SdnConfig(
+                vnet_configs=(ok_vnet, bad_vnet),
+                allow_domains=("example.com",),
+            )
+
+    def test_gateway_mismatch_caught_on_any_vnet(self) -> None:
+        """Explicit wrong gateway is caught on any vnet."""
+        base = "10.77.12"
+        bad_vnet = VnetConfig(
+            alias="bad-gw",
+            subnets=(
+                SubnetConfig(
+                    cidr=ip_network(f"{base}.0/24"),
+                    gateway=ip_address(f"{base}.99"),
+                    snat=True,
+                    dhcp_ranges=(
+                        DhcpRange(
+                            start=ip_address(f"{base}.50"),
+                            end=ip_address(f"{base}.100"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        with pytest.raises(ValidationError, match="do not set the gateway"):
+            SdnConfig(
+                vnet_configs=(_make_vnet(10), bad_vnet),
+                allow_domains=("example.com",),
+            )
+
+    def test_bare_ip_rejected_in_allow_domains(self) -> None:
+        """IP addresses are not valid domain names."""
+        with pytest.raises(
+            ValidationError, match="looks like an IP"
+        ):
+            SdnConfig(
+                vnet_configs=(_make_vnet(10),),
+                allow_domains=("8.8.8.8",),
+            )
+
+    def test_no_allow_domains_skips_vnet_validation(self) -> None:
+        """Without allow_domains, multi-vnet is always fine (no gateway constraints)."""
+        config = SdnConfig(
+            vnet_configs=(_make_vnet(10), _make_vnet(11)),
+            allow_domains=(),
+        )
+        assert len(config.vnet_configs) == 2
+
+
+# --- _gateway_mac ---
+
+
+class TestGatewayMac:
+    def test_different_vnet_index_gives_different_mac(self) -> None:
+        mac0 = _gateway_mac("test123", 0)
+        mac1 = _gateway_mac("test123", 1)
+        assert mac0 != mac1
+
+    def test_default_vnet_index_matches_explicit_zero(self) -> None:
+        assert _gateway_mac("test123") == _gateway_mac("test123", 0)
+
+    def test_mac_format(self) -> None:
+        mac = _gateway_mac("test123", 0)
+        assert mac.startswith("52:54:00:")
+        assert len(mac) == 17
+
+
+# --- _nftables_config ---
+
+
+class TestNftablesConfig:
+    def test_single_cidr_produces_sandbox_nets_set(self) -> None:
+        config = _nftables_config(("10.77.10.0/24",))
+        assert "set sandbox_nets" in config
+        assert "elements = { 10.77.10.0/24 }" in config
+        assert "@sandbox_nets" in config
+        # No raw CIDR references in chain rules
+        assert "ip saddr 10.77.10.0/24" not in config
+
+    def test_two_cidrs_produces_both_elements(self) -> None:
+        config = _nftables_config(("10.77.10.0/24", "10.77.11.0/24"))
+        assert "10.77.10.0/24, 10.77.11.0/24" in config
+        assert "set sandbox_nets" in config
+
+    def test_allowed_ips_set_with_timeout(self) -> None:
+        config = _nftables_config(("10.77.10.0/24",))
+        assert "set allowed_ips" in config
+        assert "@allowed_ips" in config
+        assert "timeout 1h" in config
+
+    def test_input_chain_restricts_to_port_53(self) -> None:
+        config = _nftables_config(("10.77.10.0/24",))
+        assert "chain input" in config
+        assert "udp dport 53 accept" in config
+        assert "tcp dport 53 accept" in config
+        assert "policy drop" in config
+
+    def test_forward_chain_restricts_to_tcp_udp(self) -> None:
+        """Forward only allows TCP and UDP to allowed IPs."""
+        config = _nftables_config(("10.77.10.0/24",))
+        assert "tcp daddr @allowed_ips" in config
+        assert "udp daddr @allowed_ips" in config
+        # No protocol-agnostic accept rule for allowed_ips
+        assert "ip daddr @allowed_ips counter accept" not in config
+
+
+# --- _dnsmasq_allowlist_config ---
+
+
+class TestDnsmasqAllowlistConfig:
+    def test_single_ip(self) -> None:
+        config = _dnsmasq_allowlist_config(("10.77.10.2",), ("example.com",))
+        assert "listen-address=10.77.10.2" in config
+        assert "server=/example.com/8.8.8.8" in config
+
+    def test_nftset_lines_generated(self) -> None:
+        """Each domain gets an nftset= line for dynamic IP injection."""
+        config = _dnsmasq_allowlist_config(
+            ("10.77.10.2",), ("example.com", "foo.org")
+        )
+        assert "nftset=/example.com/4#inet#gateway#allowed_ips" in config
+        assert "nftset=/foo.org/4#inet#gateway#allowed_ips" in config
+
+    def test_two_ips_produces_two_listen_addresses(self) -> None:
+        config = _dnsmasq_allowlist_config(
+            ("10.77.10.2", "10.77.11.2"), ("example.com",)
+        )
+        assert "listen-address=10.77.10.2" in config
+        assert "listen-address=10.77.11.2" in config
+
+    def test_bind_interfaces_present(self) -> None:
+        config = _dnsmasq_allowlist_config(("10.77.10.2",), ("example.com",))
+        assert "bind-interfaces" in config

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
@@ -227,6 +227,101 @@ async def check_os(sandbox: SandboxEnvironment, expected_in_id: str):
     )
 
 
+async def test_allow_domains() -> None:
+    """Test that allow_domains gates sandbox egress to the listed domains.
+
+    Checks:
+    - curl to an allowed domain succeeds (DNS resolved, IP added to nftset, forwarded)
+    - curl to a blocked domain fails (dnsmasq returns SERVFAIL, no IP, no nftset entry)
+    - curl to a direct IP (no prior DNS resolution) also fails — bypassing DNS via raw
+      IPs is not possible because the IP was never added to the nftset
+
+    Edge case NOT covered by this test (needs access to Proxmox host IP):
+      A sandbox VM cannot reach the Proxmox host directly because the host's RFC1918 IP
+      is never in the nftset.  This prevents a VM→Proxmox→other-VM lateral escape path.
+      Manually verify: `curl http://<proxmox_host_ip>` from inside a sandbox should
+      fail with allow_domains set.
+    """
+    from ipaddress import ip_address, ip_network
+
+    envs_dict: Dict[str, SandboxEnvironment] = {}
+    sandbox_env_config = ProxmoxSandboxEnvironmentConfig(
+        sdn_config=SdnConfig(
+            vnet_configs=(
+                VnetConfig(
+                    alias="allow-test",
+                    subnets=(
+                        SubnetConfig(
+                            cidr=ip_network("10.88.0.0/24"),
+                            gateway=ip_address("10.88.0.1"),
+                            snat=True,
+                            dhcp_ranges=(
+                                DhcpRange(
+                                    start=ip_address("10.88.0.50"),
+                                    end=ip_address("10.88.0.100"),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            use_pve_ipam_dnsnmasq=True,
+            allow_domains=("cloudflare.com",),
+        ),
+        vms_config=(
+            VmConfig(
+                name="allow-test-vm",
+                vm_source_config=VmSourceConfig(built_in="ubuntu24.04"),
+                ram_mb=512,
+                vcpus=1,
+            ),
+        ),
+    )
+    task_name = "test_allow_domains"
+    try:
+        _, envs_dict = await setup_sandbox(task_name, sandbox_env_config)
+        sandbox = envs_dict["default"]
+
+        # Positive: allowed domain should resolve and be reachable.
+        # DNS query → gateway dnsmasq → 8.8.8.8 → IP added to nftset → forwarded.
+        curl_allowed = await sandbox.exec(
+            ["curl", "--fail", "--max-time", "15", "http://cloudflare.com"],
+            timeout=20,
+        )
+        assert curl_allowed.success, (
+            f"curl to cloudflare.com (allowed) should succeed: {curl_allowed=}"
+        )
+
+        # Negative: blocked domain should fail at DNS (SERVFAIL from gateway dnsmasq).
+        curl_blocked = await sandbox.exec(
+            ["curl", "--fail", "--max-time", "5", "http://google.com"],
+            timeout=10,
+        )
+        assert not curl_blocked.success, (
+            f"curl to google.com (not in allowlist) should fail: {curl_blocked=}"
+        )
+
+        # Negative: direct IP with no prior DNS resolution is also blocked.
+        # 8.8.8.8 is Google's DNS — an IP the sandbox might know, but since the
+        # sandbox never resolved it via the gateway's dnsmasq, it's not in the nftset.
+        curl_direct_ip = await sandbox.exec(
+            ["curl", "--fail", "--max-time", "5", "http://8.8.8.8"],
+            timeout=10,
+        )
+        assert not curl_direct_ip.success, (
+            f"curl to 8.8.8.8 (direct IP, not in nftset) should fail: {curl_direct_ip=}"
+        )
+
+    finally:
+        if envs_dict:
+            await ProxmoxSandboxEnvironment.sample_cleanup(
+                task_name=task_name,
+                config=sandbox_env_config,
+                environments=envs_dict,
+                interrupted=False,
+            )
+
+
 async def test_multiple_sandboxes_isolated(sandbox_env_config) -> None:
     sandboxes = {}
 

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
@@ -253,7 +253,7 @@ async def test_allow_domains() -> None:
                     subnets=(
                         SubnetConfig(
                             cidr=ip_network("10.88.0.0/24"),
-                            gateway=ip_address("10.88.0.1"),
+                            gateway=ip_address("10.88.0.2"),
                             snat=True,
                             dhcp_ranges=(
                                 DhcpRange(


### PR DESCRIPTION
## Summary

Adds an `allow_domains` option to `SdnConfig` that restricts sandbox VM internet egress to a specified domain allowlist. Enforcement is out-of-band (gateway VM outside the sandbox), so root inside the sandbox cannot bypass it.

**How it works:**
- A gateway VM (Debian 13, cloned per eval sample from a one-time-built template `inspect-gw`) sits between sandbox VMs and the internet
- dnsmasq on the gateway intercepts all DNS from the sandbox and only forwards queries for allowed domains (returning SERVFAIL for everything else)
- nftables on the gateway drops all forwarded traffic except to IPs in an `allowed_ips` set
- Allowed domain IPs are pre-resolved at provision time and added to the set

**Usage:**
```python
sdn_config=SdnConfig(
    vnet_configs=(...),
    use_pve_ipam_dnsnmasq=True,
    allow_domains=("pypi.org", "files.pythonhosted.org"),
)
```

**Costs:** gateway template built once (~5–10 min). Per-eval overhead ~30–60 s for clone boot.

## Key implementation details

- **ARP conflict fix:** Proxmox's `SubnetConfig.gateway` field couples the bridge device IP and DHCP option-3 in a single field — setting `gateway=.2` causes both the gateway VM and the Proxmox bridge to claim `.2`. Resolved by injecting `nud permanent` ARP entries on sandbox VMs after boot, which take unconditional precedence over dynamic ARP replies.
- **Static IP persistence:** gateway VM's sandbox-facing NIC is configured via a systemd-networkd `.network` file (not `ip addr add`), so the address survives DHCP renewals.
- **DNS interception:** nftables prerouting redirects all UDP/TCP port 53 from the sandbox CIDR to the gateway's dnsmasq, preventing DNS bypass via alternative resolvers.
- **Pre-resolve:** allowed domain IPs are resolved at provision time using `python3-dnspython` querying 8.8.8.8 directly (matching dnsmasq's upstream) and seeded into the nftables set.
- **Cleanup idempotency:** SDN zone deletion now tolerates zones that were already deleted out-of-band (e.g. via the Proxmox UI), so gateway VM clones are not left orphaned when cleanup is re-run.
- **IPv6 SLAAC blocked:** built-in VM cloud-init sets `accept-ra: false` (not just `dhcp6: false`); the gateway's `table inet` forward chain policy drop covers IPv6 forwarded through it.
- **DoT blocked:** nftables forward chain drops `ip dport 853` before the `@allowed_ips accept` rule, closing the DNS-over-TLS bypass path.

## Known limitations (documented in schema docstring)

- Filtering is IP-level, not URL-level — all ports to allowed-domain IPs are permitted
- Only apex domain IPs are pre-seeded; subdomains require explicit listing (e.g. `ftp.gnu.org` when only `gnu.org` is listed will be dropped). Note: domains sharing CDN anycast IPs (e.g. two domains both behind Fastly) will not exhibit this gap — allowing the apex inadvertently allows co-hosted subdomains. A future improvement is to enable dnsmasq `nftset=` support for dynamic IP seeding.
- IPv6 SLAAC protection via `accept-ra: false` applies only to built-in VM templates; custom VM sources (OVA, `existing_vm_template_tag`) must configure this independently.
- `allow_domains` currently requires exactly one `vnet_config` — multi-vnet support is deferred to a follow-up PR.

## Test plan

- [x] `test_allow_domains` e2e test: allowed domain (cloudflare.com) reachable, blocked domain (google.com) fails, direct IP (8.8.8.8) fails
- [x] `test_allow_domains_manual.py` — first 4 manual tests passing (requires Proxmox env):
  - `test_proxmox_host_ip_is_blocked`: `curl` to the Proxmox host's RFC1918 IP fails (never in nftables set)
  - `test_subdomain_blocked_when_only_apex_listed`: `ftp.gnu.org` (IP `.20`) is unreachable when only `gnu.org` (IP `.116`) is listed
  - `test_subdomain_allowed_when_listed_explicitly`: `ftp.gnu.org` is reachable when listed explicitly alongside `gnu.org`
  - `test_all_ports_open_to_allowed_ips`: TCP port 443 to cloudflare.com reachable; google.com (not listed) unreachable
- [ ] Two new manual tests added for IPv6/DoT — need verification against live Proxmox:
  - `test_ipv6_slaac_blocked`: no global-scope IPv6 address on sandbox VM (`accept-ra: false` effective); IPv6 curl to allowed domain fails
  - `test_dns_over_tls_port_853_blocked`: port 443 to cloudflare IP reachable (IP in set), port 853 to same IP blocked (drop rule fires first)
- [ ] If upgrading an existing deployment: delete the `inspect-gw` template VM and let it rebuild to pick up `python3-dnspython`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Original ticket: [EVA-179](https://linear.app/aisi/issue/EVA-179/support-partial-internet-allowlist-in-proxmox-provider)