### PR TITLE
Fix edge-case in network cleanups.

### DIFF
--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -278,14 +278,27 @@ class InfraCommands(abc.ABC):
                         noticed_vnets.add(bridge)
                 noticed_vms.append(vm)
 
-        zones_to_delete = await self.find_all_zones(noticed_vnets)
+        # Only zones matching the provider's ephemeral-zone naming convention
+        # are eligible for sweep — `create_sdn` enforces this convention at
+        # creation (sdn_commands.create_sdn). Pre-existing user zones
+        # (referenced via sdn_config=None) and the intentionally-permanent
+        # static `inspvm*` SDN do not match, and must not be deleted even
+        # when an `inspect`-tagged VM is plugged into one of their VNETs.
+        def _is_provider_zone(zone_id: str) -> bool:
+            return bool(re.match(ZONE_REGEX, zone_id))
 
-        # We probably already have all the SDN zones already.
-        # But in case there were no VMs in a particular SDN zone
-        # (which can happen if the task setup failed)
-        # we need to check for orphans.
+        # Zones that VMs we created are plugged into. Filtered to provider
+        # zones only, so attaching a sandbox VM to a user-pre-existing VNET
+        # does not drag the user's zone into the deletion set.
+        zones_to_delete = {
+            z for z in await self.find_all_zones(noticed_vnets)
+            if _is_provider_zone(z)
+        }
+
+        # Also catch orphan provider zones with no VMs in them
+        # (e.g. when task setup failed before VMs were created).
         for zone in await self.sdn_commands.list_sdn_zones():
-            if re.match(ZONE_REGEX, zone["zone"]):
+            if _is_provider_zone(zone["zone"]):
                 zones_to_delete.add(zone["zone"])
 
         noticed_ipam_mappings = [

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -26,7 +26,7 @@ from proxmoxsandbox._impl.agent_commands import AgentCommands
 from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI
 from proxmoxsandbox._impl.infra_commands import InfraCommands, ProxmoxTarget
 from proxmoxsandbox._impl.qemu_commands import QemuCommands
-from proxmoxsandbox._impl.sdn_commands import IpamMapping
+from proxmoxsandbox._impl.sdn_commands import ZONE_REGEX, IpamMapping
 from proxmoxsandbox._impl.task_wrapper import TaskWrapper
 from proxmoxsandbox._proxmox_pool import ProxmoxPoolABC, QueueBasedProxmoxPool
 from proxmoxsandbox.schema import (
@@ -296,7 +296,8 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 InfraCommands.set_instance(target, infra_commands)
 
             # The pool guarantees one sample per instance at a time, so any
-            # leftover VNETs here are orphans from a previous failed cleanup.
+            # leftover provider-managed VNETs here are orphans from a previous
+            # failed cleanup. User pre-existing VNETs are ignored by this check.
             await cls._ensure_instance_clean(infra_commands, instance.instance_id)
 
             task_name_start = re.sub("[^a-zA-Z0-9]", "x", task_name[:3].lower())
@@ -448,17 +449,28 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     async def _ensure_instance_clean(
         cls, infra_commands: InfraCommands, instance_id: str
     ) -> None:
-        """Ensure instance has no leftover VNETs. Clean up if needed.
+        """Ensure instance has no leftover provider-managed ephemeral VNETs.
+
+        Only VNETs in zones matching the provider's ephemeral-zone naming
+        convention are considered leftovers. Pre-existing user VNETs
+        (referenced via sdn_config=None) and the static `inspvm*` SDN are
+        deliberately ignored — they are expected to persist across samples.
 
         Logs errors but does not raise - if the instance is dirty,
         the subsequent setup will fail and the error handler will deal with it.
         """
         try:
             vnets = await infra_commands.sdn_commands.read_all_vnets()
+            leftover_vnets = [
+                v
+                for v in vnets
+                if "zone" in v and re.match(ZONE_REGEX, v["zone"])
+            ]
 
-            if vnets:
+            if leftover_vnets:
                 cls.logger.warning(
-                    f"Instance {instance_id} has {len(vnets)} leftover VNETs! "
+                    f"Instance {instance_id} has {len(leftover_vnets)} "
+                    f"leftover provider-managed VNETs! "
                     f"Cleaning up before proceeding..."
                 )
                 await infra_commands.cleanup_no_id(skip_confirmation=True)

--- a/tests/proxmoxsandboxtest/test_cleanup_no_id.py
+++ b/tests/proxmoxsandboxtest/test_cleanup_no_id.py
@@ -1,0 +1,165 @@
+"""Unit tests for InfraCommands.cleanup_no_id zone-selection logic.
+
+These tests verify that cleanup_no_id only marks provider-managed
+ephemeral zones for deletion, regardless of which VNETs `inspect`-tagged
+VMs happen to be plugged into. This protects pre-existing user SDN
+state when samples reference it via sdn_config=None.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from proxmoxsandbox._impl.infra_commands import InfraCommands
+
+
+def _make_infra(
+    *,
+    vms=None,
+    vm_configs=None,
+    zones=None,
+    vnets=None,
+    ipam=None,
+):
+    """Build an InfraCommands with mocked qemu/sdn collaborators.
+
+    `vm_configs` maps vmid -> config dict (as returned by `read_vm`),
+    used to resolve the bridges each non-template inspect VM is plugged
+    into. The real teardown methods are replaced with AsyncMocks so the
+    test can assert on the arguments without making any API calls.
+    """
+    vm_configs = vm_configs or {}
+
+    infra = MagicMock()
+    infra.async_proxmox = MagicMock()
+    infra.async_proxmox.base_url = "https://test"
+
+    infra.qemu_commands = MagicMock()
+    infra.qemu_commands.list_vms = AsyncMock(return_value=vms or [])
+    infra.qemu_commands.read_vm = AsyncMock(
+        side_effect=lambda vmid: vm_configs.get(vmid, {})
+    )
+    infra.qemu_commands.destroy_vm = AsyncMock()
+
+    infra.sdn_commands = MagicMock()
+    infra.sdn_commands.list_sdn_zones = AsyncMock(return_value=zones or [])
+    infra.sdn_commands.read_all_vnets = AsyncMock(return_value=vnets or [])
+    infra.sdn_commands.read_all_ipam_mappings = AsyncMock(return_value=ipam or [])
+    infra.sdn_commands.tear_down_sdn_zones_and_vnets = AsyncMock()
+
+    # Bind the real cleanup_no_id and find_all_zones onto the mock so the
+    # mocked collaborators get exercised.
+    infra.cleanup_no_id = InfraCommands.cleanup_no_id.__get__(infra)
+    infra.find_all_zones = InfraCommands.find_all_zones.__get__(infra)
+    return infra
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_pre_existing_zone_even_with_attached_inspect_vm():
+    """A non-template inspect VM plugged into a pre-existing user vnet
+    must NOT cause that vnet's zone to be deleted."""
+    infra = _make_infra(
+        vms=[
+            {
+                "vmid": 100,
+                "name": "sandbox-vm",
+                "tags": "inspect;sandbox",
+                "template": 0,
+            },
+        ],
+        vm_configs={
+            100: {"net0": "virtio=AA:BB:CC:DD:EE:FF,bridge=monitor"},
+        },
+        # User pre-existing zone — name does not match ZONE_REGEX.
+        zones=[{"zone": "user_zone", "type": "simple"}],
+        vnets=[{"vnet": "monitor", "zone": "user_zone"}],
+    )
+
+    await infra.cleanup_no_id(skip_confirmation=True)
+
+    args, _ = infra.sdn_commands.tear_down_sdn_zones_and_vnets.call_args
+    zones_passed = args[0]
+    assert "user_zone" not in zones_passed, (
+        f"pre-existing zone wrongly targeted for deletion: {zones_passed}"
+    )
+    assert zones_passed == set(), (
+        f"no zones should have been targeted; got: {zones_passed}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_targets_provider_zone_via_regex():
+    """An ephemeral zone matching ZONE_REGEX must be targeted for deletion
+    even when no inspect VMs are still plugged into it."""
+    infra = _make_infra(
+        vms=[],
+        zones=[
+            {"zone": "tlo123z", "type": "simple"},  # matches ZONE_REGEX
+            {"zone": "user_zone", "type": "simple"},  # does not match
+        ],
+        vnets=[],
+    )
+
+    await infra.cleanup_no_id(skip_confirmation=True)
+
+    args, _ = infra.sdn_commands.tear_down_sdn_zones_and_vnets.call_args
+    zones_passed = args[0]
+    assert zones_passed == {"tlo123z"}, (
+        f"only the regex-matching zone should be targeted; got: {zones_passed}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_static_inspvm_zone():
+    """The static `inspvm*` SDN is intentionally permanent and must not be
+    swept by cleanup_no_id, even though the provider created it."""
+    infra = _make_infra(
+        vms=[],
+        zones=[{"zone": "inspvmz", "type": "simple"}],
+        vnets=[{"vnet": "inspvmv0", "zone": "inspvmz"}],
+    )
+
+    await infra.cleanup_no_id(skip_confirmation=True)
+
+    # No deletion call at all when nothing is targeted.
+    assert not infra.sdn_commands.tear_down_sdn_zones_and_vnets.called, (
+        "static inspvm* SDN must not be torn down"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_mixed_case_protects_pre_existing_only():
+    """With both an orphan provider zone and a pre-existing user zone present,
+    only the provider zone is targeted; the user zone is left alone."""
+    infra = _make_infra(
+        vms=[
+            {
+                "vmid": 100,
+                "name": "sandbox-vm",
+                "tags": "inspect;sandbox",
+                "template": 0,
+            },
+        ],
+        vm_configs={
+            # Two nics: one in the orphan provider zone, one in user zone.
+            100: {
+                "net0": "virtio=AA:BB:CC:DD:EE:FF,bridge=tlo123v0",
+                "net1": "virtio=11:22:33:44:55:66,bridge=monitor",
+            },
+        },
+        zones=[
+            {"zone": "tlo123z", "type": "simple"},  # provider, match regex
+            {"zone": "user_zone", "type": "simple"},  # pre-existing
+        ],
+        vnets=[
+            {"vnet": "tlo123v0", "zone": "tlo123z"},
+            {"vnet": "monitor", "zone": "user_zone"},
+        ],
+    )
+
+    await infra.cleanup_no_id(skip_confirmation=True)
+
+    args, _ = infra.sdn_commands.tear_down_sdn_zones_and_vnets.call_args
+    zones_passed = args[0]
+    assert zones_passed == {"tlo123z"}
+    assert "user_zone" not in zones_passed

--- a/tests/proxmoxsandboxtest/test_sample_init_cleanup.py
+++ b/tests/proxmoxsandboxtest/test_sample_init_cleanup.py
@@ -175,17 +175,26 @@ async def test_sample_init_precheck_cleans_dirty_instance(
     simple_config_file,
     mock_proxmox_api,
 ):
-    """Test that pre-check detects and cleans leftover VNETs.
+    """Test that pre-check detects and cleans leftover provider VNETs.
 
     When an instance has leftover VNETs from a failed previous cleanup,
     the pre-check should detect them and call cleanup_no_id before proceeding.
+
+    Leftover VNETs must live in a zone matching the provider's ephemeral
+    zone naming convention (ZONE_REGEX); pre-existing user VNETs are
+    intentionally ignored — see test_sample_init_precheck_ignores_pre_existing_vnets.
     """
     os.environ["PROXMOX_CONFIG_FILE"] = simple_config_file
     ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
     sdn_mock = MagicMock()
+    # Both vnets live in a zone whose name matches ZONE_REGEX
+    # (3 chars + 3 digits + "z"), simulating an orphaned ephemeral zone.
     sdn_mock.read_all_vnets = AsyncMock(
-        return_value=[{"vnet": "leftover1"}, {"vnet": "leftover2"}]
+        return_value=[
+            {"vnet": "tlo123v0", "zone": "tlo123z"},
+            {"vnet": "tlo123v1", "zone": "tlo123z"},
+        ]
     )
     infra = _make_infra_mock(
         sdn_commands=sdn_mock,
@@ -215,6 +224,56 @@ async def test_sample_init_precheck_cleans_dirty_instance(
 
 
 @pytest.mark.asyncio
+async def test_sample_init_precheck_ignores_pre_existing_vnets(
+    simple_config_file,
+    mock_proxmox_api,
+):
+    """Test that pre-check does NOT trigger cleanup for pre-existing user VNETs.
+
+    When sdn_config=None, samples plug into pre-existing VNETs that the user
+    manages. Those zones do not match the provider's ephemeral zone naming
+    convention (ZONE_REGEX), and the pre-check must leave them alone so it
+    doesn't risk wiping user state via cleanup_no_id.
+    """
+    os.environ["PROXMOX_CONFIG_FILE"] = simple_config_file
+    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
+
+    sdn_mock = MagicMock()
+    # Pre-existing user vnets in user-named zones; neither matches ZONE_REGEX.
+    # Also include the static built-in SDN, which is intentionally permanent.
+    sdn_mock.read_all_vnets = AsyncMock(
+        return_value=[
+            {"vnet": "monitor", "zone": "a254c5f5"},
+            {"vnet": "inspvmv0", "zone": "inspvmz"},
+        ]
+    )
+    infra = _make_infra_mock(
+        sdn_commands=sdn_mock,
+        find_proxmox_ids_start=AsyncMock(side_effect=Exception("Stopping after pre-check")),
+    )
+    p1, p2, p3 = _patch_infra(infra)
+
+    with p1, p2, p3:
+        try:
+            await ProxmoxSandboxEnvironment.task_init("test_task", None)
+
+            config = ProxmoxSandboxEnvironmentConfig(instance_pool_id="default")
+
+            with pytest.raises(Exception, match="Stopping after pre-check"):
+                await ProxmoxSandboxEnvironment.sample_init("test_task", config, {})
+
+            assert not infra.cleanup_no_id.called, (
+                "Pre-check must NOT call cleanup_no_id when only pre-existing "
+                "user VNETs (or the static inspvm* SDN) are present."
+            )
+
+        finally:
+            if "PROXMOX_CONFIG_FILE" in os.environ:
+                del os.environ["PROXMOX_CONFIG_FILE"]
+            ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
+
+
+@pytest.mark.asyncio
 async def test_sample_init_precheck_cleanup_fails_but_continues(
     simple_config_file,
     mock_proxmox_api,
@@ -229,7 +288,7 @@ async def test_sample_init_precheck_cleanup_fails_but_continues(
 
     sdn_mock = MagicMock()
     sdn_mock.read_all_vnets = AsyncMock(
-        return_value=[{"vnet": "leftover1"}]
+        return_value=[{"vnet": "tlo123v0", "zone": "tlo123z"}]
     )
     infra = _make_infra_mock(
         sdn_commands=sdn_mock,


### PR DESCRIPTION
It's possible to hook up a VM to a predefined VNET/Zone in Proxmox that is **not** created by the provider during eval-build-time. However, there's a long-standing edge case that makes it so that if a VM is attached to a predefined VNET, that VNET and its zone can be wiped by the provider:

- If the sample runs to completion, the cleanup is fine (the predefined VNET persists).
- If the sample is `ctrl+c`'d, the cleanup is fine (the predefined VNET persists).
- If, however, a dirty sample is interrupted and wiped manually via `inspect sandbox cleanup proxmox`, the VNET and parent Zone are wiped from the instance. The condition is that a provider-defined VM (i.e. one that has the `inspect` tag) is cloned and attached to that predefined VNET. 

This PR constrains `cleanup_no_id` to only delete zones whose names match the provider's ephemeral-zone naming convention (already enforced at zone creation). Pre-existing user zones, and the static `inspvm*` SDN, are skipped, even when an inspect-tagged VM happens to be plugged into one of their VNETs. The pre-check warning is also filtered so user VNETs no longer trip a misleading "leftover VNETs" message.

---

- [X] Tested the new tests
- [X] All tests fine