### PR TITLE
fix: chunk file writes on exec

### DIFF
--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -43,6 +43,10 @@ from proxmoxsandbox.schema import (
 # for derivation); 30 KiB leaves a little headroom for env/cwd/etc. overhead.
 _INLINE_STDIN_LIMIT = 30 * 1024
 
+# Raw bytes per exec-wrapper-script chunk; base64 stays under the 61440-char
+# agent/file-write cap.
+_SCRIPT_CHUNK_SIZE = 40 * 1024
+
 _IN_GUEST_KILL_GRACE = 5
 
 # Poll past the in-guest `timeout -k {_IN_GUEST_KILL_GRACE}s` SIGKILL (at timeout+5s)
@@ -714,9 +718,11 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 timeout=timeout,
             )
             script_path = f"{tmp_start}script.bat"
-            await self._write_file_only(script_path, script)
+            launch = await self._upload_exec_script(
+                script_path, script, is_windows=True
+            )
             exec_post_response = await self.agent_commands.exec_command(
-                vm_id=self.vm_id, command=["cmd.exe", "/c", script_path]
+                vm_id=self.vm_id, command=launch
             )
         else:
             # Inlined stdin is base64-encoded into the script, which itself
@@ -753,9 +759,11 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 timeout=timeout,
                 stdin_file=stdin_file,
             )
-            await self._write_file_only(f"{tmp_start}script.sh", script)
+            launch = await self._upload_exec_script(
+                f"{tmp_start}script.sh", script, is_windows=False
+            )
             exec_post_response = await self.agent_commands.exec_command(
-                vm_id=self.vm_id, command=["sh", f"{tmp_start}script.sh"]
+                vm_id=self.vm_id, command=launch
             )
 
         exec_response_pid = exec_post_response["pid"]
@@ -930,6 +938,49 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                     raise ex
             else:
                 raise ex
+
+    async def _upload_exec_script(
+        self, script_path: str, script: str, is_windows: bool
+    ) -> List[str]:
+        """Upload the exec wrapper script; return the command that runs it.
+
+        Bootstrap-safe: uses only _write_file_only and agent_commands.exec_command,
+        never self.exec / self.write_file (those re-enter exec and would recurse).
+        """
+        data = script.encode("utf-8")
+        if len(data) <= _SCRIPT_CHUNK_SIZE:
+            await self._write_file_only(script_path, data)
+            return (
+                ["cmd.exe", "/c", script_path]
+                if is_windows
+                else ["sh", script_path]
+            )
+
+        chunks = [
+            data[i : i + _SCRIPT_CHUNK_SIZE]
+            for i in range(0, len(data), _SCRIPT_CHUNK_SIZE)
+        ]
+        width = len(str(len(chunks) - 1))
+        for i, chunk in enumerate(chunks):
+            await self._write_file_only(f"{script_path}.part{i:0{width}d}", chunk)
+
+        if is_windows:
+            parts = "+".join(
+                f'"{script_path}.part{i:0{width}d}"' for i in range(len(chunks))
+            )
+            return [
+                "cmd.exe",
+                "/c",
+                f'copy /b {parts} "{script_path}" >nul && "{script_path}"',
+            ]
+        # zero-padded names sort correctly under the glob, so cat reassembles in
+        # order; the combine runs in the SAME launched command we already poll —
+        # no extra wait.
+        return [
+            "sh",
+            "-c",
+            f"cat {script_path}.part* > {script_path} && exec sh {script_path}",
+        ]
 
     # Above this size, write_file uses the ISO fast path; below it, chunked
     # QGA. Not a true crossover: benchmarking (live ubuntu24.04) found ISO

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -1080,6 +1080,10 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         if await self._try_iso_write(file, contents):
             return
 
+        content_bytes = (
+            contents if isinstance(contents, bytes) else contents.encode("utf-8")
+        )
+
         # Create parent directory
         if is_windows:
             parent_dir = str(PureWindowsPath(file).parent)
@@ -1096,18 +1100,12 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             )
 
         # If content is small enough, write directly
-        if len(contents) <= _WRITE_CHUNK_SIZE:
-            await self._write_file_only(file, contents)
+        if len(content_bytes) <= _WRITE_CHUNK_SIZE:
+            await self._write_file_only(file, content_bytes)
             return
 
         # For large contents, split into chunks
-        chunks = [
-            contents[i : i + _WRITE_CHUNK_SIZE]
-            for i in range(0, len(contents), _WRITE_CHUNK_SIZE)
-        ]
-
-        # Calculate padding width based on number of chunks
-        padding_width = len(str(len(chunks) - 1))
+        chunks, padding_width = _split_chunks(content_bytes)
 
         # Use appropriate temp directory
         if is_windows:

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -43,9 +43,12 @@ from proxmoxsandbox.schema import (
 # for derivation); 30 KiB leaves a little headroom for env/cwd/etc. overhead.
 _INLINE_STDIN_LIMIT = 30 * 1024
 
-# Raw bytes per exec-wrapper-script chunk; base64 stays under the 61440-char
-# agent/file-write cap.
-_SCRIPT_CHUNK_SIZE = 40 * 1024
+# 40KB chunks to be safe, to take base64 encoding into account
+# note this 40KB limit was based on the Proxmox <=8.3 limit of
+# 60Kb, but this was increased in Proxmox 8.4, so could
+# potentially be increased here. Would need to check the
+# version number to ensure backward compatibility.
+_WRITE_CHUNK_SIZE = 40 * 1024
 
 _IN_GUEST_KILL_GRACE = 5
 
@@ -948,17 +951,13 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         never self.exec / self.write_file (those re-enter exec and would recurse).
         """
         data = script.encode("utf-8")
-        if len(data) <= _SCRIPT_CHUNK_SIZE:
+        if len(data) <= _WRITE_CHUNK_SIZE:
             await self._write_file_only(script_path, data)
-            return (
-                ["cmd.exe", "/c", script_path]
-                if is_windows
-                else ["sh", script_path]
-            )
+            return ["cmd.exe", "/c", script_path] if is_windows else ["sh", script_path]
 
         chunks = [
-            data[i : i + _SCRIPT_CHUNK_SIZE]
-            for i in range(0, len(data), _SCRIPT_CHUNK_SIZE)
+            data[i : i + _WRITE_CHUNK_SIZE]
+            for i in range(0, len(data), _WRITE_CHUNK_SIZE)
         ]
         width = len(str(len(chunks) - 1))
         for i, chunk in enumerate(chunks):
@@ -995,14 +994,6 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     async def write_file(self, file: str, contents: str | bytes) -> None:
         # Writes contents to file, handling large files by splitting them into chunks
         # and recombining using cat (Linux) or copy /b (Windows).
-
-        CHUNK_SIZE = (
-            40 * 1024
-        )  # 40KB chunks to be safe, to take base64 encoding into account
-        # note this 40KB limit was based on the Proxmox <=8.3 limit of
-        # 60Kb, but this was increased in Proxmox 8.4, so could
-        # potentially be increased here. Would need to check the
-        # version number to ensure backward compatibility.
 
         is_windows = self._is_windows()
 
@@ -1072,13 +1063,13 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             )
 
         # If content is small enough, write directly
-        if len(contents) <= CHUNK_SIZE:
+        if len(contents) <= _WRITE_CHUNK_SIZE:
             await self._write_file_only(file, contents)
             return
 
         # For large contents, split into chunks
         chunks = [
-            contents[i : i + CHUNK_SIZE] for i in range(0, len(contents), CHUNK_SIZE)
+            contents[i : i + _WRITE_CHUNK_SIZE] for i in range(0, len(contents), _WRITE_CHUNK_SIZE)
         ]
 
         # Calculate padding width based on number of chunks

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -52,6 +52,14 @@ _WRITE_CHUNK_SIZE = 40 * 1024
 
 _IN_GUEST_KILL_GRACE = 5
 
+
+def _split_chunks(
+    data: bytes, size: int = _WRITE_CHUNK_SIZE
+) -> Tuple[List[bytes], int]:
+    chunks = [data[i : i + size] for i in range(0, len(data), size)]
+    return chunks, len(str(len(chunks) - 1))
+
+
 # Poll past the in-guest `timeout -k {_IN_GUEST_KILL_GRACE}s` SIGKILL (at timeout+5s)
 # so we observe the real exit instead of catching the command mid-shutdown.
 _EXEC_POLL_GRACE_SECONDS = _IN_GUEST_KILL_GRACE + 3
@@ -947,19 +955,26 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     ) -> List[str]:
         """Upload the exec wrapper script; return the command that runs it.
 
-        Bootstrap-safe: uses only _write_file_only and agent_commands.exec_command,
-        never self.exec / self.write_file (those re-enter exec and would recurse).
+        Tries write_file's ISO fast path first (>=128 KiB, Linux) and otherwise
+        falls back to chunked QGA. Bootstrap-safe: reaches only _try_iso_write
+        (→ IsoWriter, which never calls self.exec), _write_file_only, and
+        _split_chunks — never self.exec / self.write_file, which re-enter exec
+        and would recurse.
         """
         data = script.encode("utf-8")
+        launch = ["cmd.exe", "/c", script_path] if is_windows else ["sh", script_path]
+
+        # Reuse write_file's ISO fast path. On success the whole script is already
+        # in the guest; just launch it. _try_iso_write is bootstrap-safe (no
+        # self.exec), so this does not re-enter exec().
+        if await self._try_iso_write(script_path, data):
+            return launch
+
         if len(data) <= _WRITE_CHUNK_SIZE:
             await self._write_file_only(script_path, data)
-            return ["cmd.exe", "/c", script_path] if is_windows else ["sh", script_path]
+            return launch
 
-        chunks = [
-            data[i : i + _WRITE_CHUNK_SIZE]
-            for i in range(0, len(data), _WRITE_CHUNK_SIZE)
-        ]
-        width = len(str(len(chunks) - 1))
+        chunks, width = _split_chunks(data)
         for i, chunk in enumerate(chunks):
             await self._write_file_only(f"{script_path}.part{i:0{width}d}", chunk)
 
@@ -972,9 +987,11 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 "/c",
                 f'copy /b {parts} "{script_path}" >nul && "{script_path}"',
             ]
+        # Reassembly stays inline in the launched command rather than reusing
+        # write_file's combine: that combine runs via self.exec (+ an
+        # unconditional parent mkdir), which re-enters exec() -> here and recurses.
         # zero-padded names sort correctly under the glob, so cat reassembles in
-        # order; the combine runs in the SAME launched command we already poll —
-        # no extra wait.
+        # order; the combine runs in the SAME launched command we already poll.
         return [
             "sh",
             "-c",
@@ -990,6 +1007,65 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     # exercised on the normal route. Linux only — Windows always chunks.
     ISO_WRITE_THRESHOLD_BYTES = 128 * 1024
 
+    async def _try_iso_write(self, file: str, contents: str | bytes) -> bool:
+        """Attempt the Linux ISO9660 hot-plug fast path. True iff fully written via ISO.
+
+        Bootstrap-safe: IsoWriter uses only QGA + storage HTTP and does its own
+        in-guest parent mkdir, so this is safe to call from the exec() path (no
+        self.exec re-entry).
+
+        Returns False when skipped (Windows / sub-threshold / already disabled) or
+        when the ISO attempt fails — in which case the fast path is disabled for the
+        rest of this VM's life and the caller falls through to chunked QGA.
+        """
+        if (
+            self._is_windows()
+            or len(contents) < self.ISO_WRITE_THRESHOLD_BYTES
+            or self._iso_fast_path_disabled
+        ):
+            return False
+        # Hold the per-VM lock for the whole attach/copy/detach: it's a single
+        # shared sata5 slot, so concurrent writes must serialise.
+        async with self._iso_write_lock:
+            # Re-check under the lock: a write we queued behind may have already
+            # tripped the failure and disabled the fast path, in which case fall
+            # straight through to chunked QGA.
+            if self._iso_fast_path_disabled:
+                return False
+            try:
+                content_bytes = (
+                    contents
+                    if isinstance(contents, bytes)
+                    else contents.encode("utf-8")
+                )
+                iso_writer = IsoWriter(
+                    async_proxmox=self.infra_commands.async_proxmox,
+                    agent_commands=self.agent_commands,
+                    storage_commands=self.qemu_commands.storage_commands,
+                    node=self.infra_commands.node,
+                )
+                await iso_writer.write_file(self.vm_id, file, content_bytes)
+                return True
+            except Exception as ex:
+                # Persistent failure (iso_write already retried the first-call
+                # "Can't open blockdev" race internally via detach + re-attach).
+                # Usual causes: the VM template repurposed the sata5 slot; full
+                # `local` storage so the ISO upload fails; or the guest kernel
+                # refusing optical opens (dmesg shows AHCI / "Can't open
+                # blockdev"). Disable for this VM's lifetime so we don't re-pay
+                # ~3 s of ISO build+upload+attach on every subsequent large
+                # write; fall through to chunked QGA.
+                self._iso_fast_path_disabled = True
+                self.logger.warning(
+                    "iso_write fast path disabled for VM %s (writing %s); using "
+                    "the chunked-QGA fallback for the rest of this VM's life. "
+                    "Underlying error: %s",
+                    self.vm_id,
+                    file,
+                    ex,
+                )
+                return False
+
     @override
     async def write_file(self, file: str, contents: str | bytes) -> None:
         # Writes contents to file, handling large files by splitting them into chunks
@@ -997,55 +1073,12 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
 
         is_windows = self._is_windows()
 
-        # Linux large-file fast path: hot-plug ISO instead of chunked QGA.
-        # Skips the parent-mkdir round-trip below — the in-guest ISO script
-        # does its own `mkdir -p -- "$(dirname target)"`, so doing it here
-        # too is one whole env.exec() (~2s of QGA round-trips) wasted.
-        if (
-            not is_windows
-            and len(contents) >= self.ISO_WRITE_THRESHOLD_BYTES
-            and not self._iso_fast_path_disabled
-        ):
-            # Hold the per-VM lock for the whole attach/copy/detach: it's a
-            # single shared sata5 slot, so concurrent writes must serialise.
-            async with self._iso_write_lock:
-                # Re-check under the lock: a write we queued behind may have
-                # already tripped the failure and disabled the fast path,
-                # in which case fall straight through to chunked QGA.
-                if not self._iso_fast_path_disabled:
-                    try:
-                        content_bytes = (
-                            contents
-                            if isinstance(contents, bytes)
-                            else contents.encode("utf-8")
-                        )
-                        iso_writer = IsoWriter(
-                            async_proxmox=self.infra_commands.async_proxmox,
-                            agent_commands=self.agent_commands,
-                            storage_commands=self.qemu_commands.storage_commands,
-                            node=self.infra_commands.node,
-                        )
-                        await iso_writer.write_file(self.vm_id, file, content_bytes)
-                        return
-                    except Exception as ex:
-                        # Persistent failure (iso_write already retried the
-                        # first-call "Can't open blockdev" race internally via
-                        # detach + re-attach). Usual causes: the VM template
-                        # repurposed the sata5 slot; full `local` storage so
-                        # the ISO upload fails; or the guest kernel refusing
-                        # optical opens (dmesg shows AHCI / "Can't open
-                        # blockdev"). Disable for this VM's lifetime so we
-                        # don't re-pay ~3 s of ISO build+upload+attach on every
-                        # subsequent large write; fall through to chunked QGA.
-                        self._iso_fast_path_disabled = True
-                        self.logger.warning(
-                            "iso_write fast path disabled for VM %s (writing "
-                            "%s); using the chunked-QGA fallback for the rest "
-                            "of this VM's life. Underlying error: %s",
-                            self.vm_id,
-                            file,
-                            ex,
-                        )
+        # Linux large-file fast path: hot-plug ISO instead of chunked QGA. Skips
+        # the parent-mkdir round-trip below — the in-guest ISO script does its own
+        # `mkdir -p -- "$(dirname target)"`, so doing it here too would waste one
+        # whole env.exec() (~2s of QGA round-trips).
+        if await self._try_iso_write(file, contents):
+            return
 
         # Create parent directory
         if is_windows:
@@ -1069,7 +1102,8 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
 
         # For large contents, split into chunks
         chunks = [
-            contents[i : i + _WRITE_CHUNK_SIZE] for i in range(0, len(contents), _WRITE_CHUNK_SIZE)
+            contents[i : i + _WRITE_CHUNK_SIZE]
+            for i in range(0, len(contents), _WRITE_CHUNK_SIZE)
         ]
 
         # Calculate padding width based on number of chunks

--- a/tests/proxmoxsandboxtest/test_exec_script_chunking.py
+++ b/tests/proxmoxsandboxtest/test_exec_script_chunking.py
@@ -1,0 +1,105 @@
+"""_upload_exec_script chunks oversize wrapper scripts under the file-write cap.
+
+A single agent/file-write caps base64 `content` at 61440 chars, so a large
+command (its wrapper script > ~45 KiB raw) must be split across multiple writes
+and reassembled inside the launched command. These tests drive that logic with
+mocked QGA collaborators — no live VM.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from proxmoxsandbox import _proxmox_sandbox_environment as mod
+from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
+
+
+def _make_sandbox() -> ProxmoxSandboxEnvironment:
+    return ProxmoxSandboxEnvironment(
+        infra_commands=MagicMock(),
+        agent_commands=MagicMock(),
+        ipam_mappings=(),
+        vm_id=100,
+        all_vm_ids=(100,),
+        sdn_zone_id=None,
+        instance=None,
+        pool_id=None,
+        os_type="l26",
+    )
+
+
+_LINUX = (False, "/tmp/proxmox_script.sh")
+_WINDOWS = (True, r"C:\Windows\Temp\proxmox_script.bat")
+_OS_PARAMS = [pytest.param(*_LINUX, id="linux"), pytest.param(*_WINDOWS, id="windows")]
+
+
+@pytest.mark.parametrize("is_windows,script_path", _OS_PARAMS)
+async def test_small_script_single_write(is_windows: bool, script_path: str) -> None:
+    env = _make_sandbox()
+    env._write_file_only = AsyncMock()  # type: ignore[method-assign]
+
+    script = "a" * (mod._SCRIPT_CHUNK_SIZE - 100)
+    launch = await env._upload_exec_script(script_path, script, is_windows=is_windows)
+
+    env._write_file_only.assert_awaited_once_with(script_path, script.encode("utf-8"))
+    assert launch == (
+        ["cmd.exe", "/c", script_path] if is_windows else ["sh", script_path]
+    )
+
+
+@pytest.mark.parametrize("is_windows,script_path", _OS_PARAMS)
+async def test_large_script_chunked_and_reassembled(
+    is_windows: bool, script_path: str
+) -> None:
+    env = _make_sandbox()
+    env._write_file_only = AsyncMock()  # type: ignore[method-assign]
+
+    data = ("a" * (130 * 1024)).encode("utf-8")
+    expected_chunks = -(-len(data) // mod._SCRIPT_CHUNK_SIZE)
+    assert expected_chunks > 1
+    width = len(str(expected_chunks - 1))
+
+    launch = await env._upload_exec_script(
+        script_path, data.decode("utf-8"), is_windows=is_windows
+    )
+
+    written_paths = [c.args[0] for c in env._write_file_only.await_args_list]
+    expected_paths = [
+        f"{script_path}.part{i:0{width}d}" for i in range(expected_chunks)
+    ]
+    assert written_paths == expected_paths
+    # Round-tripping the written chunks must reproduce the original script bytes.
+    assert b"".join(c.args[1] for c in env._write_file_only.await_args_list) == data
+
+    if is_windows:
+        parts = "+".join(f'"{p}"' for p in expected_paths)
+        assert launch == [
+            "cmd.exe",
+            "/c",
+            f'copy /b {parts} "{script_path}" >nul && "{script_path}"',
+        ]
+    else:
+        assert launch == [
+            "sh",
+            "-c",
+            f"cat {script_path}.part* > {script_path} && exec sh {script_path}",
+        ]
+
+
+@pytest.mark.parametrize("is_windows,script_path", _OS_PARAMS)
+async def test_chunked_upload_does_not_re_enter_exec(
+    is_windows: bool, script_path: str
+) -> None:
+    # Structural guarantee made dynamic: the upload must use only leaf QGA
+    # primitives. If anyone later routes it back through self.exec / self.write_file
+    # (which re-enter the exec primitive), it recurses without bound — fail loudly.
+    env = _make_sandbox()
+    env._write_file_only = AsyncMock()  # type: ignore[method-assign]
+    env.exec = AsyncMock()  # type: ignore[method-assign]
+    env.write_file = AsyncMock()  # type: ignore[method-assign]
+
+    script = "a" * (130 * 1024)
+    await env._upload_exec_script(script_path, script, is_windows=is_windows)
+
+    env.exec.assert_not_called()
+    env.write_file.assert_not_called()

--- a/tests/proxmoxsandboxtest/test_exec_script_chunking.py
+++ b/tests/proxmoxsandboxtest/test_exec_script_chunking.py
@@ -46,6 +46,7 @@ async def test_small_script_single_write(
 ) -> None:
     env = _make_sandbox()
     env._write_file_only = AsyncMock()  # type: ignore[method-assign]
+    env._try_iso_write = AsyncMock(return_value=False)  # type: ignore[method-assign]
 
     script = "a" * size
     launch = await env._upload_exec_script(script_path, script, is_windows=is_windows)
@@ -70,6 +71,10 @@ async def test_large_script_chunked_and_reassembled(
 ) -> None:
     env = _make_sandbox()
     env._write_file_only = AsyncMock()  # type: ignore[method-assign]
+    # Force the chunked path: above 128 KiB _upload_exec_script tries the ISO
+    # fast path first, which with MagicMock collaborators would error (and flip
+    # the disabled flag) instead of cleanly skipping.
+    env._try_iso_write = AsyncMock(return_value=False)  # type: ignore[method-assign]
 
     data = ("a" * size).encode("utf-8")
     expected_chunks = -(-len(data) // mod._WRITE_CHUNK_SIZE)
@@ -116,6 +121,7 @@ async def test_chunked_upload_does_not_re_enter_exec(
     # (which re-enter the exec primitive), it recurses without bound — fail loudly.
     env = _make_sandbox()
     env._write_file_only = AsyncMock()  # type: ignore[method-assign]
+    env._try_iso_write = AsyncMock(return_value=False)  # type: ignore[method-assign]
     env.exec = AsyncMock()  # type: ignore[method-assign]
     env.write_file = AsyncMock()  # type: ignore[method-assign]
 
@@ -124,3 +130,24 @@ async def test_chunked_upload_does_not_re_enter_exec(
 
     env.exec.assert_not_called()
     env.write_file.assert_not_called()
+
+
+@pytest.mark.parametrize("is_windows,script_path", _OS_PARAMS)
+async def test_iso_fast_path_launches_single_file(
+    is_windows: bool, script_path: str
+) -> None:
+    # When the ISO fast path writes the whole script, _upload_exec_script must
+    # just launch it — no chunking, no per-file writes. The Windows variant
+    # forces True only to exercise the branch; IsoWriter itself is Linux-only.
+    env = _make_sandbox()
+    env._write_file_only = AsyncMock()  # type: ignore[method-assign]
+    env._try_iso_write = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    script = "a" * (130 * 1024)
+    launch = await env._upload_exec_script(script_path, script, is_windows=is_windows)
+
+    env._try_iso_write.assert_awaited_once_with(script_path, script.encode("utf-8"))
+    env._write_file_only.assert_not_called()
+    assert launch == (
+        ["cmd.exe", "/c", script_path] if is_windows else ["sh", script_path]
+    )

--- a/tests/proxmoxsandboxtest/test_exec_script_chunking.py
+++ b/tests/proxmoxsandboxtest/test_exec_script_chunking.py
@@ -33,12 +33,21 @@ _WINDOWS = (True, r"C:\Windows\Temp\proxmox_script.bat")
 _OS_PARAMS = [pytest.param(*_LINUX, id="linux"), pytest.param(*_WINDOWS, id="windows")]
 
 
+# `== _WRITE_CHUNK_SIZE` is the last size that still fits one write; the chunked
+# branch starts at `+ 1`. Both boundaries are exercised so the `<=` can't drift.
+@pytest.mark.parametrize(
+    "size",
+    [mod._WRITE_CHUNK_SIZE - 100, mod._WRITE_CHUNK_SIZE],
+    ids=["under", "at-boundary"],
+)
 @pytest.mark.parametrize("is_windows,script_path", _OS_PARAMS)
-async def test_small_script_single_write(is_windows: bool, script_path: str) -> None:
+async def test_small_script_single_write(
+    is_windows: bool, script_path: str, size: int
+) -> None:
     env = _make_sandbox()
     env._write_file_only = AsyncMock()  # type: ignore[method-assign]
 
-    script = "a" * (mod._SCRIPT_CHUNK_SIZE - 100)
+    script = "a" * size
     launch = await env._upload_exec_script(script_path, script, is_windows=is_windows)
 
     env._write_file_only.assert_awaited_once_with(script_path, script.encode("utf-8"))
@@ -47,15 +56,23 @@ async def test_small_script_single_write(is_windows: bool, script_path: str) -> 
     )
 
 
+# `+ 1` is the smallest chunked script (2 parts); 11 chunks forces a two-digit
+# part index (`.part10`), which only sorts after `.part09` because the names are
+# zero-padded — the property the glob reassembly relies on.
+@pytest.mark.parametrize(
+    "size",
+    [mod._WRITE_CHUNK_SIZE + 1, 130 * 1024, 11 * mod._WRITE_CHUNK_SIZE],
+    ids=["just-over", "multi-chunk", "two-digit-index"],
+)
 @pytest.mark.parametrize("is_windows,script_path", _OS_PARAMS)
 async def test_large_script_chunked_and_reassembled(
-    is_windows: bool, script_path: str
+    is_windows: bool, script_path: str, size: int
 ) -> None:
     env = _make_sandbox()
     env._write_file_only = AsyncMock()  # type: ignore[method-assign]
 
-    data = ("a" * (130 * 1024)).encode("utf-8")
-    expected_chunks = -(-len(data) // mod._SCRIPT_CHUNK_SIZE)
+    data = ("a" * size).encode("utf-8")
+    expected_chunks = -(-len(data) // mod._WRITE_CHUNK_SIZE)
     assert expected_chunks > 1
     width = len(str(expected_chunks - 1))
 
@@ -68,6 +85,10 @@ async def test_large_script_chunked_and_reassembled(
         f"{script_path}.part{i:0{width}d}" for i in range(expected_chunks)
     ]
     assert written_paths == expected_paths
+    # The invariant the zero-padding exists for: written (= numeric) order must
+    # equal lexical order, so the shell glob reassembles chunks in sequence.
+    # Unpadded names would put `.part10` before `.part2` and fail this.
+    assert written_paths == sorted(written_paths)
     # Round-tripping the written chunks must reproduce the original script bytes.
     assert b"".join(c.args[1] for c in env._write_file_only.await_args_list) == data
 

--- a/tests/proxmoxsandboxtest/test_exec_script_chunking.py
+++ b/tests/proxmoxsandboxtest/test_exec_script_chunking.py
@@ -151,3 +151,26 @@ async def test_iso_fast_path_launches_single_file(
     assert launch == (
         ["cmd.exe", "/c", script_path] if is_windows else ["sh", script_path]
     )
+
+
+async def test_write_file_chunks_text_by_encoded_bytes() -> None:
+    env = _make_sandbox()
+    env.exec = AsyncMock()  # type: ignore[method-assign]
+    env._write_file_only = AsyncMock()  # type: ignore[method-assign]
+    env._try_iso_write = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    payload = "é" * (mod._WRITE_CHUNK_SIZE // 2 + 1)
+    data = payload.encode("utf-8")
+    assert len(payload) <= mod._WRITE_CHUNK_SIZE < len(data)
+
+    await env.write_file("/tmp/out.txt", payload)
+
+    chunk_writes = [
+        call
+        for call in env._write_file_only.await_args_list
+        if "/chunk_" in call.args[0]
+    ]
+    assert [call.args[1] for call in chunk_writes] == [
+        data[: mod._WRITE_CHUNK_SIZE],
+        data[mod._WRITE_CHUNK_SIZE :],
+    ]

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -83,6 +83,23 @@ async def test_exec_10mb_limit(
     assert len(body) > 1_000_000
 
 
+async def test_exec_large_command(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    # A command large enough that its wrapper script exceeds the 61440-char
+    # agent/file-write cap. Pre-fix this fails with HTTP 400 "value may only be
+    # 61440 characters long"; the chunked script upload must handle it.
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("large-command wrapper chunking asserted on Linux only")
+
+    payload = "a" * (100 * 1024)  # ~133 KiB base64 wrapper script, over the cap
+    result = await proxmox_sandbox_environment.exec(
+        ["echo", "-n", payload], timeout=60
+    )
+    assert result.success
+    assert result.stdout == payload
+
+
 CURRENT_DIR = Path(__file__).parent
 
 

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -86,16 +86,25 @@ async def test_exec_10mb_limit(
 async def test_exec_large_command(
     proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
 ) -> None:
-    # A command large enough that its wrapper script exceeds the 61440-char
-    # agent/file-write cap. Pre-fix this fails with HTTP 400 "value may only be
-    # 61440 characters long"; the chunked script upload must handle it.
+    # A command whose wrapper script exceeds both the 61440-char agent/file-write
+    # cap and the 128 KiB ISO threshold, so it exercises the ISO-fast-path ->
+    # chunked-QGA fallback chain end to end.
+    #
+    # Built from many medium arguments rather than one giant one: the wrapper runs
+    # the command under the external `timeout` binary, so a single ~1 MiB argument
+    # would hit MAX_ARG_STRLEN (128 KiB per argv element) and fail with E2BIG long
+    # before testing the script transport. `printf %s` cycles its format over every
+    # argument, so stdout is the chunks concatenated with no separators or newline.
     if proxmox_sandbox_environment._is_windows():
         pytest.skip("large-command wrapper chunking asserted on Linux only")
 
-    payload = "a" * (100 * 1024)  # ~133 KiB base64 wrapper script, over the cap
-    result = await proxmox_sandbox_environment.exec(["echo", "-n", payload], timeout=60)
-    assert result.success
-    assert result.stdout == payload
+    chunk = "a" * (64 * 1024)
+    n = 16  # ~1 MiB wrapper script, over both caps; each arg well under MAX_ARG_STRLEN
+    result = await proxmox_sandbox_environment.exec(
+        ["printf", "%s", *([chunk] * n)], timeout=60
+    )
+    assert result.success, f"printf failed: stderr=[{result.stderr}]"
+    assert result.stdout == chunk * n
 
 
 CURRENT_DIR = Path(__file__).parent

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -83,30 +83,6 @@ async def test_exec_10mb_limit(
     assert len(body) > 1_000_000
 
 
-async def test_exec_large_command(
-    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
-) -> None:
-    # A command whose wrapper script exceeds both the 61440-char agent/file-write
-    # cap and the 128 KiB ISO threshold, so it exercises the ISO-fast-path ->
-    # chunked-QGA fallback chain end to end.
-    #
-    # Built from many medium arguments rather than one giant one: the wrapper runs
-    # the command under the external `timeout` binary, so a single ~1 MiB argument
-    # would hit MAX_ARG_STRLEN (128 KiB per argv element) and fail with E2BIG long
-    # before testing the script transport. `printf %s` cycles its format over every
-    # argument, so stdout is the chunks concatenated with no separators or newline.
-    if proxmox_sandbox_environment._is_windows():
-        pytest.skip("large-command wrapper chunking asserted on Linux only")
-
-    chunk = "a" * (64 * 1024)
-    n = 16  # ~1 MiB wrapper script, over both caps; each arg well under MAX_ARG_STRLEN
-    result = await proxmox_sandbox_environment.exec(
-        ["printf", "%s", *([chunk] * n)], timeout=60
-    )
-    assert result.success, f"printf failed: stderr=[{result.stderr}]"
-    assert result.stdout == chunk * n
-
-
 CURRENT_DIR = Path(__file__).parent
 
 

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -93,9 +93,7 @@ async def test_exec_large_command(
         pytest.skip("large-command wrapper chunking asserted on Linux only")
 
     payload = "a" * (100 * 1024)  # ~133 KiB base64 wrapper script, over the cap
-    result = await proxmox_sandbox_environment.exec(
-        ["echo", "-n", payload], timeout=60
-    )
+    result = await proxmox_sandbox_environment.exec(["echo", "-n", payload], timeout=60)
     assert result.success
     assert result.stdout == payload
 


### PR DESCRIPTION
Closes #86 

## Description

Chunks the file write for large scripts, to avoid hitting a character limit when writing to the server. Reassembles the chunks as part of the execution command that is issued to the server.