### PR TITLE
fix: task_wrapper endtime check + OVA ostype/cpu flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ sandbox=SandboxEnvironmentSpec(
                 is_sandbox=False, # optional, default is True. A virtual machine that is not a sandbox; the qemu-guest-agent need not be installed.
                 disk_controller="scsi", # optional, default will be SCSI. Can also use "ide" for older VM images.
                 nic_controller="virtio", # optional, default will be VirtIO. Can also use "e1000" for older VM images.
+                cpu="host", # optional, default "host". The qemu CPU model (e.g. "host", "qemu64", "x86-64-v2"). Older guest kernels (notably FreeBSD/pfSense) can panic on nested virtualization with "host"; use "qemu64" for those.
                 firewall=True, # optional, default is False. Enables the Proxmox firewall on all NICs for VM isolation.
                 # If you have more than one VNet, assign the VM to the VNet via nics.
                 # You can assign more than one, to give the VM more than one network interface.

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -272,11 +272,12 @@ class QemuCommands(abc.ABC):
 
                     json_for_create: ProxmoxJsonDataType = {
                         "node": self.node,
-                        "cpu": "host",
-                        "ostype": vm_config.os_type,
+                        "cpu": vm_config.cpu if vm_config.cpu else "host",
                         "scsihw": "virtio-scsi-single",
                         "start": False,
                     }
+                    if vm_config.os_type is not None:
+                        json_for_create["ostype"] = vm_config.os_type
 
                     disk_prefix = (
                         "scsi"

--- a/src/proxmoxsandbox/_impl/task_wrapper.py
+++ b/src/proxmoxsandbox/_impl/task_wrapper.py
@@ -49,13 +49,12 @@ class TaskWrapper(abc.ABC):
     async def new_incomplete_tasks(self, pre_existing_incomplete_tasks):
         current_tasks = await self.async_proxmox.request("GET", "/cluster/tasks")
 
+        # A task is truly incomplete (still running) if it has no endtime.
+        # Completed tasks (success or failure) have endtime set.
         current_incomplete_tasks = [
             current_task
             for current_task in current_tasks
-            if (
-                ("status" in current_task and current_task["status"] != "OK")
-                or "status" not in current_task
-            )
+            if not current_task.get("endtime")
         ]
 
         new_tasks = [

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -191,6 +191,9 @@ class VmConfig(BaseModel, frozen=True):
             This is required for proper VM isolation. Defaults to False.
         os_type: The OS type. If unset, defaults to "l26". Only for OVA. See
             https://pve.proxmox.com/wiki/Manual:_qm.conf for more details
+        cpu: The qemu CPU model (e.g. "host", "qemu64", "x86-64-v2"). If unset,
+            defaults to "host". Older guest kernels (notably FreeBSD/pfSense) can
+            panic on nested virtualization with "host"; use "qemu64" for those.
 
     Note on nics configuration:
     - If set, the VM will be connected to these VNets (one interface per VNet)
@@ -213,6 +216,7 @@ class VmConfig(BaseModel, frozen=True):
     nic_controller: Optional[Literal["virtio", "e1000"]] = None
     firewall: bool = False
     os_type: Optional[OsType] = "l26"
+    cpu: Optional[str] = None
 
 
 class ProxmoxInstanceConfig(BaseModel, frozen=True):

--- a/tests/proxmoxsandboxtest/test_task_wrapper.py
+++ b/tests/proxmoxsandboxtest/test_task_wrapper.py
@@ -1,0 +1,75 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from proxmoxsandbox._impl.task_wrapper import TaskWrapper
+
+
+def _make_task_wrapper(cluster_tasks: list[dict]) -> TaskWrapper:
+    api = MagicMock()
+    api.request = AsyncMock(return_value=cluster_tasks)
+    return TaskWrapper(api)
+
+
+@pytest.mark.asyncio
+async def test_running_task_treated_as_incomplete() -> None:
+    # No endtime → still running.
+    tasks = [
+        {
+            "upid": "UPID:proxmox:running:1",
+            "starttime": 1777541620,
+            "type": "qmstart",
+        },
+    ]
+    wrapper = _make_task_wrapper(tasks)
+    incomplete = await wrapper.new_incomplete_tasks(pre_existing_incomplete_tasks=[])
+    assert len(incomplete) == 1
+    assert incomplete[0]["upid"] == "UPID:proxmox:running:1"
+
+
+@pytest.mark.asyncio
+async def test_failed_task_treated_as_complete() -> None:
+    # Task finished but failed: endtime is set, status is the error message.
+    # Regression: old code treated `status != "OK"` as still running and would
+    # wait forever on background failures like a routine apt-get update.
+    tasks = [
+        {
+            "upid": "UPID:proxmox:aptupdate:1",
+            "starttime": 1777541624,
+            "endtime": 1777541625,
+            "status": "command 'apt-get update' failed: exit code 100",
+            "type": "aptupdate",
+        },
+    ]
+    wrapper = _make_task_wrapper(tasks)
+    incomplete = await wrapper.new_incomplete_tasks(pre_existing_incomplete_tasks=[])
+    assert incomplete == []
+
+
+@pytest.mark.asyncio
+async def test_succeeded_task_treated_as_complete() -> None:
+    tasks = [
+        {
+            "upid": "UPID:proxmox:reload:1",
+            "starttime": 1777541622,
+            "endtime": 1777541623,
+            "status": "OK",
+            "type": "reloadnetworkall",
+        },
+    ]
+    wrapper = _make_task_wrapper(tasks)
+    incomplete = await wrapper.new_incomplete_tasks(pre_existing_incomplete_tasks=[])
+    assert incomplete == []
+
+
+@pytest.mark.asyncio
+async def test_pre_existing_incomplete_filtered_out() -> None:
+    tasks = [
+        {"upid": "UPID:already-running", "starttime": 1, "type": "x"},
+        {"upid": "UPID:newly-running", "starttime": 2, "type": "y"},
+    ]
+    wrapper = _make_task_wrapper(tasks)
+    incomplete = await wrapper.new_incomplete_tasks(
+        pre_existing_incomplete_tasks=[{"upid": "UPID:already-running"}],
+    )
+    assert [t["upid"] for t in incomplete] == ["UPID:newly-running"]


### PR DESCRIPTION
## Summary

Two bug fixes and one small feature, surfaced while running Crystal Peak PT evals on a nitrovirt-backed proxmox.

1. **task_wrapper: failed tasks looked incomplete.** \`new_incomplete_tasks\` filtered on \`status != "OK"\`, but a task with status like \`command 'apt-get update' failed: exit code 100\` is done — just not OK. The tenacity retry then polled it for the full 20 min stop_after_delay before giving up, and stale failed entries in \`/cluster/tasks\` from previous runs poisoned subsequent ones. Fix: check \`endtime\` presence; completed tasks (success or failure) have it set.

2. **qemu_commands: \`ostype: None\` crashes qmcreate.** When \`sandbox.yaml\` omits \`os_type\`, \`vm_config.os_type\` is \`None\` and was passed to proxmox as \`"ostype": None\`, which responds \`qmcreate failed: unable to parse value of 'ostype'\`. Fix: only include \`ostype\` in the create payload when set.

3. **qemu_commands: \`cpu\` was hardcoded to \"host\".** Host passthrough can cause guest-kernel panics on nested virt for older guests (e.g. FreeBSD/pfSense). Fix: surface a \`cpu\` field on \`VmConfig\`, default \"host\", overridable per-VM.

## Why this came up

On a nitrovirt-based proxmox (non-metal m8i with nested virt) the Crystal Peak handoff attempt hit both bugs. (1) was the most painful — it wasted ~38 min per run before timing out. (2) blocked epoch 2 of pt01 specifically (all CP PT challenges omit \`os_type\`). (3) was a follow-on made while preparing this branch.

## Test plan
- [x] pt01 verify_solutions × 10 epochs on nitrovirt: 10/10 pass, 40m59s with these fixes
- [x] pt01-pt16 (all 16 PT challenges) × 2 epochs: 30/32 pass (pt09 unrelated race, fixed separately in ctf-evals-crystal-peak#170)
- [x] No stalls on failed proxmox tasks; stale task history from earlier runs no longer blocks progress

## Notes
- Commits are split by concern (task_wrapper fix / qemu_commands ostype+cpu) so they can be merged or reordered independently.
- Draft — happy to polish or split further if you'd prefer one fix per PR.