### PR TITLE
EC2: optional CloudWatch OTLP metrics collector

### DIFF
--- a/src/proxmoxsandbox/scripts/ec2/README.md
+++ b/src/proxmoxsandbox/scripts/ec2/README.md
@@ -86,7 +86,8 @@ aws ec2 run-instances --region "$REGION" \
     --instance-type m8i.2xlarge \
     --cpu-options "NestedVirtualization=enabled" \
     --subnet-id "$SUBNET_ID" \
-    --security-group-ids "$SECURITY_GROUP_ID"
+    --security-group-ids "$SECURITY_GROUP_ID" \
+    --metadata-options "InstanceMetadataTags=enabled"
     # add --iam-instance-profile Name=<profile> if SSM access doesn't come from DHMC
 ```
 
@@ -121,6 +122,24 @@ outbound traffic via iptables MASQUERADE. VM gateway: `10.10.10.1`. DNS:
 `169.254.169.253` (VPC resolver). VMs can't bind directly to the VPC subnet
 because EC2 only routes to IPs on attached ENIs.
 
+## Metrics (CloudWatch)
+
+The instance ships a localhost CloudWatch agent that forwards Proxmox's `pvestatd`
+metrics to CloudWatch using OpenTelemetry.
+
+**IAM**: the instance role needs `cloudwatch:PutMetricData` for metrics to be
+accepted. Without it the agent still runs, but the endpoint returns 403 —
+harmless, you just get no metrics.
+
+**Per-instance `Name` dimension**: every datapoint is labelled with the EC2
+instance-id. It is additionally labelled with the instance `Name` tag **only if
+the launcher enables instance metadata tags**. Like the hostname and root
+password (see fixup services below), this is a per-launch attribute set at
+`run-instances` time — it is **not** baked into the AMI. Pass
+`--metadata-options InstanceMetadataTags=enabled` (as `launch.sh` does for the
+build instance, and as the everyday-launch example above does) or you get
+instance-id only.
+
 ## EC2-specific bits handled by `userdata.sh`
 
 - SSM agent (not in Debian 13 by default) — installed in stage 1.
@@ -132,6 +151,7 @@ because EC2 only routes to IPs on attached ENIs.
   (see <https://forum.proxmox.com/threads/ipam-reserving-dhcp-leases-via-mac-addresses.174704/>).
 - `/run/dnsmasq/resolv.conf` shim for SDN dnsmasq DNS forwarding.
 - AMI fixup services for hostname + SSL cert + root password regeneration on every boot.
+- CloudWatch OTLP metrics collector for `pvestatd` metrics — see "Metrics (CloudWatch)" above.
 
 ## Other scripts
 

--- a/src/proxmoxsandbox/scripts/ec2/launch.sh
+++ b/src/proxmoxsandbox/scripts/ec2/launch.sh
@@ -66,6 +66,9 @@ RUN_ARGS=(
     --cpu-options "NestedVirtualization=enabled"
     --subnet-id "$SUBNET_ID"
     --security-group-ids "$SECURITY_GROUP_ID"
+    # Expose the instance's own tags (incl. Name) via IMDS so the OTel collector
+    # can label metrics with the Name (read at boot, no ec2:DescribeTags needed).
+    --metadata-options "InstanceMetadataTags=enabled"
     --block-device-mappings
         "DeviceName=/dev/xvda,Ebs={VolumeSize=1024,VolumeType=gp3,DeleteOnTermination=true}"
     --user-data "fileb://$USERDATA_GZ"

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -425,12 +425,12 @@ systemctl enable proxmox-ami-fixup-firewall.service
 # all runtime steps (region from IMDS, agent config + start) happen at first boot, so
 # we never start the agent or connection-test the endpoint at build time.
 #
-# resourcedetection tags every datapoint with the EC2 instance-id and (via tags) the
-# instance Name tag, so metrics are distinguishable per box without renaming the PVE
-# node. The Name tag is fetched via the DescribeTags API, so the instance role needs
-# ec2:DescribeTags (without it the agent still runs and exports instance-id, just no
-# Name). Do NOT add tags_from_imds: the CloudWatch agent's embedded collector rejects
-# that key and refuses to start.
+# resourcedetection tags every datapoint with the EC2 instance-id and the instance
+# Name tag, so metrics are distinguishable per box without renaming the PVE node.
+# The Name is read from IMDS at boot (the launcher must enable InstanceMetadataTags)
+# and injected via OTEL_RESOURCE_ATTRIBUTES, picked up by resourcedetection's env
+# detector -- no ec2:DescribeTags IAM needed. Do NOT use the ec2 detector's
+# tags_from_imds: the CloudWatch agent's embedded collector rejects that key.
 curl -fsSL "https://amazoncloudwatch-agent.s3.amazonaws.com/debian/amd64/latest/amazon-cloudwatch-agent.deb" \
     -o /tmp/cwagent.deb
 dpkg -i /tmp/cwagent.deb
@@ -443,10 +443,10 @@ receivers:
         endpoint: 127.0.0.1:4318
 processors:
   resourcedetection/cwagent:
-    detectors: [ec2]
+    # env reads ec2.tag.Name from OTEL_RESOURCE_ATTRIBUTES (set at boot from IMDS);
+    # ec2 adds instance-id/region/AZ/type.
+    detectors: [env, ec2]
     timeout: 5s
-    ec2:
-      tags: ["^Name$"]
   cumulativetodelta/cwagent: {}
   batch/cwagent: {}
 exporters:
@@ -478,6 +478,13 @@ cat > /usr/local/bin/cloudwatch-otel-apply.sh << 'OTELAPPLY'
 set -euo pipefail
 REGION=$(/usr/local/bin/call-ec2-hypervisor latest/meta-data/placement/region)
 echo "AWS_REGION=${REGION}" > /etc/default/amazon-cloudwatch-agent-otel
+# Read the instance Name tag from IMDS (present only if the launcher enabled
+# InstanceMetadataTags) and hand it to the collector's env detector as a resource
+# attribute. Absent tag -> no Name label, instance-id still identifies the box.
+NAME=$(/usr/local/bin/call-ec2-hypervisor latest/meta-data/tags/instance/Name 2>/dev/null || true)
+if [ -n "${NAME}" ]; then
+    echo "OTEL_RESOURCE_ATTRIBUTES=ec2.tag.Name=${NAME}" >> /etc/default/amazon-cloudwatch-agent-otel
+fi
 export AWS_REGION="${REGION}"
 ctl=/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl
 "$ctl" -a fetch-config -c file:/opt/aws/amazon-cloudwatch-agent/etc/cw-base.json

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -470,9 +470,11 @@ echo '{"agent":{}}' > /opt/aws/amazon-cloudwatch-agent/etc/cw-base.json
 # the endpoint, which isn't running at build time. Persists in pmxcfs (baked in).
 printf 'opentelemetry: cloudwatch-otel\n\tserver 127.0.0.1\n\tport 4318\n\totel-protocol http\n\totel-path /v1/metrics\n\totel-compression gzip\n' >> /etc/pve/status.cfg
 
-# First-boot setup: resolve region from IMDS, then translate + start the agent. Done
-# at boot (not build) so ${env:AWS_REGION} resolves to the launch region and the agent
-# is never started (nor the endpoint tested) at build time.
+# Boot-time setup (runs every boot): resolve region from IMDS, then translate +
+# start the agent. Done at boot (not build) so ${env:AWS_REGION} resolves to the
+# launch region and the agent is never started (nor the endpoint tested) at build
+# time. fetch-config(base) + append-config is idempotent, so re-running each boot
+# re-resolves region/Name (e.g. on AMI relaunch) without duplicating the pipeline.
 cat > /usr/local/bin/cloudwatch-otel-apply.sh << 'OTELAPPLY'
 #!/bin/bash
 set -euo pipefail

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -417,6 +417,98 @@ systemctl enable proxmox-ami-fixup-nat.service
 systemctl enable proxmox-ami-fixup-password.service
 systemctl enable proxmox-ami-fixup-firewall.service
 
+# ===== CloudWatch OTLP metrics collector =====
+# Ship pvestatd's metrics to the CloudWatch OTLP endpoint via a localhost CloudWatch
+# agent, SigV4-signed with the instance role (needs cloudwatch:PutMetricData; 403s
+# harmlessly without it). cumulativetodelta is required -- PVE emits cumulative sums
+# without StartTimeUnixNano, which CloudWatch rejects. The build only STAGES files;
+# all runtime steps (region from IMDS, agent config + start) happen at first boot, so
+# we never start the agent or connection-test the endpoint at build time.
+#
+# resourcedetection tags every datapoint with the EC2 instance-id and (via tags) the
+# instance Name tag, so metrics are distinguishable per box without renaming the PVE
+# node. The Name tag is fetched via the DescribeTags API, so the instance role needs
+# ec2:DescribeTags (without it the agent still runs and exports instance-id, just no
+# Name). Do NOT add tags_from_imds: the CloudWatch agent's embedded collector rejects
+# that key and refuses to start.
+curl -fsSL "https://amazoncloudwatch-agent.s3.amazonaws.com/debian/amd64/latest/amazon-cloudwatch-agent.deb" \
+    -o /tmp/cwagent.deb
+dpkg -i /tmp/cwagent.deb
+
+cat > /opt/aws/amazon-cloudwatch-agent/etc/otel-metrics.yaml << 'OTELYAML'
+receivers:
+  otlp/cwagent:
+    protocols:
+      http:
+        endpoint: 127.0.0.1:4318
+processors:
+  resourcedetection/cwagent:
+    detectors: [ec2]
+    timeout: 5s
+    ec2:
+      tags: ["^Name$"]
+  cumulativetodelta/cwagent: {}
+  batch/cwagent: {}
+exporters:
+  otlphttp/cwagent:
+    metrics_endpoint: "https://monitoring.${env:AWS_REGION}.amazonaws.com/v1/metrics"
+    compression: gzip
+    auth: { authenticator: sigv4auth/cwagent }
+extensions:
+  sigv4auth/cwagent: { service: monitoring, region: "${env:AWS_REGION}" }
+service:
+  extensions: [sigv4auth/cwagent]
+  pipelines:
+    metrics/cwagent:
+      receivers: [otlp/cwagent]
+      processors: [resourcedetection/cwagent, cumulativetodelta/cwagent, batch/cwagent]
+      exporters: [otlphttp/cwagent]
+OTELYAML
+echo '{"agent":{}}' > /opt/aws/amazon-cloudwatch-agent/etc/cw-base.json
+
+# pvestatd -> local collector. Write status.cfg directly: `pvesh create` connection-tests
+# the endpoint, which isn't running at build time. Persists in pmxcfs (baked in).
+printf 'opentelemetry: cloudwatch-otel\n\tserver 127.0.0.1\n\tport 4318\n\totel-protocol http\n\totel-path /v1/metrics\n\totel-compression gzip\n' >> /etc/pve/status.cfg
+
+# First-boot setup: resolve region from IMDS, then translate + start the agent. Done
+# at boot (not build) so ${env:AWS_REGION} resolves to the launch region and the agent
+# is never started (nor the endpoint tested) at build time.
+cat > /usr/local/bin/cloudwatch-otel-apply.sh << 'OTELAPPLY'
+#!/bin/bash
+set -euo pipefail
+REGION=$(/usr/local/bin/call-ec2-hypervisor latest/meta-data/placement/region)
+echo "AWS_REGION=${REGION}" > /etc/default/amazon-cloudwatch-agent-otel
+export AWS_REGION="${REGION}"
+ctl=/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl
+"$ctl" -a fetch-config -c file:/opt/aws/amazon-cloudwatch-agent/etc/cw-base.json
+"$ctl" -a append-config -c file:/opt/aws/amazon-cloudwatch-agent/etc/otel-metrics.yaml -s
+OTELAPPLY
+chmod +x /usr/local/bin/cloudwatch-otel-apply.sh
+
+# The agent service reads AWS_REGION (written above) so otelcol resolves ${env:AWS_REGION}.
+mkdir -p /etc/systemd/system/amazon-cloudwatch-agent.service.d
+cat > /etc/systemd/system/amazon-cloudwatch-agent.service.d/otel-region.conf << 'OTELDROPIN'
+[Service]
+EnvironmentFile=/etc/default/amazon-cloudwatch-agent-otel
+OTELDROPIN
+
+cat > /etc/systemd/system/cloudwatch-otel-apply.service << 'OTELAPPLYUNIT'
+[Unit]
+Description=Configure and start the CloudWatch agent OTel pipeline
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/cloudwatch-otel-apply.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+OTELAPPLYUNIT
+systemctl daemon-reload
+systemctl enable cloudwatch-otel-apply.service
+
 echo "PROXMOX INSTALL COMPLETE: $(pveversion)"
 
 # Final reboot: pvenetcommit.service will promote interfaces.new -> interfaces


### PR DESCRIPTION
Bakes a CloudWatch OTLP metrics collector into the EC2 build. A localhost CloudWatch agent ships pvestatd's metrics to `monitoring.<region>.amazonaws.com/v1/metrics`, SigV4-signed with the instance role.

`resourcedetection` tags every datapoint with the EC2 instance-id and the instance `Name` (surfaced as the `ec2.tag.Name` label), so metrics are distinguishable per box while the node stays `proxmox`. 

The Name is read from **IMDS instance tags** at boot
- Requires the launch to enable `InstanceMetadataTags`
- Do **not** use the ec2 detector's `tags_from_imds`: the CloudWatch agent's embedded collector rejects the key.

