### PR TITLE
feat: parallelise chunked write_file with bounded asyncio.Semaphore

### DIFF
--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import errno
 import re
@@ -872,13 +873,27 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             else:
                 await self.exec(cmd=["mkdir", "-p", "--", temp_dir])
 
-            # Write chunks to temp files with zero-padded numbers
-            for i, chunk in enumerate(chunks):
+            # Write chunks concurrently (bounded). Each call is hard-capped
+            # at ~40 KiB by the Proxmox API (PVE Agent.pm enforces a 60 KiB
+            # `content` ceiling, leaving ~40 KiB after base64), so the only
+            # way to make a multi-MB write significantly faster is to have
+            # more calls in flight. Higher values speed up further but
+            # increase the chance of transient QGA / storage IOPS pressure
+            # under multi-VM load — 8 was a reliable trade-off in testing.
+            MAX_CONCURRENT_WRITES = 8
+            sem = asyncio.Semaphore(MAX_CONCURRENT_WRITES)
+
+            async def write_one(i: int, chunk: bytes) -> None:
                 if is_windows:
                     chunk_file = f"{temp_dir}\\chunk_{i:0{padding_width}d}"
                 else:
                     chunk_file = f"{temp_dir}/chunk_{i:0{padding_width}d}"
-                await self._write_file_only(chunk_file, chunk)
+                async with sem:
+                    await self._write_file_only(chunk_file, chunk)
+
+            await asyncio.gather(
+                *(write_one(i, chunk) for i, chunk in enumerate(chunks))
+            )
 
             if is_windows:
                 # Batch script to combine chunks using copy /b


### PR DESCRIPTION
## Summary

`SandboxEnvironment.write_file` currently writes file chunks to the guest sequentially via the QGA `guest-file-write` API. Each chunk is hard-capped at ~40 KiB after base64 (PVE `Agent.pm` enforces `maxLength => 60 * 1024` on the `content` parameter), so large files require many round-trips, and each one pays per-call HTTP/QGA latency.

This PR runs the chunked-write phase concurrently, bounded by an `asyncio.Semaphore(8)`, so multiple chunks can be in flight at once. The combine step (concatenating the chunks with `cat` on Linux / `copy /b` on Windows) is unchanged.

## Motivation

For larger uploads (50+ MB), the sequential implementation is dominated by per-call latency rather than bytes-on-the-wire. Concrete numbers from a ~56 MB upload to a Linux guest:

| Concurrency | Wallclock | Notes |
|---|---|---|
| 1 (current) | ~18 min | latency-bound on ~1400 chunks |
| 8 | ~10 min | no chunk-write retries observed under typical load |
| 16 | ~6 min | reliable in light loads; under multi-sample / saturated-storage load, ~5–10% of chunk writes hit transient `Agent error: failed to open file ... (mode: 'wb'): No such file or directory` and `HTTP 596 Broken pipe`. The existing `agent_commands` retry path (3 attempts, 3 s delay) recovers all of them, but it's wasteful and noisy. |

The driver of those transients at concurrency=16 looks like the underlying storage's IOPS budget (qcow2 first-touch metadata = refcount + L2 updates per new cluster, plus the synchronous flush semantics of `guest-file-write`). At concurrency=8 we stayed comfortably below the saturation point in our testing without losing too much wallclock improvement.

## Tested

- Existing test suite passes.
- A 100-epoch end-to-end run of a multi-VM Proxmox sandbox (each sample pushes ~50 MB of files into a guest before running) saw zero `write_file`-related failures attributable to this change. The one outlier in the run was a downstream paramiko race in the workload itself, unrelated to chunk writes.

## Trade-off / follow-up ideas (not in this PR)

- The `MAX_CONCURRENT_WRITES = 8` constant is conservative. Could be exposed via `VmConfig` or an env knob if maintainers want callers to tune per workload.
- Longer-term: tar-and-extract (one big API call instead of N small ones, via a different QGA primitive) would sidestep the 40-KiB cap entirely. Real refactor; out of scope here.