### PR TITLE
Block Proxmox sandbox VMs from accessing EC2 instance metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
+- Prevent sandbox VMs from accessing EC2 instance metadata credentials when using the bundled provisioning scripts. Rebuild existing Proxmox AMIs/templates or apply the documented host rules to install this protection
 
 ## 0.11.0 - 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ If you don't already have a Proxmox instance, see [CONTRIBUTING.md](CONTRIBUTING
 
 By default a sandbox VM can reach the Proxmox host's own services — the API
 (`pveproxy`, port 8006), SSH, etc. — via the SDN gateway, the `vmbr0` IP, or the
-host's external NIC. For cyber evals especially, you want those blocked so agents
-can't attack the Proxmox control plane.
+host's external NIC. Forwarded traffic can also reach cloud instance metadata
+services. For cyber evals especially, you want those blocked so agents can't
+attack the Proxmox or cloud control planes.
 
 This is **configured on the host at provisioning time, not by this library** — it
 needs the host's live routing table to know which interface external API/SSH
@@ -48,10 +49,11 @@ provisioning scripts in this repo (`scripts/virtualized_proxmox/build_proxmox_au
 and `scripts/ec2/userdata.sh`) set it up automatically, so hosts you create with
 them are isolated out of the box.
 
-If you provision Proxmox some other way, run these once **on the node**. They
-accept the management ports only on the default-route interface (where external
-callers arrive) and leave SDN DNS/DHCP open; sandbox VMs sit on other bridges and
-hit the default-deny policy:
+If you provision Proxmox some other way, configure equivalent persistent rules
+**on the node**. The Proxmox rules accept management ports only on the
+default-route interface (where external callers arrive) and leave SDN DNS/DHCP
+open. The raw-table rules block forwarded sandbox traffic to the fixed EC2
+metadata endpoints without preventing host processes from using them:
 
 ```bash
 NIC=$(ip route show default | awk '{print $5}' | head -1)
@@ -62,7 +64,18 @@ pvesh create /nodes/$(hostname)/firewall/rules --type in --action ACCEPT --proto
 pvesh create /nodes/$(hostname)/firewall/rules --type in --action ACCEPT --proto udp --dport 67 --enable 1
 pvesh set /nodes/$(hostname)/firewall/options --enable 1
 pvesh set /cluster/firewall/options --enable 1
+iptables -w -t raw -C PREROUTING -d 169.254.169.254/32 -j DROP 2>/dev/null \
+    || iptables -w -t raw -I PREROUTING 1 -d 169.254.169.254/32 -j DROP
+if command -v ip6tables >/dev/null; then
+    ip6tables -w -t raw -C PREROUTING -d fd00:ec2::254/128 -j DROP 2>/dev/null \
+        || ip6tables -w -t raw -I PREROUTING 1 -d fd00:ec2::254/128 -j DROP
+fi
 ```
+
+Persist the raw-table rules across reboots using your host firewall tooling or
+a systemd unit. The bundled provisioning scripts install such a unit.
+Upgrading this package does not modify existing Proxmox hosts or templates;
+rebuild them or apply these rules manually.
 
 ### Single Proxmox Instance
 

--- a/src/proxmoxsandbox/scripts/ec2/README.md
+++ b/src/proxmoxsandbox/scripts/ec2/README.md
@@ -68,6 +68,9 @@ aws ec2 wait image-available --region "$REGION" --image-ids <ami-id>
 aws ec2 terminate-instances --region "$REGION" --instance-ids <instance-id>
 ```
 
+Rebuild AMIs created with older versions of these scripts so the persistent
+guest-to-metadata forwarding block is present on the host.
+
 ## Everyday: launch from the AMI
 
 Find the AMI ID for the latest Proxmox AMI you built:
@@ -87,7 +90,7 @@ aws ec2 run-instances --region "$REGION" \
     --cpu-options "NestedVirtualization=enabled" \
     --subnet-id "$SUBNET_ID" \
     --security-group-ids "$SECURITY_GROUP_ID" \
-    --metadata-options "InstanceMetadataTags=enabled"
+    --metadata-options "HttpTokens=required,HttpPutResponseHopLimit=1,HttpProtocolIpv6=disabled,InstanceMetadataTags=enabled"
     # add --iam-instance-profile Name=<profile> if SSM access doesn't come from DHMC
 ```
 
@@ -122,6 +125,11 @@ outbound traffic via iptables MASQUERADE. VM gateway: `10.10.10.1`. DNS:
 `169.254.169.253` (VPC resolver). VMs can't bind directly to the VPC subnet
 because EC2 only routes to IPs on attached ENIs.
 
+Sandbox forwarding to the EC2 metadata endpoints (`169.254.169.254` and
+`fd00:ec2::254`) is blocked on the Proxmox host. Processes running directly on
+the host retain IMDS access. Keep `HttpPutResponseHopLimit=1`; increasing it
+allows nested guests to receive IMDSv2 token responses.
+
 ## Metrics (CloudWatch)
 
 The instance ships a localhost CloudWatch agent that forwards Proxmox's `pvestatd`
@@ -136,8 +144,8 @@ instance-id. It is additionally labelled with the instance `Name` tag **only if
 the launcher enables instance metadata tags**. Like the hostname and root
 password (see fixup services below), this is a per-launch attribute set at
 `run-instances` time — it is **not** baked into the AMI. Pass
-`--metadata-options InstanceMetadataTags=enabled` (as `launch.sh` does for the
-build instance, and as the everyday-launch example above does) or you get
+`InstanceMetadataTags=enabled` in `--metadata-options` (as `launch.sh` does for
+the build instance, and as the everyday-launch example above does) or you get
 instance-id only.
 
 ## EC2-specific bits handled by `userdata.sh`
@@ -151,6 +159,7 @@ instance-id only.
   (see <https://forum.proxmox.com/threads/ipam-reserving-dhcp-leases-via-mac-addresses.174704/>).
 - `/run/dnsmasq/resolv.conf` shim for SDN dnsmasq DNS forwarding.
 - AMI fixup services for hostname + SSL cert + root password regeneration on every boot.
+- A boot-time firewall rule blocking sandbox forwarding to EC2 instance metadata.
 - CloudWatch OTLP metrics collector for `pvestatd` metrics — see "Metrics (CloudWatch)" above.
 
 ## Other scripts

--- a/src/proxmoxsandbox/scripts/ec2/launch.sh
+++ b/src/proxmoxsandbox/scripts/ec2/launch.sh
@@ -66,9 +66,10 @@ RUN_ARGS=(
     --cpu-options "NestedVirtualization=enabled"
     --subnet-id "$SUBNET_ID"
     --security-group-ids "$SECURITY_GROUP_ID"
-    # Expose the instance's own tags (incl. Name) via IMDS so the OTel collector
-    # can label metrics with the Name (read at boot, no ec2:DescribeTags needed).
-    --metadata-options "InstanceMetadataTags=enabled"
+    # Require IMDSv2 and keep token responses on the host. A hop limit above 1
+    # allows nested sandbox VMs to retrieve host metadata credentials.
+    # InstanceMetadataTags lets the OTel collector read the instance Name.
+    --metadata-options "HttpTokens=required,HttpPutResponseHopLimit=1,HttpProtocolIpv6=disabled,InstanceMetadataTags=enabled"
     --block-device-mappings
         "DeviceName=/dev/xvda,Ebs={VolumeSize=1024,VolumeType=gp3,DeleteOnTermination=true}"
     --user-data "fileb://$USERDATA_GZ"

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -363,6 +363,40 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 FIXUP_NAT_UNIT
 
+# Block forwarded sandbox traffic to cloud instance metadata while preserving
+# IMDS access for processes running directly on the Proxmox host. The raw table
+# sees guest packets before routing and SNAT, so this covers dynamically named
+# SDN VNet bridges as well as vmbr0.
+cat > /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh << 'BLOCK_METADATA'
+#!/bin/bash
+set -euo pipefail
+
+iptables -w -t raw -C PREROUTING -d 169.254.169.254/32 -j DROP 2>/dev/null \
+    || iptables -w -t raw -I PREROUTING 1 -d 169.254.169.254/32 -j DROP
+
+if command -v ip6tables >/dev/null; then
+    ip6tables -w -t raw -C PREROUTING -d fd00:ec2::254/128 -j DROP 2>/dev/null \
+        || ip6tables -w -t raw -I PREROUTING 1 -d fd00:ec2::254/128 -j DROP
+fi
+BLOCK_METADATA
+chmod +x /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
+
+cat > /etc/systemd/system/inspect-proxmox-block-cloud-metadata.service << 'BLOCK_METADATA_UNIT'
+[Unit]
+Description=Block sandbox forwarding to cloud instance metadata
+After=network-online.target pve-firewall.service proxmox-firewall.service
+Wants=network-online.target
+Before=proxmox-ami-fixup-nat.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+BLOCK_METADATA_UNIT
+
 # Host isolation. See root README.
 # Re-applied every boot (no marker): the node name changes per launch, so any
 # node-scoped rules baked into the AMI are orphaned under the old node name, and
@@ -416,6 +450,7 @@ systemctl enable proxmox-ami-fixup-certs.service
 systemctl enable proxmox-ami-fixup-nat.service
 systemctl enable proxmox-ami-fixup-password.service
 systemctl enable proxmox-ami-fixup-firewall.service
+systemctl enable inspect-proxmox-block-cloud-metadata.service
 
 # ===== CloudWatch OTLP metrics collector =====
 # Ship pvestatd's metrics to the CloudWatch OTLP endpoint via a localhost CloudWatch

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -255,6 +255,42 @@ pvesh create /nodes/proxmox/firewall/rules --type in --action ACCEPT --proto udp
 pvesh set /nodes/proxmox/firewall/options --enable 1
 pvesh set /cluster/firewall/options --enable 1
 
+# Block forwarded sandbox traffic to cloud instance metadata while preserving
+# metadata access for processes running directly on the Proxmox host. Install
+# this as a boot service because the template is powered off below and later
+# cloned into fresh Proxmox instances.
+cat > /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh << 'BLOCK_METADATA'
+#!/bin/bash
+set -euo pipefail
+
+iptables -w -t raw -C PREROUTING -d 169.254.169.254/32 -j DROP 2>/dev/null \
+    || iptables -w -t raw -I PREROUTING 1 -d 169.254.169.254/32 -j DROP
+
+if command -v ip6tables >/dev/null; then
+    ip6tables -w -t raw -C PREROUTING -d fd00:ec2::254/128 -j DROP 2>/dev/null \
+        || ip6tables -w -t raw -I PREROUTING 1 -d fd00:ec2::254/128 -j DROP
+fi
+BLOCK_METADATA
+chmod +x /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
+
+cat > /etc/systemd/system/inspect-proxmox-block-cloud-metadata.service << 'BLOCK_METADATA_UNIT'
+[Unit]
+Description=Block sandbox forwarding to cloud instance metadata
+After=network-online.target pve-firewall.service proxmox-firewall.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+BLOCK_METADATA_UNIT
+
+systemctl daemon-reload
+systemctl enable inspect-proxmox-block-cloud-metadata.service
+
 touch /var/local/inspect-proxmox-on-first-boot.done
 
 # shut down to signal to virt-install that installation is complete

--- a/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
+++ b/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
@@ -74,7 +74,31 @@ async def test_sandbox_vm_cannot_reach_host_or_cloud_metadata() -> None:
             f"SSH on {gw}:22 reachable from sandbox VM: {ssh_res.stdout!r}"
         )
 
-        metadata_res = await env.exec(
+        # A token PUT can time out solely because HttpPutResponseHopLimit=1,
+        # even when IMDS is reachable. A tokenless GET returns 401 when IMDSv2
+        # is required (or 200 when optional), so 000 specifically verifies that
+        # the host forwarding rule blocked the request.
+        metadata_get_res = await env.exec(
+            [
+                "curl",
+                "-sS",
+                "--max-time",
+                "5",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                "http://169.254.169.254/latest/meta-data/instance-id",
+            ],
+            timeout=15,
+        )
+        assert metadata_get_res.stdout.strip() == "000", (
+            "cloud instance metadata reachable from sandbox VM "
+            f"(curl returned http_code={metadata_get_res.stdout.strip()!r}). "
+            "Was the metadata forwarding block installed?"
+        )
+
+        metadata_token_res = await env.exec(
             [
                 "curl",
                 "-sS",
@@ -92,9 +116,9 @@ async def test_sandbox_vm_cannot_reach_host_or_cloud_metadata() -> None:
             ],
             timeout=15,
         )
-        assert metadata_res.stdout.strip() == "000", (
-            "cloud instance metadata reachable from sandbox VM "
-            f"(curl returned http_code={metadata_res.stdout.strip()!r}). "
+        assert metadata_token_res.stdout.strip() == "000", (
+            "cloud instance metadata token endpoint reachable from sandbox VM "
+            f"(curl returned http_code={metadata_token_res.stdout.strip()!r}). "
             "Was the metadata forwarding block installed?"
         )
 

--- a/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
+++ b/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
@@ -15,12 +15,14 @@ from proxmoxsandbox._proxmox_sandbox_environment import (
 from .proxmox_sandbox_utils import setup_sandbox
 
 
-async def test_sandbox_vm_cannot_reach_pveproxy_or_ssh() -> None:
-    """A sandbox VM brought up via sample_init can't curl pveproxy or SSH.
+async def test_sandbox_vm_cannot_reach_host_or_cloud_metadata() -> None:
+    """A sandbox VM can't reach host services or cloud instance metadata.
 
     The VM reaches the host over its SDN bridge, so its packets never ingress
     on the host's management interface and hit the default-deny policy — even
-    when aimed at the SDN gateway IP where pveproxy also listens.
+    when aimed at the SDN gateway IP where pveproxy also listens. Metadata
+    traffic is forwarded rather than host-bound, so provisioning also installs
+    an explicit forwarding block for the fixed metadata endpoints.
     """
     task_name = "test_host_isolation_e2e"
     config = ProxmoxSandboxEnvironmentConfig()
@@ -70,6 +72,30 @@ async def test_sandbox_vm_cannot_reach_pveproxy_or_ssh() -> None:
         )
         assert ssh_res.stdout.strip() == "blocked", (
             f"SSH on {gw}:22 reachable from sandbox VM: {ssh_res.stdout!r}"
+        )
+
+        metadata_res = await env.exec(
+            [
+                "curl",
+                "-sS",
+                "--max-time",
+                "5",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                "-X",
+                "PUT",
+                "-H",
+                "X-aws-ec2-metadata-token-ttl-seconds: 60",
+                "http://169.254.169.254/latest/api/token",
+            ],
+            timeout=15,
+        )
+        assert metadata_res.stdout.strip() == "000", (
+            "cloud instance metadata reachable from sandbox VM "
+            f"(curl returned http_code={metadata_res.stdout.strip()!r}). "
+            "Was the metadata forwarding block installed?"
         )
 
     finally:

--- a/tests/proxmoxsandboxtest/test_provisioning_security.py
+++ b/tests/proxmoxsandboxtest/test_provisioning_security.py
@@ -35,7 +35,9 @@ def test_provisioners_block_forwarded_cloud_metadata(
 ) -> None:
     script = provisioner.read_text()
 
-    assert "-t raw -C PREROUTING -d 169.254.169.254/32 -j DROP" in script
-    assert "-t raw -C PREROUTING -d fd00:ec2::254/128 -j DROP" in script
+    assert "iptables -w -t raw -C PREROUTING -d 169.254.169.254/32 -j DROP" in script
+    assert "iptables -w -t raw -I PREROUTING 1 -d 169.254.169.254/32 -j DROP" in script
+    assert "ip6tables -w -t raw -C PREROUTING -d fd00:ec2::254/128 -j DROP" in script
+    assert "ip6tables -w -t raw -I PREROUTING 1 -d fd00:ec2::254/128 -j DROP" in script
     assert "ExecStart=/usr/local/bin/inspect-proxmox-block-cloud-metadata.sh" in script
     assert "systemctl enable inspect-proxmox-block-cloud-metadata.service" in script

--- a/tests/proxmoxsandboxtest/test_provisioning_security.py
+++ b/tests/proxmoxsandboxtest/test_provisioning_security.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[2]
+EC2_SCRIPTS = REPO_ROOT / "src" / "proxmoxsandbox" / "scripts" / "ec2"
+VIRTUALIZED_SCRIPT = (
+    REPO_ROOT
+    / "src"
+    / "proxmoxsandbox"
+    / "scripts"
+    / "virtualized_proxmox"
+    / "build_proxmox_auto.sh"
+)
+
+
+def test_ec2_launch_requires_imdsv2_with_one_hop() -> None:
+    launch = (EC2_SCRIPTS / "launch.sh").read_text()
+
+    assert (
+        "HttpTokens=required,HttpPutResponseHopLimit=1,"
+        "HttpProtocolIpv6=disabled,InstanceMetadataTags=enabled"
+    ) in launch
+
+
+@pytest.mark.parametrize(
+    "provisioner",
+    [
+        EC2_SCRIPTS / "userdata.sh",
+        VIRTUALIZED_SCRIPT,
+    ],
+)
+def test_provisioners_block_forwarded_cloud_metadata(
+    provisioner: Path,
+) -> None:
+    script = provisioner.read_text()
+
+    assert "-t raw -C PREROUTING -d 169.254.169.254/32 -j DROP" in script
+    assert "-t raw -C PREROUTING -d fd00:ec2::254/128 -j DROP" in script
+    assert "ExecStart=/usr/local/bin/inspect-proxmox-block-cloud-metadata.sh" in script
+    assert "systemctl enable inspect-proxmox-block-cloud-metadata.service" in script


### PR DESCRIPTION
## Summary

- Require IMDSv2 with a one-hop response limit for EC2 Proxmox hosts.
- Install persistent IPv4 and IPv6 forwarding blocks for cloud metadata in
  both bundled provisioning paths.
- Extend host-isolation tests and document the migration requirement for
  existing AMIs and templates.

## Security rationale

Sandbox VMs receive outbound access through SNAT. Without an explicit deny,
they can reach EC2 IMDS and potentially retrieve credentials belonging to the
host.

The forwarding rules drop guest traffic before routing or SNAT. Host-originated
traffic does not traverse PREROUTING, so Proxmox services retain IMDS access.

## Deployment note

Existing Proxmox AMIs and virtualized templates must be rebuilt, or the
documented persistent firewall rules must be applied manually.

## Verification

- `uv run pytest tests/proxmoxsandboxtest/test_provisioning_security.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- Shell syntax checks for both provisioners and the EC2 launcher
- Live EC2/Proxmox test with effective metadata hop limit 2:
  - host IMDS access remained available
  - sandbox IMDS access was blocked
  - rules survived Proxmox firewall restarts
  - end-to-end isolation test passed
