### PR TITLE
Rationalize task cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,14 +81,18 @@ this is deliberate, to keep things simple and to avoid premature indirection.
 
 The design of this provider is constrained by what is offered by the 
 [Proxmox REST API](https://pve.proxmox.com/wiki/Proxmox_VE_API). 
-For example, OVA is the only supported upload format. It would be useful to be able to upload qcow2 disk images,
-but this isn't supported.
+
+For example, there is no way to upload arbitrary large files directly to the server, other
+than qcow2 and OVA files.
 
 ### Cleanup
 
-There are two paths for cleaning up resources. The normal, "happy", path, is via `ProxmoxSandboxEnvironment`'s  `all_vm_ids` and `sdn_zone_id`
-fields. These are populated during sample setup.
+There are two paths for cleaning up resources. The normal, "happy", path is via `sample_cleanup()`, which uses
+`ProxmoxSandboxEnvironment`'s `all_vm_ids`, `sdn_zone_id`, and `all_ipam_mappings` fields. These are populated
+during sample setup and passed explicitly to `InfraCommands.delete_sdn_and_vms()`.
 
-However, the user can press Ctrl-C, per the [Inspect docs](https://inspect.aisi.org.uk/sandboxing.html#environment-cleanup): so the 
-`QemuCommands` and `SdnCommands` use context variables to keep track of created resources, and tear down in a separate way via
-`InfraCommands.cleanup()`.
+However, the user can press Ctrl-C, per the [Inspect docs](https://inspect.aisi.org.uk/sandboxing.html#environment-cleanup).
+In this case `sample_cleanup` is skipped and `task_cleanup()` handles teardown instead. `InfraCommands` tracks all
+created resources (VMs, SDN zones, IPAM mappings) as instance attributes. A single shared `InfraCommands` instance is
+created in `task_init()` and stored in a class-level dict keyed by `ProxmoxTarget(host, port, node)`, so that
+`task_cleanup()` can retrieve it and destroy any resources not already cleaned up by `sample_cleanup`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,8 @@ There are two paths for cleaning up resources. The normal, "happy", path is via 
 during sample setup and passed explicitly to `InfraCommands.delete_sdn_and_vms()`.
 
 However, the user can press Ctrl-C, per the [Inspect docs](https://inspect.aisi.org.uk/sandboxing.html#environment-cleanup).
-In this case `sample_cleanup` is skipped and `task_cleanup()` handles teardown instead. `InfraCommands` tracks all
-created resources (VMs, SDN zones, IPAM mappings) as instance attributes. A single shared `InfraCommands` instance is
-created in `task_init()` and stored in a class-level dict keyed by `ProxmoxTarget(host, port, node)`, so that
-`task_cleanup()` can retrieve it and destroy any resources not already cleaned up by `sample_cleanup`.
+In this case `sample_cleanup` is skipped and `task_cleanup()` handles teardown instead. `QemuCommands` tracks
+created VM IDs and `SdnCommands` tracks created SDN zones and IPAM mappings, each as instance attributes. A single
+shared `InfraCommands` instance (which owns these collaborators) is created in `task_init()` and stored in a
+class-level dict keyed by `ProxmoxTarget(host, port, node)`, so that `task_cleanup()` can retrieve it and delegate
+cleanup to each collaborator for any resources not already cleaned up by `sample_cleanup`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,10 @@ The design of this provider is constrained by what is offered by the
 For example, there is no way to upload arbitrary large files directly to the server, other
 than qcow2 and OVA files.
 
+For VM and SDN zone deletions, the Proxmox API has been observed to return HTTP 500 (not 404)
+when the resource does not exist. The cleanup code checks for 500 + "does not exist" in the
+response body to distinguish this from genuine errors.
+
 ### Cleanup
 
 There are two paths for cleaning up resources. The normal, "happy", path is via `sample_cleanup()`, which uses

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -4,7 +4,7 @@ import re
 import sys
 from logging import getLogger
 from random import randint
-from typing import Collection, List, Sequence, Set, Tuple
+from typing import ClassVar, Collection, Dict, List, NamedTuple, Sequence, Set, Tuple
 
 from inspect_ai.util import trace_action
 from rich import box, print
@@ -28,10 +28,26 @@ from proxmoxsandbox.schema import (
 )
 
 
+class ProxmoxTarget(NamedTuple):
+    """Identifies a specific Proxmox host+node combination."""
+
+    host: str
+    port: int
+    node: str
+
+
 class InfraCommands(abc.ABC):
+    """Orchestrates Proxmox infrastructure commands.
+
+    Tracks created resources (VMs, SDN zones, IPAM mappings) so that
+    ``task_cleanup`` can destroy anything left behind after an interrupted eval.
+    """
+
     logger = getLogger(__name__)
 
     TRACE_NAME = "proxmox_infra_command"
+
+    _instances: ClassVar[Dict[ProxmoxTarget, "InfraCommands"]] = {}
 
     async_proxmox: AsyncProxmoxAPI
     task_wrapper: TaskWrapper
@@ -56,6 +72,57 @@ class InfraCommands(abc.ABC):
         self.qemu_commands = qemu_commands
         self.built_in_vm = built_in_vm
         self.node = node
+        self._tracked_vm_ids: Set[int] = set()
+        self._tracked_sdn_zone_ids: Set[str] = set()
+        self._tracked_ipam_mappings: List[IpamMapping] = []
+
+    @classmethod
+    def get_instance(cls, target: ProxmoxTarget) -> "InfraCommands":
+        """Retrieve the InfraCommands instance for a Proxmox target.
+
+        Raises:
+            LookupError: If no instance has been stored for *target*
+                (i.e. ``task_init`` was not called).
+        """
+        if target not in cls._instances:
+            raise LookupError(
+                f"No InfraCommands instance for {target}. Was task_init called?"
+            )
+        return cls._instances[target]
+
+    @classmethod
+    def set_instance(cls, target: ProxmoxTarget, instance: "InfraCommands") -> None:
+        """Store an InfraCommands instance for a Proxmox target."""
+        cls._instances[target] = instance
+
+    def register_vm(self, vm_id: int) -> None:
+        """Track a created VM for cleanup on early termination."""
+        self._tracked_vm_ids.add(vm_id)
+
+    def register_sdn_zone(self, zone_id: str) -> None:
+        """Track a created SDN zone for cleanup on early termination."""
+        self._tracked_sdn_zone_ids.add(zone_id)
+
+    def register_ipam_mapping(self, mapping: IpamMapping) -> None:
+        """Track a created IPAM mapping for cleanup on early termination."""
+        self._tracked_ipam_mappings.append(mapping)
+
+    def deregister_resources(
+        self,
+        vm_ids: Tuple[int, ...],
+        sdn_zone_id: str | None,
+        ipam_mappings: Sequence[IpamMapping],
+    ) -> None:
+        """Remove successfully cleaned-up resources from tracking."""
+        for vm_id in vm_ids:
+            self._tracked_vm_ids.discard(vm_id)
+        if sdn_zone_id:
+            self._tracked_sdn_zone_ids.discard(sdn_zone_id)
+        for m in ipam_mappings:
+            try:
+                self._tracked_ipam_mappings.remove(m)
+            except ValueError:
+                pass
 
     @classmethod
     def build(
@@ -91,6 +158,8 @@ class InfraCommands(abc.ABC):
         sdn_zone_id, vnet_aliases = await self.sdn_commands.create_sdn(
             proxmox_ids_start, sdn_config
         )
+        if sdn_zone_id:
+            self.register_sdn_zone(sdn_zone_id)
 
         known_builtins = await self.built_in_vm.known_builtins()
 
@@ -110,6 +179,7 @@ class InfraCommands(abc.ABC):
                     vm_config=vm_config,
                     built_in_vm_ids=known_builtins,
                 )
+                self.register_vm(vm_id)
                 vm_configs_with_ids.append((vm_id, vm_config))
 
         # TODO check for failed starts in the log somehow
@@ -174,6 +244,7 @@ class InfraCommands(abc.ABC):
                 vnet_id=vnet_id, zone_id=sdn_zone_id, mac=nic.mac, ipv4=nic.ipv4
             )
             await self.sdn_commands.create_ipam_mapping(ipam_mapping)
+            self.register_ipam_mapping(ipam_mapping)
             ipam_mappings.append(ipam_mapping)
         return ipam_mappings
 
@@ -199,9 +270,21 @@ class InfraCommands(abc.ABC):
         )
 
     async def task_cleanup(self) -> None:
-        self.logger.debug("infra_commands cleanup activated")
-        await self.qemu_commands.task_cleanup()
-        await self.sdn_commands.task_cleanup()
+        """Destroy any tracked resources not already cleaned up by sample_cleanup."""
+        self.logger.debug(
+            f"infra_commands task_cleanup; "
+            f"vms={self._tracked_vm_ids}, sdns={self._tracked_sdn_zone_ids}"
+        )
+        for vm_id in list(self._tracked_vm_ids):
+            self.logger.debug(f"task_cleanup: destroy_vm {vm_id=}")
+            await self.qemu_commands.destroy_vm(vm_id)
+        if self._tracked_sdn_zone_ids:
+            await self.sdn_commands.tear_down_sdn_zones_and_vnets(
+                self._tracked_sdn_zone_ids, self._tracked_ipam_mappings
+            )
+        self._tracked_vm_ids.clear()
+        self._tracked_sdn_zone_ids.clear()
+        self._tracked_ipam_mappings.clear()
 
     async def cleanup_no_id(self) -> None:
         noticed_vnets = set()

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -39,8 +39,9 @@ class ProxmoxTarget(NamedTuple):
 class InfraCommands(abc.ABC):
     """Orchestrates Proxmox infrastructure commands.
 
-    Tracks created resources (VMs, SDN zones, IPAM mappings) so that
-    ``task_cleanup`` can destroy anything left behind after an interrupted eval.
+    Collaborators (``QemuCommands``, ``SdnCommands``) track their own created
+    resources so that ``task_cleanup`` can destroy anything left behind after
+    an interrupted eval.
     """
 
     logger = getLogger(__name__)
@@ -72,9 +73,6 @@ class InfraCommands(abc.ABC):
         self.qemu_commands = qemu_commands
         self.built_in_vm = built_in_vm
         self.node = node
-        self._tracked_vm_ids: Set[int] = set()
-        self._tracked_sdn_zone_ids: Set[str] = set()
-        self._tracked_ipam_mappings: List[IpamMapping] = []
 
     @classmethod
     def get_instance(cls, target: ProxmoxTarget) -> "InfraCommands":
@@ -95,18 +93,6 @@ class InfraCommands(abc.ABC):
         """Store an InfraCommands instance for a Proxmox target."""
         cls._instances[target] = instance
 
-    def register_vm(self, vm_id: int) -> None:
-        """Track a created VM for cleanup on early termination."""
-        self._tracked_vm_ids.add(vm_id)
-
-    def register_sdn_zone(self, zone_id: str) -> None:
-        """Track a created SDN zone for cleanup on early termination."""
-        self._tracked_sdn_zone_ids.add(zone_id)
-
-    def register_ipam_mapping(self, mapping: IpamMapping) -> None:
-        """Track a created IPAM mapping for cleanup on early termination."""
-        self._tracked_ipam_mappings.append(mapping)
-
     def deregister_resources(
         self,
         vm_ids: Tuple[int, ...],
@@ -114,15 +100,8 @@ class InfraCommands(abc.ABC):
         ipam_mappings: Sequence[IpamMapping],
     ) -> None:
         """Remove successfully cleaned-up resources from tracking."""
-        for vm_id in vm_ids:
-            self._tracked_vm_ids.discard(vm_id)
-        if sdn_zone_id:
-            self._tracked_sdn_zone_ids.discard(sdn_zone_id)
-        for m in ipam_mappings:
-            try:
-                self._tracked_ipam_mappings.remove(m)
-            except ValueError:
-                pass
+        self.qemu_commands.deregister_vms(vm_ids)
+        self.sdn_commands.deregister_sdn_resources(sdn_zone_id, ipam_mappings)
 
     @classmethod
     def build(
@@ -159,7 +138,7 @@ class InfraCommands(abc.ABC):
             proxmox_ids_start, sdn_config
         )
         if sdn_zone_id:
-            self.register_sdn_zone(sdn_zone_id)
+            self.sdn_commands.register_sdn_zone(sdn_zone_id)
 
         known_builtins = await self.built_in_vm.known_builtins()
 
@@ -179,7 +158,7 @@ class InfraCommands(abc.ABC):
                     vm_config=vm_config,
                     built_in_vm_ids=known_builtins,
                 )
-                self.register_vm(vm_id)
+                self.qemu_commands.register_vm(vm_id)
                 vm_configs_with_ids.append((vm_id, vm_config))
 
         # TODO check for failed starts in the log somehow
@@ -244,7 +223,7 @@ class InfraCommands(abc.ABC):
                 vnet_id=vnet_id, zone_id=sdn_zone_id, mac=nic.mac, ipv4=nic.ipv4
             )
             await self.sdn_commands.create_ipam_mapping(ipam_mapping)
-            self.register_ipam_mapping(ipam_mapping)
+            self.sdn_commands.register_ipam_mapping(ipam_mapping)
             ipam_mappings.append(ipam_mapping)
         return ipam_mappings
 
@@ -271,20 +250,9 @@ class InfraCommands(abc.ABC):
 
     async def task_cleanup(self) -> None:
         """Destroy any tracked resources not already cleaned up by sample_cleanup."""
-        self.logger.debug(
-            f"infra_commands task_cleanup; "
-            f"vms={self._tracked_vm_ids}, sdns={self._tracked_sdn_zone_ids}"
-        )
-        for vm_id in list(self._tracked_vm_ids):
-            self.logger.debug(f"task_cleanup: destroy_vm {vm_id=}")
-            await self.qemu_commands.destroy_vm(vm_id)
-        if self._tracked_sdn_zone_ids:
-            await self.sdn_commands.tear_down_sdn_zones_and_vnets(
-                self._tracked_sdn_zone_ids, self._tracked_ipam_mappings
-            )
-        self._tracked_vm_ids.clear()
-        self._tracked_sdn_zone_ids.clear()
-        self._tracked_ipam_mappings.clear()
+        self.logger.debug("infra_commands task_cleanup activated")
+        await self.qemu_commands.task_cleanup()
+        await self.sdn_commands.task_cleanup()
 
     async def cleanup_no_id(self) -> None:
         noticed_vnets = set()

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import Collection, Dict, List, Set
 
+import httpx
 import tenacity
 from inspect_ai.util import trace_action
 from pydantic.networks import HttpUrl
@@ -57,8 +58,23 @@ class QemuCommands(abc.ABC):
         self.logger.debug(f"qemu_commands task_cleanup; vms={self._tracked_vm_ids}")
         for vm_id in list(self._tracked_vm_ids):
             self.logger.debug(f"task_cleanup: destroy_vm {vm_id=}")
-            await self.destroy_vm(vm_id)
-        self._tracked_vm_ids.clear()
+            try:
+                await self.destroy_vm(vm_id)
+                self._tracked_vm_ids.discard(vm_id)
+            except httpx.HTTPStatusError as e:
+                # Proxmox returns 500 (not 404) when a VM config file is missing
+                already_gone = (
+                    e.response.status_code == 500
+                    and "does not exist" in e.response.text
+                )
+                if already_gone:
+                    self._tracked_vm_ids.discard(vm_id)
+                else:
+                    self.logger.warning(
+                        f"task_cleanup: failed to destroy VM {vm_id}: {e}"
+                    )
+            except Exception as e:
+                self.logger.warning(f"task_cleanup: failed to destroy VM {vm_id}: {e}")
 
     async def await_vm(
         self,

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -29,6 +29,7 @@ class QemuCommands(abc.ABC):
     image_storage: str
     storage_commands: LocalStorageCommands
     node: str
+    _tracked_vm_ids: Set[int]
 
     def __init__(
         self,

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -1,10 +1,9 @@
 import abc
 import re
 import tarfile
-from contextvars import ContextVar
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Dict, List
 
 import tenacity
 from inspect_ai.util import trace_action
@@ -30,13 +29,6 @@ class QemuCommands(abc.ABC):
     image_storage: str
     storage_commands: LocalStorageCommands
     node: str
-
-    _running_proxmox_vms: ContextVar[Set[int]] = ContextVar(
-        "proxmox_running_vms", default=set()
-    )
-    _cleanup_completed: ContextVar[bool] = ContextVar(
-        "proxmox_vms_cleanup_executed", default=False
-    )
 
     def __init__(
         self,
@@ -311,7 +303,7 @@ class QemuCommands(abc.ABC):
                     sdn_vnet_aliases,
                     vm_config.is_sandbox,
                 )
-                await self.register_created_vm(new_vm_id)
+
 
             else:
                 raise NotImplementedError(
@@ -483,7 +475,6 @@ class QemuCommands(abc.ABC):
                 f"/nodes/{self.node}/qemu/{vm_id_to_clone}/clone",
                 json={"newid": new_vm_id, "full": 0, "name": vm_config.name},
             )
-            await self.register_created_vm(new_vm_id)
 
         await self.task_wrapper.do_action_and_wait_for_tasks(create_clone)
 
@@ -533,21 +524,3 @@ class QemuCommands(abc.ABC):
 
     async def connection_url(self, vm_id: int) -> str:
         return f"{self.async_proxmox.base_url}/?console=kvm&novnc=1&vmid={vm_id}&node={self.node}"  # noqa: E501
-
-    async def register_created_vm(self, vm_id: int | None) -> None:
-        if vm_id is not None:
-            self._running_proxmox_vms.get().add(vm_id)
-
-    async def task_cleanup(self) -> None:
-        cleanup_completed = self._cleanup_completed.get()
-        self.logger.debug(f"qemu_commands cleanup activated; {cleanup_completed=}")
-        if cleanup_completed:
-            return
-
-        with trace_action(self.logger, self.TRACE_NAME, "cleanup all VMs"):
-            running_proxmox_vms = self._running_proxmox_vms.get()
-            self.logger.debug(f"existing vm count: {len(running_proxmox_vms)}")
-            for vm_id in running_proxmox_vms:
-                self.logger.debug(f"destroy_vm {vm_id=}")
-                await self.destroy_vm(vm_id)
-            self._cleanup_completed.set(True)

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -3,7 +3,7 @@ import re
 import tarfile
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List
+from typing import Collection, Dict, List, Set
 
 import tenacity
 from inspect_ai.util import trace_action
@@ -43,6 +43,21 @@ class QemuCommands(abc.ABC):
         self.storage_commands = storage_commands
         self.node = node
         self.image_storage = image_storage
+        self._tracked_vm_ids: Set[int] = set()
+
+    def register_vm(self, vm_id: int) -> None:
+        self._tracked_vm_ids.add(vm_id)
+
+    def deregister_vms(self, vm_ids: Collection[int]) -> None:
+        for vm_id in vm_ids:
+            self._tracked_vm_ids.discard(vm_id)
+
+    async def task_cleanup(self) -> None:
+        self.logger.debug(f"qemu_commands task_cleanup; vms={self._tracked_vm_ids}")
+        for vm_id in list(self._tracked_vm_ids):
+            self.logger.debug(f"task_cleanup: destroy_vm {vm_id=}")
+            await self.destroy_vm(vm_id)
+        self._tracked_vm_ids.clear()
 
     async def await_vm(
         self,
@@ -303,7 +318,6 @@ class QemuCommands(abc.ABC):
                     sdn_vnet_aliases,
                     vm_config.is_sandbox,
                 )
-
 
             else:
                 raise NotImplementedError(

--- a/src/proxmoxsandbox/_impl/sdn_commands.py
+++ b/src/proxmoxsandbox/_impl/sdn_commands.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from random import shuffle
 from typing import Collection, List, Optional, Sequence, Tuple, TypeAlias
 
+import httpx
 from inspect_ai.util import trace_action
 from pydantic import BaseModel
 from pydantic.networks import IPvAnyAddress
@@ -111,12 +112,12 @@ class SdnCommands(abc.ABC):
             f"sdns={self._tracked_sdn_zone_ids}, "
             f"ipam_mappings={len(self._tracked_ipam_mappings)}"
         )
-        if self._tracked_sdn_zone_ids:
+        for zone_id in list(self._tracked_sdn_zone_ids):
             await self.tear_down_sdn_zones_and_vnets(
-                self._tracked_sdn_zone_ids, self._tracked_ipam_mappings
+                {zone_id}, self._tracked_ipam_mappings
             )
-        self._tracked_sdn_zone_ids.clear()
-        self._tracked_ipam_mappings.clear()
+            self._tracked_sdn_zone_ids.discard(zone_id)
+            self._tracked_ipam_mappings.clear()
 
     def find_existing_cidr_overlaps(
         self, list1: List[str], list2: List[str]
@@ -402,27 +403,43 @@ class SdnCommands(abc.ABC):
             await self.tear_down_sdn_ip_allocations(ipam_mappings)
 
             for sdn_zone_id in sdn_zone_ids:
-                all_vnets = await self.read_all_vnets()
-                relevant_vnets = list(
-                    vnet for vnet in all_vnets if vnet["zone"] == sdn_zone_id
-                )
-                for vnet_details in relevant_vnets:
-                    vnet = vnet_details["vnet"]
-                    subnets = await self.async_proxmox.request(
-                        "GET", f"/cluster/sdn/vnets/{vnet}/subnets"
+                try:
+                    all_vnets = await self.read_all_vnets()
+                    relevant_vnets = list(
+                        vnet for vnet in all_vnets if vnet["zone"] == sdn_zone_id
                     )
-                    for subnet_details in subnets:
-                        subnet_id = subnet_details["id"]
+                    for vnet_details in relevant_vnets:
+                        vnet = vnet_details["vnet"]
+                        subnets = await self.async_proxmox.request(
+                            "GET", f"/cluster/sdn/vnets/{vnet}/subnets"
+                        )
+                        for subnet_details in subnets:
+                            subnet_id = subnet_details["id"]
+                            await self.async_proxmox.request(
+                                "DELETE",
+                                f"/cluster/sdn/vnets/{vnet}/subnets/{subnet_id}",
+                            )
                         await self.async_proxmox.request(
-                            "DELETE",
-                            f"/cluster/sdn/vnets/{vnet}/subnets/{subnet_id}",
+                            "DELETE", f"/cluster/sdn/vnets/{vnet}"
                         )
                     await self.async_proxmox.request(
-                        "DELETE", f"/cluster/sdn/vnets/{vnet}"
+                        "DELETE", f"/cluster/sdn/zones/{sdn_zone_id}"
                     )
-                await self.async_proxmox.request(
-                    "DELETE", f"/cluster/sdn/zones/{sdn_zone_id}"
-                )
+                except httpx.HTTPStatusError as e:
+                    # Proxmox has been observed to return 500 (not 404) when a
+                    # zone or vnet does not exist; treat that as already gone
+                    already_gone = (
+                        e.response.status_code == 500
+                        and "does not exist" in e.response.text
+                    )
+                    if not already_gone:
+                        self.logger.warning(
+                            f"failed to tear down SDN zone {sdn_zone_id}: {e}"
+                        )
+                except Exception as e:
+                    self.logger.warning(
+                        f"failed to tear down SDN zone {sdn_zone_id}: {e}"
+                    )
 
         await self.do_update_all_sdn()
 

--- a/src/proxmoxsandbox/_impl/sdn_commands.py
+++ b/src/proxmoxsandbox/_impl/sdn_commands.py
@@ -1,10 +1,9 @@
 import abc
 import re
-from contextvars import ContextVar
 from ipaddress import ip_address, ip_network
 from logging import getLogger
 from random import shuffle
-from typing import Collection, List, Optional, Sequence, Set, Tuple, TypeAlias
+from typing import Collection, List, Optional, Sequence, Tuple, TypeAlias
 
 from inspect_ai.util import trace_action
 from pydantic import BaseModel
@@ -78,16 +77,6 @@ class SdnCommands(abc.ABC):
 
     async_proxmox: AsyncProxmoxAPI
     task_wrapper: TaskWrapper
-
-    _created_sdns: ContextVar[Set[str]] = ContextVar(
-        "proxmox_created_sdns", default=set()
-    )
-    _created_ipam_mappings: ContextVar[List[IpamMapping]] = ContextVar(
-        "proxmox_created_ipam_mappings", default=list()
-    )
-    _cleanup_completed: ContextVar[bool] = ContextVar(
-        "proxmox_sdns_cleanup_executed", default=False
-    )
 
     def __init__(self, async_proxmox: AsyncProxmoxAPI, task_wrapper: TaskWrapper):
         self.async_proxmox = async_proxmox
@@ -300,8 +289,6 @@ class SdnCommands(abc.ABC):
 
         await self.do_update_all_sdn()
 
-        self._created_sdns.get().add(sdn_zone_id)
-
         return sdn_zone_id, existing_vnet_aliases
 
     async def do_update_all_sdn(self) -> None:
@@ -436,21 +423,4 @@ class SdnCommands(abc.ABC):
                 f"/cluster/sdn/vnets/{ipam_mapping.vnet_id}/ips",
                 json=ipam_mapping.to_proxmox_format(),
             )
-            # We save the ip allocations so that we can delete them later
-            self._created_ipam_mappings.get().append(ipam_mapping)
 
-    async def task_cleanup(self) -> None:
-        cleanup_completed = self._cleanup_completed.get()
-
-        self.logger.debug(
-            f"sdn cleanup; {cleanup_completed=}; {self._created_sdns.get()=}"
-        )
-
-        if cleanup_completed:
-            return
-
-        with trace_action(self.logger, self.TRACE_NAME, "cleanup all SDNs"):
-            await self.tear_down_sdn_zones_and_vnets(
-                self._created_sdns.get(), self._created_ipam_mappings.get()
-            )
-            self._cleanup_completed.set(True)

--- a/src/proxmoxsandbox/_impl/sdn_commands.py
+++ b/src/proxmoxsandbox/_impl/sdn_commands.py
@@ -77,6 +77,8 @@ class SdnCommands(abc.ABC):
 
     async_proxmox: AsyncProxmoxAPI
     task_wrapper: TaskWrapper
+    _tracked_sdn_zone_ids: set[str]
+    _tracked_ipam_mappings: List[IpamMapping]
 
     def __init__(self, async_proxmox: AsyncProxmoxAPI, task_wrapper: TaskWrapper):
         self.async_proxmox = async_proxmox

--- a/src/proxmoxsandbox/_impl/sdn_commands.py
+++ b/src/proxmoxsandbox/_impl/sdn_commands.py
@@ -81,6 +81,40 @@ class SdnCommands(abc.ABC):
     def __init__(self, async_proxmox: AsyncProxmoxAPI, task_wrapper: TaskWrapper):
         self.async_proxmox = async_proxmox
         self.task_wrapper = task_wrapper
+        self._tracked_sdn_zone_ids: set[str] = set()
+        self._tracked_ipam_mappings: List[IpamMapping] = []
+
+    def register_sdn_zone(self, zone_id: str) -> None:
+        self._tracked_sdn_zone_ids.add(zone_id)
+
+    def register_ipam_mapping(self, mapping: IpamMapping) -> None:
+        self._tracked_ipam_mappings.append(mapping)
+
+    def deregister_sdn_resources(
+        self,
+        sdn_zone_id: str | None,
+        ipam_mappings: Sequence[IpamMapping],
+    ) -> None:
+        if sdn_zone_id:
+            self._tracked_sdn_zone_ids.discard(sdn_zone_id)
+        for m in ipam_mappings:
+            try:
+                self._tracked_ipam_mappings.remove(m)
+            except ValueError:
+                pass
+
+    async def task_cleanup(self) -> None:
+        self.logger.debug(
+            f"sdn_commands task_cleanup; "
+            f"sdns={self._tracked_sdn_zone_ids}, "
+            f"ipam_mappings={len(self._tracked_ipam_mappings)}"
+        )
+        if self._tracked_sdn_zone_ids:
+            await self.tear_down_sdn_zones_and_vnets(
+                self._tracked_sdn_zone_ids, self._tracked_ipam_mappings
+            )
+        self._tracked_sdn_zone_ids.clear()
+        self._tracked_ipam_mappings.clear()
 
     def find_existing_cidr_overlaps(
         self, list1: List[str], list2: List[str]
@@ -423,4 +457,3 @@ class SdnCommands(abc.ABC):
                 f"/cluster/sdn/vnets/{ipam_mapping.vnet_id}/ips",
                 json=ipam_mapping.to_proxmox_format(),
             )
-

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -167,9 +167,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         infra_commands = InfraCommands.build(
             async_proxmox_api, config.node, config.image_storage
         )
-        target = ProxmoxTarget(
-            host=config.host, port=config.port, node=config.node
-        )
+        target = ProxmoxTarget(host=config.host, port=config.port, node=config.node)
         InfraCommands.set_instance(target, infra_commands)
         await cls.ensure_vms(async_proxmox_api, config)
 
@@ -186,9 +184,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         if not isinstance(config, ProxmoxSandboxEnvironmentConfig):
             raise ValueError("config must be a ProxmoxSandboxEnvironmentConfig")
 
-        target = ProxmoxTarget(
-            host=config.host, port=config.port, node=config.node
-        )
+        target = ProxmoxTarget(host=config.host, port=config.port, node=config.node)
         infra_commands = InfraCommands.get_instance(target)
 
         task_name_start = re.sub("[^a-zA-Z0-9]", "x", task_name[:3].lower())
@@ -314,9 +310,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             raise ValueError("config must be a ProxmoxSandboxEnvironmentConfig")
 
         if cleanup:
-            target = ProxmoxTarget(
-                host=config.host, port=config.port, node=config.node
-            )
+            target = ProxmoxTarget(host=config.host, port=config.port, node=config.node)
             infra_commands = InfraCommands.get_instance(target)
             await infra_commands.task_cleanup()
         else:

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -24,7 +24,7 @@ from typing_extensions import override
 
 from proxmoxsandbox._impl.agent_commands import AgentCommands
 from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI
-from proxmoxsandbox._impl.infra_commands import InfraCommands
+from proxmoxsandbox._impl.infra_commands import InfraCommands, ProxmoxTarget
 from proxmoxsandbox._impl.qemu_commands import QemuCommands
 from proxmoxsandbox._impl.sdn_commands import IpamMapping
 from proxmoxsandbox._impl.task_wrapper import TaskWrapper
@@ -159,12 +159,19 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     async def task_init(
         cls, task_name: str, config: SandboxEnvironmentConfigType | None
     ) -> None:
-        if config is not None:
-            if not isinstance(config, ProxmoxSandboxEnvironmentConfig):
-                raise ValueError("config must be a ProxmoxSandboxEnvironmentConfig")
-            async_proxmox_api = cls._create_async_proxmox_api(config)
-            await ProxmoxSandboxEnvironment.ensure_vms(async_proxmox_api, config)
-        return None
+        if config is None:
+            config = ProxmoxSandboxEnvironmentConfig()
+        if not isinstance(config, ProxmoxSandboxEnvironmentConfig):
+            raise ValueError("config must be a ProxmoxSandboxEnvironmentConfig")
+        async_proxmox_api = cls._create_async_proxmox_api(config)
+        infra_commands = InfraCommands.build(
+            async_proxmox_api, config.node, config.image_storage
+        )
+        target = ProxmoxTarget(
+            host=config.host, port=config.port, node=config.node
+        )
+        InfraCommands.set_instance(target, infra_commands)
+        await cls.ensure_vms(async_proxmox_api, config)
 
     @classmethod
     @override
@@ -179,19 +186,14 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         if not isinstance(config, ProxmoxSandboxEnvironmentConfig):
             raise ValueError("config must be a ProxmoxSandboxEnvironmentConfig")
 
-        async_proxmox_api = cls._create_async_proxmox_api(config)
-
-        infra_commands = InfraCommands.build(
-            async_proxmox_api, config.node, config.image_storage
+        target = ProxmoxTarget(
+            host=config.host, port=config.port, node=config.node
         )
+        infra_commands = InfraCommands.get_instance(target)
 
         task_name_start = re.sub("[^a-zA-Z0-9]", "x", task_name[:3].lower())
 
         proxmox_ids_start = await infra_commands.find_proxmox_ids_start(task_name_start)
-
-        await ProxmoxSandboxEnvironment.ensure_vms(
-            async_proxmox_api=async_proxmox_api, config=config
-        )
 
         async with concurrency("proxmox", 1):
             (
@@ -213,7 +215,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         found_default = False
 
         agent_commands = AgentCommands(
-            async_proxmox=async_proxmox_api, node=config.node
+            async_proxmox=infra_commands.async_proxmox, node=config.node
         )
 
         for idx, vm_config_and_id in enumerate(vm_configs_with_ids):
@@ -288,6 +290,11 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                         ipam_mappings=any_vm_sandbox_environment.all_ipam_mappings,
                         vm_ids=any_vm_sandbox_environment.all_vm_ids,
                     )
+                    any_vm_sandbox_environment.infra_commands.deregister_resources(
+                        vm_ids=any_vm_sandbox_environment.all_vm_ids,
+                        sdn_zone_id=any_vm_sandbox_environment.sdn_zone_id,
+                        ipam_mappings=any_vm_sandbox_environment.all_ipam_mappings,
+                    )
         return None
 
     @classmethod
@@ -307,11 +314,10 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             raise ValueError("config must be a ProxmoxSandboxEnvironmentConfig")
 
         if cleanup:
-            infra_commands = InfraCommands.build(
-                cls._create_async_proxmox_api(config),
-                config.node,
-                config.image_storage,
+            target = ProxmoxTarget(
+                host=config.host, port=config.port, node=config.node
             )
+            infra_commands = InfraCommands.get_instance(target)
             await infra_commands.task_cleanup()
         else:
             print(

--- a/tests/proxmoxsandboxtest/conftest.py
+++ b/tests/proxmoxsandboxtest/conftest.py
@@ -6,9 +6,11 @@ import pytest
 
 from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI
 from proxmoxsandbox._impl.built_in_vm import BuiltInVM
-from proxmoxsandbox._impl.infra_commands import InfraCommands
+from proxmoxsandbox._impl.infra_commands import InfraCommands, ProxmoxTarget
 from proxmoxsandbox._impl.qemu_commands import QemuCommands, VnetAliases
 from proxmoxsandbox._impl.sdn_commands import SdnCommands
+from proxmoxsandbox._impl.storage_commands import LocalStorageCommands
+from proxmoxsandbox._impl.task_wrapper import TaskWrapper
 from proxmoxsandbox._proxmox_sandbox_environment import (
     ProxmoxSandboxEnvironment,
     ProxmoxSandboxEnvironmentConfig,
@@ -37,14 +39,32 @@ async def infra_commands(
     async_proxmox_api: AsyncProxmoxAPI,
     sandbox_env_config: ProxmoxSandboxEnvironmentConfig,
 ) -> InfraCommands:
-    return InfraCommands.build(
+    target = ProxmoxTarget(
+        host=sandbox_env_config.host,
+        port=sandbox_env_config.port,
+        node=sandbox_env_config.node,
+    )
+    instance = InfraCommands.build(
         async_proxmox_api, sandbox_env_config.node, sandbox_env_config.image_storage
     )
+    InfraCommands.set_instance(target, instance)
+    return instance
 
 
 @pytest.fixture
 async def sdn_commands(infra_commands: InfraCommands) -> SdnCommands:
     return infra_commands.sdn_commands
+
+
+@pytest.fixture
+async def storage_commands(
+    async_proxmox_api: AsyncProxmoxAPI,
+    sandbox_env_config: ProxmoxSandboxEnvironmentConfig,
+) -> LocalStorageCommands:
+    task_wrapper = TaskWrapper(async_proxmox_api)
+    return LocalStorageCommands(
+        async_proxmox_api, sandbox_env_config.node, task_wrapper
+    )
 
 
 @pytest.fixture

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_environment_e2e.py
@@ -339,6 +339,64 @@ async def test_connect(proxmox_sandbox_environment: ProxmoxSandboxEnvironment) -
     assert "open 'http" in connection.command
 
 
+async def test_task_cleanup_after_interrupted_sample(
+    qemu_commands: QemuCommands, sdn_commands: SdnCommands
+) -> None:
+    """Simulate Ctrl-C: skip sample_cleanup, verify task_cleanup destroys resources."""
+    sandbox_env_config = ProxmoxSandboxEnvironmentConfig(
+        vms_config=(
+            VmConfig(
+                vm_source_config=VmSourceConfig(built_in="ubuntu24.04"),
+                name="test-task-cleanup",
+            ),
+        )
+    )
+
+    existing_vms = await qemu_commands.list_vms()
+    existing_zones = await sdn_commands.list_sdn_zones()
+
+    task_name = "ttc"
+    _, envs_dict = await setup_sandbox(task_name, sandbox_env_config)
+
+    # Resources should exist on Proxmox
+    mid_vms = await qemu_commands.list_vms()
+    mid_zones = await sdn_commands.list_sdn_zones()
+    assert len(mid_vms) == len(existing_vms) + 1
+    assert len(mid_zones) == len(existing_zones) + 1
+
+    # Simulate Ctrl-C: sample_cleanup is called with interrupted=True,
+    # which skips the happy-path deletion
+    await ProxmoxSandboxEnvironment.sample_cleanup(
+        task_name=task_name,
+        config=sandbox_env_config,
+        environments=envs_dict,
+        interrupted=True,
+    )
+
+    # Resources should still exist — sample_cleanup did nothing
+    still_vms = await qemu_commands.list_vms()
+    still_zones = await sdn_commands.list_sdn_zones()
+    assert len(still_vms) == len(existing_vms) + 1
+    assert len(still_zones) == len(existing_zones) + 1
+
+    # Now task_cleanup runs (as Inspect would after Ctrl-C)
+    await ProxmoxSandboxEnvironment.task_cleanup(
+        task_name=task_name,
+        config=sandbox_env_config,
+        cleanup=True,
+    )
+
+    # Resources should be gone
+    post_vms = await qemu_commands.list_vms()
+    post_zones = await sdn_commands.list_sdn_zones()
+    assert set(vm["vmid"] for vm in post_vms) == set(
+        vm["vmid"] for vm in existing_vms
+    )
+    existing_zones.sort(key=lambda x: x["zone"])
+    post_zones.sort(key=lambda x: x["zone"])
+    assert post_zones == existing_zones
+
+
 async def test_cli_cleanup(
     qemu_commands: QemuCommands, sdn_commands: SdnCommands
 ) -> None:


### PR DESCRIPTION
Now that object creation is better factored (in #50), we can store the known resources (VM IDs, SDNs, IPAM mappings) in normal fields instead of ContextVars, which were confusing and unnecessary. The only tricky part is finding the relevant `InfraCommands` for a given sample, which is stored in a map in a class-level variable now.