### PR TITLE
Track PVE auth ticket lifetime

### DIFF
--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import time
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from logging import getLogger
@@ -35,8 +36,13 @@ class AsyncProxmoxAPI:
     password: str
     verify_tls: bool
     ticket: Optional[str] = None
+    ticket_date: Optional[float] = None
     csrf_token: Optional[str] = None
     discovered_proxmox_version: Optional[ProxmoxVersionInfo] = None
+
+    # PVE tickets expire after 2 hours; refresh proactively with 10 min buffer
+    TICKET_LIFETIME_SECONDS = 7200
+    TICKET_REFRESH_THRESHOLD = TICKET_LIFETIME_SECONDS - 600
 
     # note: host *includes* :port
     def __init__(self, host: str, user: str, password: str, verify_tls: bool = True):
@@ -60,6 +66,7 @@ class AsyncProxmoxAPI:
 
             data = response.json()["data"]
             self.ticket = data["ticket"]
+            self.ticket_date = time.monotonic()
             self.csrf_token = data["CSRFPreventionToken"]
             version_info = await self.request("GET", "/version")
             self.discovered_proxmox_version = ProxmoxVersionInfo(**version_info)
@@ -84,8 +91,8 @@ class AsyncProxmoxAPI:
             verify=self.verify_tls,
             timeout=httpx.Timeout(connect=5, read=60, write=60, pool=60),
         ) as client:
-            # Always get a fresh ticket if we don't have one
-            if not self.ticket:
+            # Get a fresh ticket if we don't have one or it's approaching expiry
+            if not self.ticket or self._ticket_near_expiry():
                 await self._login(client)
 
             if self.csrf_token is None:
@@ -145,6 +152,12 @@ class AsyncProxmoxAPI:
                 raise ValueError("CSRF token was not set; login first")
             headers["CSRFPreventionToken"] = self.csrf_token
         return headers
+
+    def _ticket_near_expiry(self) -> bool:
+        """Check if the current ticket is approaching its 2-hour expiry."""
+        if self.ticket_date is None:
+            return True
+        return (time.monotonic() - self.ticket_date) >= self.TICKET_REFRESH_THRESHOLD
 
     # this more naturally belongs in qemu_commands
     # but it's copied here because of read_file


### PR DESCRIPTION
 Long-running samples (2h+) can fail with a `401` (invalid PVE ticket) because the ticket expires mid-run. The `read_file` and `upload_file_with_curl` code paths use the ticket directly in headers rather than going through `request()`, so they rely on the ticket being fresh when they start.

Previously, `request()` only checked `if not self.ticket`; an expired ticket string passes that check. The `401` retry in `request()` should catch this, but under concurrent load the recovery path is seemingly unreliable (it's a really tight race, I am kind of surprised we got it to happen multiple times).

This PR stores a `ticket_date` on login and proactively refreshes the ticket when it's within 10 minutes of the 2-hour PVE expiry, so the error path is never needed during normal operation.