### PR TITLE
Set timeouts on pycurl upload to prevent unbounded hangs

### DIFF
--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -300,7 +300,36 @@ class AsyncProxmoxAPI:
                 ],
             )
 
-            curl.perform()
+            # Stall-based timeouts: better than a flat TIMEOUT for multi-GB
+            # uploads — only fires when the transfer truly stops making progress.
+            curl.setopt(pycurl.CONNECTTIMEOUT, 30)
+            curl.setopt(pycurl.LOW_SPEED_LIMIT, 1024)
+            curl.setopt(pycurl.LOW_SPEED_TIME, 60)
+
+            upload_url = f"{self.api_base_url}/nodes/{node}/storage/{storage}/upload"
+            try:
+                file_size = file.stat().st_size
+            except OSError:
+                file_size = -1
+            self.logger.info(
+                "pycurl upload starting: url=%s file=%s size=%d",
+                upload_url,
+                actual_filename,
+                file_size,
+            )
+
+            try:
+                curl.perform()
+            except pycurl.error as e:
+                code = e.args[0] if e.args else None
+                curl.close()
+                if code in (pycurl.E_OPERATION_TIMEDOUT, pycurl.E_COULDNT_CONNECT):
+                    raise TimeoutError(
+                        f"pycurl upload stalled or failed to connect "
+                        f"(code={code}): url={upload_url} file={actual_filename} "
+                        f"size={file_size}: {e}"
+                    ) from e
+                raise
             status_code = curl.getinfo(pycurl.RESPONSE_CODE)
             curl.close()
 


### PR DESCRIPTION
## Summary

`upload_file_with_curl` configured `pycurl.Curl()` with no timeouts. A transient Proxmox/network glitch stalled `pycurl.perform()` for ~9 minutes during testing with no recovery — the outer test-runner timeout was the only thing that killed it, and the failure was opaque.

This PR adds:

- `CONNECTTIMEOUT = 30 s` — bounds the connect+TLS-handshake phase. (The kernel's default SYN-retry budget is ~130 s, so without this a dead host blocks the upload for over two minutes.)
- `LOW_SPEED_LIMIT = 1024 B/s` over `LOW_SPEED_TIME = 60 s` — stall detector during the transfer itself. 1024 B/s is well below any link a real eval would run on (so no false fire). 60 s is generous enough to absorb transient pauses on multi-GB uploads, where a flat `TIMEOUT` would either kill long uploads or be useless.
- Translates `pycurl.error` codes `E_OPERATION_TIMEDOUT (28)` and `E_COULDNT_CONNECT (7)` into `TimeoutError`, with URL, filename, and file size in the message. Same context logged at INFO before `perform()`.

## Test plan

Verified empirically against a real Proxmox host, driving the existing `tests/proxmoxsandboxtest/test_storage_commands.py::test_upload_no_size_check`:

- [x] **Happy path** — passes in ~4 s without interference.
- [x] **`CONNECTTIMEOUT` fires** — blackhole the proxmox port before pycurl's connect (`iptables -I OUTPUT -p tcp --dport 8006 -j DROP`): PR raises `TimeoutError` at 30.0 s. On main, the same scenario hangs for the kernel SYN-retry budget (~130 s).
- [x] **`LOW_SPEED` fires on one-way stalls** — drop only the return path mid-upload (`iptables -I INPUT -p tcp --sport 8006 -j DROP` after the `pycurl upload starting` log): PR raises `TimeoutError: … (28, 'Operation too slow. Less than 1024 bytes/sec transferred the last 60 seconds')` at ~67 s. On main, hangs ≥ 180 s (test killed by watchdog).
- [x] **`LOW_SPEED` fires on server-overload-during-upload** — TCP proxy that freezes both directions mid-flight (faithfully simulates a pveproxy that can't drain its recv buffer; connection alive, no FIN/RST forwarded): PR `TimeoutError` at ~67 s; main hangs the full 180 s cap.
- [x] **No false fire on legitimately slow links** — tc HTB 64 kbit/s (~8 KB/s outgoing), tc netem 500 ms latency, and tc netem 50 % loss all complete the test normally.

## Limits — not fully addressed

- The 60 s `LOW_SPEED_TIME` is longer than pveproxy's own server-side read timeout (~20 s observed). When the **client side** is the slow one (e.g. tc throttle to a few hundred B/s), pveproxy preempts and pycurl raises `pycurl.error(52, 'Empty reply from server')` — bounded, but **not** wrapped to `TimeoutError`. The "callers can catch `TimeoutError`" mental model holds for connect-failure and server-side stalls, but not for client-side throttling.
- Other pycurl codes that pass through unwrapped: `52` (`GOT_NOTHING`), `55/56` (`SEND/RECV_ERROR`), `18` (`PARTIAL_FILE`), `35` (`SSL_CONNECT_ERROR`), `6` (`COULDNT_RESOLVE_HOST`). All are bounded by TCP / the server, so they don't hang — but a caller hoping to pattern-match on `TimeoutError` for retry will miss them. Possible follow-up: widen the wrap, or introduce a typed `ProxmoxUploadError`.
- No unit test for the new wrapping logic. Existing tests cover happy path; the failure path is tested only by manual integration. A small test that monkey-patches `pycurl.Curl().perform` to raise `pycurl.error(28, …)` and asserts `TimeoutError` would lock the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
