### PR TITLE
fix: surface exec timeout instead of opaque RetryError (#76)

### DIFF
--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -43,13 +43,8 @@ from proxmoxsandbox.schema import (
 # for derivation); 30 KiB leaves a little headroom for env/cwd/etc. overhead.
 _INLINE_STDIN_LIMIT = 30 * 1024
 
-# Grace added to the exec polling deadline on top of the caller's timeout.
-# The in-guest `timeout -k 5s {timeout}s` wrapper only SIGTERMs the command at
-# `timeout`; a command that doesn't exit at once on SIGTERM (e.g. `john` saves
-# its session first) lingers until the SIGKILL at `timeout`+5s. Polling for only
-# `timeout` then catches the command mid-shutdown and raised an opaque
-# RetryError (issue #76); the grace lets the poll outlast the SIGKILL so the
-# real exit (rc 124, or 137 if it had to be killed) is seen instead.
+# Poll past the in-guest `timeout -k 5s` SIGKILL (at timeout+5s) so we observe
+# the real exit instead of catching the command mid-shutdown.
 _EXEC_POLL_GRACE_SECONDS = 10
 
 
@@ -763,13 +758,9 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             try:
                 exec_status = await wait_for_exec(self.vm_id, exec_response_pid)
             except tenacity.RetryError as ex:
-                # wait_for_exec only raises RetryError when stop_after_delay
-                # fired while exec-status still reported the process running, so
-                # timeout is set. With the grace margin this should not normally
-                # happen — the in-guest timeout SIGKILLs by timeout+5s — so it
-                # means exec-status itself could not confirm completion within
-                # timeout+grace (a genuinely unresponsive guest agent). Surface a
-                # clear TimeoutError instead of the opaque RetryError (issue #76).
+                # Grace margin should prevent this; reaching here means the guest
+                # agent never confirmed completion within timeout+grace. Surface
+                # it clearly, not as RetryError.
                 raise TimeoutError(
                     f"Command did not complete within {timeout}s "
                     f"(+{_EXEC_POLL_GRACE_SECONDS}s guest-agent grace) on VM "

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -43,6 +43,15 @@ from proxmoxsandbox.schema import (
 # for derivation); 30 KiB leaves a little headroom for env/cwd/etc. overhead.
 _INLINE_STDIN_LIMIT = 30 * 1024
 
+# Grace added to the exec polling deadline on top of the caller's timeout.
+# The in-guest `timeout -k 5s {timeout}s` wrapper only SIGTERMs the command at
+# `timeout`; a command that doesn't exit at once on SIGTERM (e.g. `john` saves
+# its session first) lingers until the SIGKILL at `timeout`+5s. Polling for only
+# `timeout` then catches the command mid-shutdown and raised an opaque
+# RetryError (issue #76); the grace lets the poll outlast the SIGKILL so the
+# real exit (rc 124, or 137 if it had to be killed) is seen instead.
+_EXEC_POLL_GRACE_SECONDS = 10
+
 
 @sandboxenv(name="proxmox")
 class ProxmoxSandboxEnvironment(SandboxEnvironment):
@@ -656,7 +665,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
 
         @tenacity.retry(
             wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
-            stop=tenacity.stop_after_delay(timeout)
+            stop=tenacity.stop_after_delay(timeout + _EXEC_POLL_GRACE_SECONDS)
             if timeout is not None
             else tenacity.stop_never,
             retry=tenacity.retry_if_result(lambda x: x is False),
@@ -743,7 +752,23 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             self.TRACE_NAME,
             f"exec_command {self.vm_id=} {exec_response_pid=}",
         ):
-            exec_status = await wait_for_exec(self.vm_id, exec_response_pid)
+            try:
+                exec_status = await wait_for_exec(self.vm_id, exec_response_pid)
+            except tenacity.RetryError as ex:
+                # wait_for_exec only raises RetryError when stop_after_delay
+                # fired while exec-status still reported the process running, so
+                # timeout is set. With the grace margin this should not normally
+                # happen — the in-guest timeout SIGKILLs by timeout+5s — so it
+                # means exec-status itself could not confirm completion within
+                # timeout+grace (a genuinely unresponsive guest agent). Surface a
+                # clear TimeoutError instead of the opaque RetryError (issue #76).
+                raise TimeoutError(
+                    f"Command did not complete within {timeout}s "
+                    f"(+{_EXEC_POLL_GRACE_SECONDS}s guest-agent grace) on VM "
+                    f"{self.vm_id}, pid {exec_response_pid}. The QEMU guest "
+                    f"agent did not report the process as finished. "
+                    f"Command: {shlex.join(cmd)[:200]}"
+                ) from ex
 
         if exec_status and isinstance(exec_status, Dict) and "err-data" in exec_status:
             # Something went wrong with the wrapper script, not the actual command

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -43,14 +43,16 @@ from proxmoxsandbox.schema import (
 # for derivation); 30 KiB leaves a little headroom for env/cwd/etc. overhead.
 _INLINE_STDIN_LIMIT = 30 * 1024
 
+_IN_GUEST_KILL_GRACE = 5
+
 # Grace added to the exec polling deadline on top of the caller's timeout.
-# The in-guest `timeout -k 5s {timeout}s` wrapper only SIGTERMs the command at
+# The in-guest `timeout -k {_IN_GUEST_KILL_GRACE}s {timeout}s` wrapper only SIGTERMs the command at
 # `timeout`; a command that doesn't exit at once on SIGTERM (e.g. `john` saves
-# its session first) lingers until the SIGKILL at `timeout`+5s. Polling for only
+# its session first) lingers until the SIGKILL at `timeout`+_IN_GUEST_KILL_GRACE. Polling for only
 # `timeout` then catches the command mid-shutdown and raised an opaque
 # RetryError (issue #76); the grace lets the poll outlast the SIGKILL so the
 # real exit (rc 124, or 137 if it had to be killed) is seen instead.
-_EXEC_POLL_GRACE_SECONDS = 10
+_EXEC_POLL_GRACE_SECONDS = _IN_GUEST_KILL_GRACE + 3
 
 
 @sandboxenv(name="proxmox")
@@ -133,7 +135,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         # (requires terminating the remote process).
         # `-k 5s` sends SIGKILL after grace period in case user command doesn't respect
         # SIGTERM.
-        return f"timeout -k 5s {timeout}s "
+        return f"timeout -k {_IN_GUEST_KILL_GRACE}s {timeout}s "
 
     def _is_windows(self) -> bool:
         """Check if this VM is running Windows based on os_type."""

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -46,9 +46,10 @@ _INLINE_STDIN_LIMIT = 30 * 1024
 _IN_GUEST_KILL_GRACE = 5
 
 # Grace added to the exec polling deadline on top of the caller's timeout.
-# The in-guest `timeout -k {_IN_GUEST_KILL_GRACE}s {timeout}s` wrapper only SIGTERMs the command at
-# `timeout`; a command that doesn't exit at once on SIGTERM (e.g. `john` saves
-# its session first) lingers until the SIGKILL at `timeout`+_IN_GUEST_KILL_GRACE. Polling for only
+# The in-guest `timeout -k {_IN_GUEST_KILL_GRACE}s {timeout}s` wrapper only
+# SIGTERMs the command at `timeout`; a command that doesn't exit at once on
+# SIGTERM (e.g. `john` saves its session first) lingers until the SIGKILL at
+# `timeout`+_IN_GUEST_KILL_GRACE. Polling for only
 # `timeout` then catches the command mid-shutdown and raised an opaque
 # RetryError (issue #76); the grace lets the poll outlast the SIGKILL so the
 # real exit (rc 124, or 137 if it had to be killed) is seen instead.

--- a/tests/proxmoxsandboxtest/test_eval.py
+++ b/tests/proxmoxsandboxtest/test_eval.py
@@ -77,9 +77,10 @@ def _make_structured_payload(line_count: int) -> bytes:
     predictable. ~5 MiB for 200k lines — well over the 1 MiB fast-path
     threshold.
     """
-    return b"\n".join(
-        f"line {i:08d} payload xyz".encode() for i in range(line_count)
-    ) + b"\n"
+    return (
+        b"\n".join(f"line {i:08d} payload xyz".encode() for i in range(line_count))
+        + b"\n"
+    )
 
 
 _DMESG_RED_FLAGS = (
@@ -159,7 +160,8 @@ def _write_and_inspect(line_count: int) -> Solver:
         new_dmesg = "\n".join(chunks[5:]).strip()
 
         red_flag_hits = [
-            line for line in new_dmesg.splitlines()
+            line
+            for line in new_dmesg.splitlines()
             if any(flag in line for flag in _DMESG_RED_FLAGS)
         ]
 
@@ -194,7 +196,7 @@ def _iso_write_health_scorer():
         checks = {
             "lines": m.get("actual_lines") == m.get("expected_lines"),
             "bytes": m.get("actual_bytes") == m.get("payload_size"),
-            "sha":   m.get("actual_sha") == m.get("expected_sha"),
+            "sha": m.get("actual_sha") == m.get("expected_sha"),
             "kernel_quiet": not m.get("dmesg_red_flags"),
         }
         all_ok = all(checks.values())
@@ -295,9 +297,9 @@ def test_iso_write_fast_path_via_eval() -> None:
     # this log line; if it were used, this assertion would catch a silent
     # regression).
     iso_write_log_lines = [
-        msg for (name, msg) in captured
-        if name == "proxmoxsandbox._impl.iso_write"
-        and msg.startswith("iso_write vm=")
+        msg
+        for (name, msg) in captured
+        if name == "proxmoxsandbox._impl.iso_write" and msg.startswith("iso_write vm=")
     ]
     assert iso_write_log_lines, (
         f"expected at least one 'iso_write vm=' log line proving the "
@@ -307,9 +309,7 @@ def test_iso_write_fast_path_via_eval() -> None:
 
     # Hard: the per-VM disable mechanism didn't fire — that warning
     # would mean iso_write gave up on this VM entirely.
-    disabled_warnings = [
-        msg for (_, msg) in captured if "fast path disabled" in msg
-    ]
+    disabled_warnings = [msg for (_, msg) in captured if "fast path disabled" in msg]
     assert not disabled_warnings, (
         f"fast path got disabled unexpectedly: {disabled_warnings}"
     )
@@ -325,7 +325,8 @@ def test_iso_write_fast_path_via_eval() -> None:
             "iso_write fast path emitted guest kernel red flags during "
             "write (path recovered, but worth investigating): %s "
             "(new dmesg lines added: %s)",
-            red_flags, m.get("dmesg_lines_added"),
+            red_flags,
+            m.get("dmesg_lines_added"),
         )
 
 

--- a/tests/proxmoxsandboxtest/test_exec_timeout.py
+++ b/tests/proxmoxsandboxtest/test_exec_timeout.py
@@ -1,0 +1,49 @@
+"""Unit tests for exec timeout handling (issue #76).
+
+When the guest agent never reports a command as completed within the polling
+deadline, the underlying tenacity loop raises an opaque RetryError. exec()
+must convert that into a clear TimeoutError instead of leaking RetryError.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from proxmoxsandbox import _proxmox_sandbox_environment as mod
+from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
+
+
+def _make_sandbox(agent_commands) -> ProxmoxSandboxEnvironment:
+    return ProxmoxSandboxEnvironment(
+        infra_commands=MagicMock(),
+        agent_commands=agent_commands,
+        ipam_mappings=(),
+        vm_id=100,
+        all_vm_ids=(100,),
+        sdn_zone_id=None,
+        instance=None,
+        pool_id=None,
+        os_type="l26",
+    )
+
+
+@pytest.mark.asyncio
+async def test_exec_unresponsive_agent_raises_timeouterror(monkeypatch):
+    """If exec-status never reports completion, exec raises TimeoutError."""
+    # Drop the grace so the poll deadline is just `timeout`, keeping the test fast.
+    monkeypatch.setattr(mod, "_EXEC_POLL_GRACE_SECONDS", 0)
+
+    agent = MagicMock()
+    agent.write_file = AsyncMock()
+    agent.exec_command = AsyncMock(return_value={"pid": 42})
+    # exited != 1 means "still running"; the agent never reports completion.
+    agent.get_agent_exec_status = AsyncMock(return_value={"exited": 0})
+
+    env = _make_sandbox(agent)
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await env.exec(["sleep", "100"], timeout=1)
+
+    message = str(exc_info.value)
+    assert "guest" in message.lower()
+    assert "RetryError" not in message

--- a/tests/proxmoxsandboxtest/test_exec_timeout.py
+++ b/tests/proxmoxsandboxtest/test_exec_timeout.py
@@ -1,9 +1,4 @@
-"""Unit tests for exec timeout handling (issue #76).
-
-When the guest agent never reports a command as completed within the polling
-deadline, the underlying tenacity loop raises an opaque RetryError. exec()
-must convert that into a clear TimeoutError instead of leaking RetryError.
-"""
+"""exec() converts an exhausted poll into a clear TimeoutError, not a RetryError."""
 
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -14,15 +14,7 @@ from .proxmox_sandbox_utils import setup_requests_logging
 async def test_exec_timeout_with_sigterm_handler_no_retryerror(
     proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
 ) -> None:
-    """A SIGTERM-handling command that outlives its timeout must not raise RetryError.
-
-    Issue #76: a command that handles SIGTERM and doesn't exit immediately
-    (like `john` saving its session) used to surface an opaque tenacity
-    RetryError when it ran past its timeout, because the poll deadline equalled
-    the in-guest timeout and so fired while the command was still in the
-    `timeout -k 5s` SIGKILL grace window. It must now surface as a clean
-    TimeoutError or a terminated returncode — never RetryError.
-    """
+    """A SIGTERM-handling command outliving its timeout must not raise RetryError."""
     if proxmox_sandbox_environment._is_windows():
         pytest.skip("SIGTERM handling is Linux-only")
 
@@ -36,7 +28,7 @@ async def test_exec_timeout_with_sigterm_handler_no_retryerror(
     except TimeoutError:
         pass  # also acceptable: surfaced as a clean timeout
     except tenacity.RetryError as ex:
-        pytest.fail(f"exec leaked tenacity.RetryError (issue #76): {ex}")
+        pytest.fail(f"exec leaked tenacity.RetryError: {ex}")
 
 
 async def test_exec_10mb_limit(

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -3,11 +3,40 @@ from pathlib import Path
 from typing import List
 
 import pytest
+import tenacity
 from inspect_ai.util._sandbox.self_check import self_check
 
 from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
 
 from .proxmox_sandbox_utils import setup_requests_logging
+
+
+async def test_exec_timeout_with_sigterm_handler_no_retryerror(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    """A SIGTERM-handling command that outlives its timeout must not raise RetryError.
+
+    Issue #76: a command that handles SIGTERM and doesn't exit immediately
+    (like `john` saving its session) used to surface an opaque tenacity
+    RetryError when it ran past its timeout, because the poll deadline equalled
+    the in-guest timeout and so fired while the command was still in the
+    `timeout -k 5s` SIGKILL grace window. It must now surface as a clean
+    TimeoutError or a terminated returncode — never RetryError.
+    """
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("SIGTERM handling is Linux-only")
+
+    try:
+        result = await proxmox_sandbox_environment.exec(
+            ["sh", "-c", "trap 'sleep 30' TERM; while :; do :; done"],
+            timeout=5,
+        )
+        # Force-killed by the in-guest SIGKILL after the grace period.
+        assert result.returncode != 0
+    except TimeoutError:
+        pass  # also acceptable: surfaced as a clean timeout
+    except tenacity.RetryError as ex:
+        pytest.fail(f"exec leaked tenacity.RetryError (issue #76): {ex}")
 
 
 async def test_exec_10mb_limit(


### PR DESCRIPTION
## Issue

Fixes #76 — `exec` sometimes fails with an opaque `tenacity.RetryError: RetryError[<Future ... returned bool>]` and an uninformative stack trace.

## What I observed

I built a repro that runs through `inspect eval` against a Proxmox VM and ran it on the current code before changing anything. In that setup:

- The error reproduces for a command that **handles SIGTERM and does not exit immediately** (e.g. `trap 'sleep 30' TERM; while :; do :; done`, a stand-in for `john` saving its session) when it runs past its timeout.
- A command that exits promptly on SIGTERM times out cleanly (`SandboxTimeoutError`) on the same code.
- I did **not** observe the guest agent becoming unresponsive under CPU saturation (8 busy loops on a 2-vCPU VM): cheap probe `exec`s kept returning in ~2s throughout. So, at least in my testing, the trigger appears to be the command's SIGTERM handling rather than QGA itself failing — though I can't rule out that heavy real workloads behave differently from my synthetic ones.

Mechanism, as far as I can tell: `exec` wraps the command in-guest with `timeout -k 5s {timeout}s`, which SIGTERMs at `timeout` and only SIGKILLs at `timeout`+5s. The outer poll loop used `stop_after_delay(timeout)` — the same value — so once the deadline passes, the next poll can catch the command still alive in the SIGKILL grace window and raise `RetryError` instead of seeing the real exit.

## Change

- Extend the poll deadline by a grace margin (`timeout + 8s`) so the poll outlasts the in-guest SIGKILL and observes the command's actual exit.
- Convert any residual `RetryError` into a `TimeoutError` carrying VM/pid/timeout/command context, so a genuinely stuck poll no longer surfaces as an opaque tenacity error.

## Caveat

A command that ignores SIGTERM past the grace period is SIGKILLed and returns `rc=137` as a normal `ExecResult` rather than raising `TimeoutError`. The common case (a command that exits within the grace, including `john` as far as I understand it) returns `rc 124` → `TimeoutError`. I did not map `137` to `TimeoutError` because that signal is ambiguous (OOM, external kill); happy to revisit if a timeout-shaped error is preferred there.

## Testing

- e2e regression test (`test_exec_timeout_with_sigterm_handler_no_retryerror`): fails on the pre-change code with `RetryError`, passes with the change. Runs against a real Proxmox VM.
- Unit test (`test_exec_timeout.py`) for the `RetryError`→`TimeoutError` backstop using a mocked unresponsive agent.
- Existing `test_exec_10mb_limit` still passes e2e.
- These were run against a single Linux VM on one NitroVirt instance; I have not exercised the Windows path or multi-instance pools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
