### PR TITLE
Update Kali built-in VM from 2025.3 to 2025.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ sandbox=SandboxEnvironmentSpec(
             VmConfig(
                 # A virtual machine that this provider will install and configure automatically.
                 vm_source_config=VmSourceConfig(
-                    built_in="ubuntu24.04" # currently supported: "ubuntu24.04, "debian13", "kali2025.3"; see schema.py
+                    built_in="ubuntu24.04" # currently supported: "ubuntu24.04", "debian13", "kali2025.4"; see schema.py
                 ),
                 name="romeo", # name is optional, but recommended - it will be shown in the Proxmox GUI and registered as the Inspect sandbox environment identifier. Must be a valid DNS name.
                 ram_mb=512, # optional, default is 2048 MB
@@ -321,6 +321,10 @@ The project follows [semantic versioning](https://semver.org/) and is aiming for
 - Firewall off the SDN from the Proxmox server and from other SDNs
 - Support cloud-init for VM definition
 - Escape hatch for Proxmox API so you can specify arbitrary parameters during VM / SDN creation 
+
+## Built-in VM image versions
+
+The built-in VMs (`ubuntu24.04`, `debian13`, `kali2025.4`) pin specific upstream image URLs in `built_in_vm.py`. These are not auto-updated — when a new upstream release appears (e.g. a new Kali quarterly release), the URL, the `Literal` type in `schema.py`, and all references in tests and examples must be updated together.
 
 ## Tech debt
 

--- a/src/proxmoxsandbox/_impl/built_in_vm.py
+++ b/src/proxmoxsandbox/_impl/built_in_vm.py
@@ -39,8 +39,8 @@ UBUNTU_URL = (
 )
 UBUNTU_VMDK_FILENAME = "ubuntu-noble-24.04-cloudimg.vmdk"
 DEBIAN_13_URL = "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2"
-KALI_DOWNLOAD_URL = "https://kali.download/cloud-images/kali-2025.3/kali-linux-2025.3-cloud-genericcloud-amd64.tar.xz"
-KALI_DISK_RENAMED = "kali-2025.3-genericcloud-amd64.raw"
+KALI_DOWNLOAD_URL = "https://kali.download/cloud-images/kali-2025.4/kali-linux-2025.4-cloud-genericcloud-amd64.tar.xz"
+KALI_DISK_RENAMED = "kali-2025.4-genericcloud-amd64.raw"
 
 STATIC_VNET_ID = f"{STATIC_SDN_START}v0"
 
@@ -338,7 +338,7 @@ runcmd:
                 built_in=built_in_name,
                 source_image_source_url=DEBIAN_13_URL,
             )
-        elif built_in_name == "kali2025.3":
+        elif built_in_name == "kali2025.4":
             await self.ensure_version(9)
             await self.ensure_exists_from_xz(
                 next_available_vm_id=next_available_vm_id,

--- a/src/proxmoxsandbox/experimental/ctf4.py
+++ b/src/proxmoxsandbox/experimental/ctf4.py
@@ -126,7 +126,7 @@ For example if the password was 'trustno1', submit 5fcfd41e547a12215b173ff47fdd3
                 vms_config=(
                     VmConfig(
                         vm_source_config=VmSourceConfig(
-                            built_in="kali2025.3",
+                            built_in="kali2025.4",
                         ),
                         name="agent",
                         nics=(VmNicConfig(vnet_alias="ctf4_net"),),

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -97,7 +97,7 @@ class VmSourceConfig(BaseModel, frozen=True):
     # source.
     # From Proxmox 9.0 onwards, qcow2 and raw are also supported, allowing Debian 13,
     # Kali, and others.
-    built_in: Literal["ubuntu24.04", "debian13", "kali2025.3"] | None = None
+    built_in: Literal["ubuntu24.04", "debian13", "kali2025.4"] | None = None
 
     @model_validator(mode="after")
     def _validate_single_source(self) -> "VmSourceConfig":

--- a/tests/proxmoxsandboxtest/test_built_in_vm.py
+++ b/tests/proxmoxsandboxtest/test_built_in_vm.py
@@ -11,7 +11,7 @@ async def test_debian(qemu_commands: QemuCommands, built_in_vm: BuiltInVM) -> No
 
 
 async def test_kali(qemu_commands: QemuCommands, built_in_vm: BuiltInVM) -> None:
-    await _do_test_builtin(qemu_commands, built_in_vm, "kali2025.3")
+    await _do_test_builtin(qemu_commands, built_in_vm, "kali2025.4")
 
 
 async def _do_test_builtin(

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
@@ -148,7 +148,7 @@ async def test_built_in() -> None:
             ),
             VmConfig(
                 name="kali",
-                vm_source_config=VmSourceConfig(built_in="kali2025.3"),
+                vm_source_config=VmSourceConfig(built_in="kali2025.4"),
                 nics=(
                     VmNicConfig(vnet_alias="vnet80"),
                     VmNicConfig(vnet_alias="vnet81"),


### PR DESCRIPTION
## Summary
- Kali 2025.3 cloud image is no longer available for download, causing `test_kali` to fail with `FileNotFoundError`
- Bumps to 2025.4 (latest quarterly release, verified available at https://kali.download/cloud-images/kali-2025.4/)
- Adds a README section documenting the built-in VM image version pinning process

## Test plan
- [x] `test_kali` passes (was failing with `FileNotFoundError` on 2025.3)
- [x] `test_multiple_sandboxes_isolated` passes (uses Kali VM)
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)