### PR TITLE
Allow Docker pull through cache to be specified

### DIFF
--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -150,12 +150,15 @@ touch /var/local/inspect-proxmox-on-first-boot.done
 poweroff
 EOFONFIRSTBOOT
 
-# Override DEBIAN_BASE_IMAGE to use a pull-through cache, e.g.:
+# Pre-pull base image from a pull-through cache if configured, e.g.:
 # DEBIAN_BASE_IMAGE=123456789.dkr.ecr.eu-west-2.amazonaws.com/docker-hub/library/debian:bookworm-slim
-DEBIAN_BASE_IMAGE=${DEBIAN_BASE_IMAGE:-debian:bookworm-slim}
+if [ -n "${DEBIAN_BASE_IMAGE:-}" ]; then
+    docker pull "$DEBIAN_BASE_IMAGE"
+    docker tag "$DEBIAN_BASE_IMAGE" debian:bookworm-slim
+fi
 
-echo "FROM $DEBIAN_BASE_IMAGE" > Dockerfile
-cat << 'EOFDOCKER' >> Dockerfile
+cat << 'EOFDOCKER' > Dockerfile
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y \
      gnupg \

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -154,8 +154,8 @@ EOFONFIRSTBOOT
 # DEBIAN_BASE_IMAGE=123456789.dkr.ecr.eu-west-2.amazonaws.com/docker-hub/library/debian:bookworm-slim
 DEBIAN_BASE_IMAGE=${DEBIAN_BASE_IMAGE:-debian:bookworm-slim}
 
-cat << EOFDOCKER > Dockerfile
-FROM $DEBIAN_BASE_IMAGE
+echo "FROM $DEBIAN_BASE_IMAGE" > Dockerfile
+cat << 'EOFDOCKER' >> Dockerfile
 
 RUN apt-get update && apt-get install -y \
      gnupg \
@@ -167,7 +167,7 @@ RUN mkdir -p /iso
 
 RUN wget -q -O /iso/proxmox.iso https://enterprise.proxmox.com/iso/proxmox-ve_9.0-1.iso
 
-# Confusingly, although Proxmox 9 is based on trixie (Debian 13), this Docker build 
+# Confusingly, although Proxmox 9 is based on trixie (Debian 13), this Docker build
 # must continue to use bookworm (Debian 12) because there are not yet any trixie proxmox packages.
 RUN echo "deb http://download.proxmox.com/debian/pve/ bookworm pve-no-subscription" > /etc/apt/sources.list.d/pve.list
 RUN wget -O- http://download.proxmox.com/debian/proxmox-release-bookworm.gpg | apt-key add -
@@ -185,7 +185,6 @@ VOLUME /output
 
 # Default command to copy the ISO to the output volume
 CMD ["cp", "/iso/proxmox-auto-from-iso.iso", "/output/"]
-
 EOFDOCKER
 
 docker build -t proxmox-auto-install .

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -150,8 +150,23 @@ touch /var/local/inspect-proxmox-on-first-boot.done
 poweroff
 EOFONFIRSTBOOT
 
-cat << 'EOFDOCKER' > Dockerfile
-FROM debian:bookworm-slim
+# Use ECR pull-through cache if available
+DEBIAN_BASE_IMAGE="debian:bookworm-slim"
+if command -v aws &>/dev/null && AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null); then
+    ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+    # Only use the cache if a docker-hub pull-through cache rule is actually configured
+    if aws ecr describe-pull-through-cache-rules --region "${AWS_DEFAULT_REGION}" \
+           --query "pullThroughCacheRules[?ecrRepositoryPrefix=='docker-hub'] | [0]" \
+           --output text 2>/dev/null | grep -q "docker-hub"; then
+        aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" \
+            | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+        DEBIAN_BASE_IMAGE="${ECR_REGISTRY}/docker-hub/library/debian:bookworm-slim"
+        echo "Using ECR pull-through cache: $DEBIAN_BASE_IMAGE"
+    fi
+fi
+
+cat << EOFDOCKER > Dockerfile
+FROM $DEBIAN_BASE_IMAGE
 
 RUN apt-get update && apt-get install -y \
      gnupg \

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -150,20 +150,9 @@ touch /var/local/inspect-proxmox-on-first-boot.done
 poweroff
 EOFONFIRSTBOOT
 
-# Use ECR pull-through cache if available
-DEBIAN_BASE_IMAGE="debian:bookworm-slim"
-if command -v aws &>/dev/null && AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null); then
-    ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-    # Only use the cache if a docker-hub pull-through cache rule is actually configured
-    if aws ecr describe-pull-through-cache-rules --region "${AWS_DEFAULT_REGION}" \
-           --query "pullThroughCacheRules[?ecrRepositoryPrefix=='docker-hub'] | [0]" \
-           --output text 2>/dev/null | grep -q "docker-hub"; then
-        aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" \
-            | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
-        DEBIAN_BASE_IMAGE="${ECR_REGISTRY}/docker-hub/library/debian:bookworm-slim"
-        echo "Using ECR pull-through cache: $DEBIAN_BASE_IMAGE"
-    fi
-fi
+# Override DEBIAN_BASE_IMAGE to use a pull-through cache, e.g.:
+# DEBIAN_BASE_IMAGE=123456789.dkr.ecr.eu-west-2.amazonaws.com/docker-hub/library/debian:bookworm-slim
+DEBIAN_BASE_IMAGE=${DEBIAN_BASE_IMAGE:-debian:bookworm-slim}
 
 cat << EOFDOCKER > Dockerfile
 FROM $DEBIAN_BASE_IMAGE


### PR DESCRIPTION
So you can still build your proxmox image even if DockerHub is having a lie down