### PR TITLE
fix: handle `exec` killing it's own wrapper process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError` (#75)
+- Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
 
 ## 0.11.0 - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError` (#75)
+
 ## 0.11.0 - 2026-06-01
 
 - Faster large `write_file` on Linux via hot-plugged ISO (reserves `sata5` on sandbox VMs); falls back to the guest-agent path on failure

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -784,14 +784,8 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             )["content"]
             returncode = await self._read_return_code(tmp_start)
             if returncode is None:
-                # exited==1 but the wrapper never wrote its returncode file: it was
-                # killed before completion. This happens when the command kills
-                # processes by name (e.g. `pkill -f script.sh`) and matches the
-                # wrapper's own command line (`pkill -f` spares its own PID but not its
-                # parent). Recover gracefully rather than misreporting a timeout (the
-                # old 124 sentinel did exactly that). Use the signal if exec-status
-                # still carries it; the PID-gone fallback strips it, in which case we
-                # assume a SIGKILL-class kill (137).
+                # exec exited but the wrapper never wrote its returncode file: it was
+                # killed before completion.
                 signal_num = (
                     exec_status.get("signal") if isinstance(exec_status, Dict) else None
                 )
@@ -850,11 +844,6 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     @tenacity.retry(
         wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
         stop=tenacity.stop_after_delay(2),
-        # Returns None if the file never becomes readable within the window. A genuine
-        # `timeout` writes a non-empty "124" (the wrapper survives and records it), so
-        # this exhaustion path is only reached when the wrapper itself died without
-        # writing the file; the caller maps None to a graceful failure. (Must not return
-        # 124 here: it would be indistinguishable from a real timeout.)
         retry_error_callback=lambda retry_state: None,
     )
     async def _read_return_code(self, tmp_start) -> int | None:

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -783,12 +783,42 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 )
             )["content"]
             returncode = await self._read_return_code(tmp_start)
-            exec_response = ExecResult(
-                success=returncode == 0,
-                returncode=returncode,
-                stdout=stdout,
-                stderr=stderr,
-            )
+            if returncode is None:
+                # exited==1 but the wrapper never wrote its returncode file: it was
+                # killed before completion. This happens when the command kills
+                # processes by name (e.g. `pkill -f script.sh`) and matches the
+                # wrapper's own command line (`pkill -f` spares its own PID but not its
+                # parent). Recover gracefully rather than misreporting a timeout (the
+                # old 124 sentinel did exactly that). Use the signal if exec-status
+                # still carries it; the PID-gone fallback strips it, in which case we
+                # assume a SIGKILL-class kill (137).
+                signal_num = (
+                    exec_status.get("signal") if isinstance(exec_status, Dict) else None
+                )
+                returncode = 128 + signal_num if signal_num else 137
+                if signal_num:
+                    killed_note = (
+                        f"proxmox sandbox: command-runner wrapper terminated by signal "
+                        f"{signal_num} before completion; reporting code {returncode}."
+                    )
+                else:
+                    killed_note = (
+                        "proxmox sandbox: command-runner wrapper terminated before "
+                        "writing an exit code (likely killed by the command itself)."
+                    )
+                exec_response = ExecResult(
+                    success=False,
+                    returncode=returncode,
+                    stdout=stdout,
+                    stderr=f"{stderr}\n{killed_note}" if stderr else killed_note,
+                )
+            else:
+                exec_response = ExecResult(
+                    success=returncode == 0,
+                    returncode=returncode,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
 
         # cleanup - we don't need to wait for the result of this
         if is_windows:
@@ -820,9 +850,14 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     @tenacity.retry(
         wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
         stop=tenacity.stop_after_delay(2),
-        retry_error_callback=lambda retry_state: 124,
+        # Returns None if the file never becomes readable within the window. A genuine
+        # `timeout` writes a non-empty "124" (the wrapper survives and records it), so
+        # this exhaustion path is only reached when the wrapper itself died without
+        # writing the file; the caller maps None to a graceful failure. (Must not return
+        # 124 here: it would be indistinguishable from a real timeout.)
+        retry_error_callback=lambda retry_state: None,
     )
-    async def _read_return_code(self, tmp_start):
+    async def _read_return_code(self, tmp_start) -> int | None:
         returncode_string = (
             await self.agent_commands.read_file_or_blank(
                 vm_id=self.vm_id,

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -44,6 +44,10 @@ from proxmoxsandbox.schema import (
 _INLINE_STDIN_LIMIT = 30 * 1024
 
 
+class ReturnCodeNotWritten(Exception):
+    """The exec wrapper exited without writing its returncode file."""
+
+
 @sandboxenv(name="proxmox")
 class ProxmoxSandboxEnvironment(SandboxEnvironment):
     """An Inspect sandbox environment for Proxmox virtual machines."""
@@ -782,8 +786,15 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                     max_size=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
                 )
             )["content"]
-            returncode = await self._read_return_code(tmp_start)
-            if returncode is None:
+            try:
+                returncode = await self._read_return_code(tmp_start)
+                exec_response = ExecResult(
+                    success=returncode == 0,
+                    returncode=returncode,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            except ReturnCodeNotWritten:
                 # exec exited but the wrapper never wrote its returncode file: it was
                 # killed before completion.
                 signal_num = (
@@ -805,13 +816,6 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                     returncode=returncode,
                     stdout=stdout,
                     stderr=f"{stderr}\n{killed_note}" if stderr else killed_note,
-                )
-            else:
-                exec_response = ExecResult(
-                    success=returncode == 0,
-                    returncode=returncode,
-                    stdout=stdout,
-                    stderr=stderr,
                 )
 
         # cleanup - we don't need to wait for the result of this
@@ -844,9 +848,9 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     @tenacity.retry(
         wait=tenacity.wait_exponential(min=0.1, exp_base=1.3),
         stop=tenacity.stop_after_delay(2),
-        retry_error_callback=lambda retry_state: None,
+        reraise=True,
     )
-    async def _read_return_code(self, tmp_start) -> int | None:
+    async def _read_return_code(self, tmp_start) -> int:
         returncode_string = (
             await self.agent_commands.read_file_or_blank(
                 vm_id=self.vm_id,
@@ -856,7 +860,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         )["content"]
         returncode_string_stripped = returncode_string.strip()
         if len(returncode_string_stripped) == 0:
-            raise ValueError("Return code file is empty")
+            raise ReturnCodeNotWritten()
         return int(returncode_string_stripped)
 
     # Platform-specific "file not found" messages from the QEMU guest agent.

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -99,6 +99,23 @@ async def test_self_check(
     )
 
 
+async def test_exec_self_kill_degrades_gracefully(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    # GH #75: a command that kills processes by name can match and kill its own
+    # wrapper shell. exec() must report a failed result rather than raise, and the
+    # sandbox must survive for subsequent execs.
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("signal kill is POSIX-only")
+
+    result = await proxmox_sandbox_environment.exec(["sh", "-c", "pkill -f script.sh"])
+    assert result.success is False
+    assert result.returncode in (143, 137)  # 128+SIGTERM / 128+SIGKILL
+
+    after = await proxmox_sandbox_environment.exec(["echo", "alive"])
+    assert after.success and after.stdout.strip() == "alive"
+
+
 async def check_results_of_self_check(sandbox_env, known_failures=[]):
     self_check_results = await self_check(sandbox_env)
     failures = []

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -102,9 +102,6 @@ async def test_self_check(
 async def test_exec_self_kill_degrades_gracefully(
     proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
 ) -> None:
-    # GH #75: a command that kills processes by name can match and kill its own
-    # wrapper shell. exec() must report a failed result rather than raise, and the
-    # sandbox must survive for subsequent execs.
     if proxmox_sandbox_environment._is_windows():
         pytest.skip("signal kill is POSIX-only")
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "agent-client-protocol"
 version = "0.10.1"
@@ -533,7 +537,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3106,7 +3110,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard" },
+    { name = "zstandard", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -7,10 +7,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "agent-client-protocol"
 version = "0.10.1"
@@ -537,7 +533,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3110,7 +3106,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard", marker = "python_full_version < '3.15'" },
+    { name = "zstandard" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [


### PR DESCRIPTION
Closes #75 

## Description

This PR explicitly handles the case where the command on the sandbox kills it's own wrapper process, by checking exit codes when process before the return code was written, and returning the relevant exit code rather than allowing errors to escalate.