### PR TITLE
fix: redact Proxmox credentials from cleanup logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Security: redact Proxmox passwords in configuration representations and omit credentials from cleanup logs
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
 
 ## 0.11.0 - 2026-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Security: redact Proxmox passwords in configuration representations and omit credentials from cleanup logs
+- Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
 
 ## 0.11.0 - 2026-06-01

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -626,10 +626,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         config: SandboxEnvironmentConfigType | None,
         cleanup: bool,
     ) -> None:
-        config_type = type(config).__name__ if config is not None else None
-        cls.logger.debug(
-            f"task cleanup activated; {cleanup=}; config_type={config_type}"
-        )
+        cls.logger.debug(f"task cleanup activated; {cleanup=}; {config=}")
 
         if cleanup:
             # Sweep orphaned resources across all Proxmox instances that

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -626,7 +626,20 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         config: SandboxEnvironmentConfigType | None,
         cleanup: bool,
     ) -> None:
-        cls.logger.debug(f"task cleanup activated; {cleanup=}; {config=}")
+        config_type = type(config).__name__ if config is not None else None
+        if isinstance(config, ProxmoxSandboxEnvironmentConfig):
+            cls.logger.debug(
+                f"task cleanup activated; {cleanup=}; "
+                f"config_type={config_type}; "
+                f"instance_pool_id={config.instance_pool_id}; "
+                f"host={config.host}; "
+                f"port={config.port}; "
+                f"node={config.node}"
+            )
+        else:
+            cls.logger.debug(
+                f"task cleanup activated; {cleanup=}; config_type={config_type}"
+            )
 
         if cleanup:
             # Sweep orphaned resources across all Proxmox instances that

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -342,7 +342,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             async_proxmox_api = AsyncProxmoxAPI(
                 host=f"{instance.host}:{instance.port}",
                 user=f"{instance.user}@{instance.user_realm}",
-                password=instance.password,
+                password=instance.password.get_secret_value(),
                 verify_tls=instance.verify_tls,
             )
 
@@ -503,7 +503,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         return AsyncProxmoxAPI(
             host=f"{config.host}:{config.port}",
             user=f"{config.user}@{config.user_realm}",
-            password=config.password,
+            password=config.password.get_secret_value(),
             verify_tls=config.verify_tls,
         )
 
@@ -608,7 +608,10 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                         f"NOT releasing instance {instance.instance_id} "
                         f"from pool '{pool_id}' - "
                         f"cleanup failed, instance may be dirty\n"
-                        f"instance={instance}\n"
+                        f"instance_id={instance.instance_id}\n"
+                        f"host={instance.host}\n"
+                        f"port={instance.port}\n"
+                        f"node={instance.node}\n"
                         f"pool_id={pool_id}\n"
                         f"cleanup_succeeded={cleanup_succeeded}"
                     )
@@ -623,7 +626,10 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         config: SandboxEnvironmentConfigType | None,
         cleanup: bool,
     ) -> None:
-        cls.logger.debug(f"task cleanup activated; {cleanup=}; {config=}")
+        config_type = type(config).__name__ if config is not None else None
+        cls.logger.debug(
+            f"task cleanup activated; {cleanup=}; config_type={config_type}"
+        )
 
         if cleanup:
             # Sweep orphaned resources across all Proxmox instances that
@@ -649,7 +655,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 async_proxmox_api = AsyncProxmoxAPI(
                     host=f"{instance.host}:{instance.port}",
                     user=f"{instance.user}@{instance.user_realm}",
-                    password=instance.password,
+                    password=instance.password.get_secret_value(),
                     verify_tls=instance.verify_tls,
                 )
                 infra_commands = InfraCommands.build(

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -6,7 +6,7 @@ from os import getenv
 from pathlib import Path
 from typing import Annotated, Literal, Optional, Tuple, TypeAlias, Union
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, SecretStr, model_validator
 from pydantic.networks import IPvAnyAddress, IPvAnyNetwork
 from pydantic_extra_types.mac_address import MacAddress
 
@@ -241,7 +241,7 @@ class ProxmoxInstanceConfig(BaseModel, frozen=True):
     port: int
     user: str
     user_realm: str
-    password: str
+    password: SecretStr
     node: str
     verify_tls: bool
 
@@ -322,8 +322,8 @@ class ProxmoxSandboxEnvironmentConfig(BaseModel, frozen=True):
     port: int = Field(default_factory=lambda: int(getenv("PROXMOX_PORT", "8006")))
     user: str = Field(default_factory=lambda: getenv("PROXMOX_USER", "root"))
     user_realm: str = Field(default_factory=lambda: getenv("PROXMOX_REALM", "pam"))
-    password: str = Field(
-        default_factory=lambda: getenv("PROXMOX_PASSWORD", "password")
+    password: SecretStr = Field(
+        default_factory=lambda: SecretStr(getenv("PROXMOX_PASSWORD", "password"))
     )
     node: str = Field(default_factory=lambda: getenv("PROXMOX_NODE", "proxmox"))
     verify_tls: bool = Field(

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -6,7 +6,7 @@ from os import getenv
 from pathlib import Path
 from typing import Annotated, Literal, Optional, Tuple, TypeAlias, Union
 
-from pydantic import BaseModel, Field, SecretStr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from pydantic.networks import IPvAnyAddress, IPvAnyNetwork
 from pydantic_extra_types.mac_address import MacAddress
 
@@ -218,7 +218,7 @@ class VmConfig(BaseModel, frozen=True):
     cpu: Optional[str] = None
 
 
-class ProxmoxInstanceConfig(BaseModel, frozen=True):
+class ProxmoxInstanceConfig(BaseModel):
     """
     Configuration for a single Proxmox instance.
 
@@ -234,6 +234,8 @@ class ProxmoxInstanceConfig(BaseModel, frozen=True):
         node: The name of the Proxmox node
         verify_tls: Whether to verify the Proxmox server's TLS certificate
     """
+
+    model_config = ConfigDict(frozen=True, hide_input_in_errors=True)
 
     instance_id: str
     pool_id: str
@@ -286,7 +288,7 @@ def _load_instances_from_env_or_file() -> Tuple[ProxmoxInstanceConfig, ...]:
     return ()
 
 
-class ProxmoxSandboxEnvironmentConfig(BaseModel, frozen=True):
+class ProxmoxSandboxEnvironmentConfig(BaseModel):
     """
     Configuration for a Proxmox sandbox environment.
 
@@ -307,6 +309,8 @@ class ProxmoxSandboxEnvironmentConfig(BaseModel, frozen=True):
         node: The name of the Proxmox node
         verify_tls: Whether to verify the Proxmox server's TLS certificate
     """
+
+    model_config = ConfigDict(frozen=True, hide_input_in_errors=True)
 
     # Which pool to use (references pool_id in PROXMOX_CONFIG_FILE)
     instance_pool_id: str = "default"

--- a/tests/proxmoxsandboxtest/conftest.py
+++ b/tests/proxmoxsandboxtest/conftest.py
@@ -43,7 +43,7 @@ async def async_proxmox_api(
     yield AsyncProxmoxAPI(
         host=f"{sandbox_env_config.host}:{sandbox_env_config.port}",
         user=f"{sandbox_env_config.user}@{sandbox_env_config.user_realm}",
-        password=sandbox_env_config.password,
+        password=sandbox_env_config.password.get_secret_value(),
         verify_tls=sandbox_env_config.verify_tls,
     )
 

--- a/tests/proxmoxsandboxtest/test_cli_cleanup.py
+++ b/tests/proxmoxsandboxtest/test_cli_cleanup.py
@@ -3,7 +3,7 @@
 import json
 import os
 import tempfile
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -84,10 +84,36 @@ async def test_cli_cleanup_all_instances(multi_instance_config_file):
 
     try:
         with (
-            patch("proxmoxsandbox._proxmox_sandbox_environment.AsyncProxmoxAPI"),
+            patch(
+                "proxmoxsandbox._proxmox_sandbox_environment.AsyncProxmoxAPI"
+            ) as mock_proxmox_api,
             patch.object(InfraCommands, "build", side_effect=create_mock_infra),
         ):
             await ProxmoxSandboxEnvironment.cli_cleanup(id=None)
+
+            mock_proxmox_api.assert_has_calls(
+                [
+                    call(
+                        host="10.0.1.10:8006",
+                        user="root@pam",
+                        password="test",
+                        verify_tls=False,
+                    ),
+                    call(
+                        host="10.0.1.11:8006",
+                        user="root@pam",
+                        password="test",
+                        verify_tls=False,
+                    ),
+                    call(
+                        host="10.0.1.20:8006",
+                        user="root@pam",
+                        password="test",
+                        verify_tls=False,
+                    ),
+                ]
+            )
+            assert mock_proxmox_api.call_count == 3
 
             # Verify InfraCommands.build was called for each instance
             assert len(mock_infra_instances) == 3

--- a/tests/proxmoxsandboxtest/test_config_loading.py
+++ b/tests/proxmoxsandboxtest/test_config_loading.py
@@ -67,7 +67,7 @@ def test_load_instances_from_file():
         assert instances[0].port == 8006
         assert instances[0].user == "root"
         assert instances[0].user_realm == "pam"
-        assert instances[0].password == "secret"
+        assert instances[0].password.get_secret_value() == "secret"
         assert instances[0].node == "pve1"
         assert instances[0].verify_tls is False
 
@@ -77,7 +77,7 @@ def test_load_instances_from_file():
         assert instances[1].port == 8006
         assert instances[1].user == "root"
         assert instances[1].user_realm == "pam"
-        assert instances[1].password == "secret"
+        assert instances[1].password.get_secret_value() == "secret"
         assert instances[1].node == "pve2"
         assert instances[1].verify_tls is True
 
@@ -116,7 +116,7 @@ def test_load_instances_from_env_vars():
         assert instances[0].port == 8006
         assert instances[0].user == "admin"
         assert instances[0].user_realm == "pve"
-        assert instances[0].password == "test123"
+        assert instances[0].password.get_secret_value() == "test123"
         assert instances[0].node == "node1"
         assert instances[0].verify_tls is False
 

--- a/tests/proxmoxsandboxtest/test_credential_redaction.py
+++ b/tests/proxmoxsandboxtest/test_credential_redaction.py
@@ -4,7 +4,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from pydantic import SecretStr
+from pydantic import SecretStr, ValidationError
 
 from proxmoxsandbox._impl.infra_commands import InfraCommands
 from proxmoxsandbox._proxmox_sandbox_environment import (
@@ -45,6 +45,17 @@ def test_passwords_are_redacted_in_config_representations():
         assert PASSWORD_SENTINEL not in repr(config)
         assert PASSWORD_SENTINEL not in str(config)
         assert PASSWORD_SENTINEL not in config.model_dump_json()
+
+
+def test_validation_error_messages_hide_raw_instance_config():
+    """Rendered validation errors must not include raw credentials."""
+    with pytest.raises(ValidationError) as exc_info:
+        ProxmoxInstanceConfig.model_validate({"password": PASSWORD_SENTINEL})
+
+    message = str(exc_info.value)
+    assert PASSWORD_SENTINEL not in message
+    assert PASSWORD_SENTINEL not in repr(exc_info.value)
+    assert "input_value=" not in message
 
 
 def test_password_is_unwrapped_only_for_api_authentication():
@@ -100,8 +111,14 @@ async def test_cleanup_failure_log_excludes_instance_password(caplog):
 
 @pytest.mark.asyncio
 async def test_task_cleanup_debug_log_excludes_config_password(caplog):
-    """Debug logging renders the config with the password masked by SecretStr."""
-    config = ProxmoxSandboxEnvironmentConfig(password=PASSWORD_SENTINEL)
+    """Debug logging includes useful context from an explicit safe field list."""
+    config = ProxmoxSandboxEnvironmentConfig(
+        instance_pool_id="audit-pool",
+        host="127.0.0.1",
+        port=8006,
+        password=PASSWORD_SENTINEL,
+        node="proxmox",
+    )
 
     with (
         patch.object(InfraCommands, "_instances", {}),
@@ -115,4 +132,12 @@ async def test_task_cleanup_debug_log_excludes_config_password(caplog):
 
     messages = "\n".join(record.getMessage() for record in caplog.records)
     assert PASSWORD_SENTINEL not in messages
-    assert "password=SecretStr('**********')" in messages
+    assert "password=" not in messages
+    assert "config=ProxmoxSandboxEnvironmentConfig" not in messages
+    assert "vms_config=" not in messages
+    assert "sdn_config=" not in messages
+    assert "config_type=ProxmoxSandboxEnvironmentConfig" in messages
+    assert "instance_pool_id=audit-pool" in messages
+    assert "host=127.0.0.1" in messages
+    assert "port=8006" in messages
+    assert "node=proxmox" in messages

--- a/tests/proxmoxsandboxtest/test_credential_redaction.py
+++ b/tests/proxmoxsandboxtest/test_credential_redaction.py
@@ -1,0 +1,120 @@
+"""Tests that Proxmox credentials cannot leak through configuration logs."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from proxmoxsandbox._impl.infra_commands import InfraCommands
+from proxmoxsandbox._proxmox_sandbox_environment import (
+    ProxmoxSandboxEnvironment,
+)
+from proxmoxsandbox.schema import (
+    ProxmoxInstanceConfig,
+    ProxmoxSandboxEnvironmentConfig,
+)
+
+PASSWORD_SENTINEL = "audit-password-sentinel-do-not-log"
+
+
+def _instance_config() -> ProxmoxInstanceConfig:
+    return ProxmoxInstanceConfig(
+        instance_id="audit-instance",
+        pool_id="audit-pool",
+        host="127.0.0.1",
+        port=8006,
+        user="root",
+        user_realm="pam",
+        password=PASSWORD_SENTINEL,
+        node="proxmox",
+        verify_tls=False,
+    )
+
+
+def test_passwords_are_redacted_in_config_representations():
+    """Config repr, str, and JSON serialization must not contain passwords."""
+    configs = (
+        _instance_config(),
+        ProxmoxSandboxEnvironmentConfig(password=PASSWORD_SENTINEL),
+    )
+
+    for config in configs:
+        assert isinstance(config.password, SecretStr)
+        assert config.password.get_secret_value() == PASSWORD_SENTINEL
+        assert PASSWORD_SENTINEL not in repr(config)
+        assert PASSWORD_SENTINEL not in str(config)
+        assert PASSWORD_SENTINEL not in config.model_dump_json()
+
+
+def test_password_is_unwrapped_only_for_api_authentication():
+    """The API client still receives the configured plaintext credential."""
+    config = ProxmoxSandboxEnvironmentConfig(password=PASSWORD_SENTINEL)
+
+    api = ProxmoxSandboxEnvironment._create_async_proxmox_api(config)
+
+    assert api.password == PASSWORD_SENTINEL
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_log_excludes_instance_password(caplog):
+    """A cleanup warning contains safe instance context but no credential."""
+    instance = _instance_config()
+    infra_commands = MagicMock()
+    infra_commands.delete_sdn_and_vms = AsyncMock(
+        side_effect=RuntimeError("forced cleanup failure")
+    )
+    environment = ProxmoxSandboxEnvironment(
+        infra_commands=infra_commands,
+        agent_commands=MagicMock(),
+        ipam_mappings=(),
+        vm_id=100,
+        all_vm_ids=(100,),
+        sdn_zone_id="abc123z",
+        instance=instance,
+        pool_id=instance.pool_id,
+    )
+
+    with (
+        patch.object(ProxmoxSandboxEnvironment, "proxmox_pool"),
+        caplog.at_level(logging.DEBUG, logger=ProxmoxSandboxEnvironment.logger.name),
+        pytest.raises(RuntimeError, match="forced cleanup failure"),
+    ):
+        await ProxmoxSandboxEnvironment.sample_cleanup(
+            task_name="audit",
+            config=None,
+            environments={"default": environment},
+            interrupted=False,
+        )
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert PASSWORD_SENTINEL not in messages
+    assert "instance=ProxmoxInstanceConfig" not in messages
+    assert "password=" not in messages
+    assert "instance_id=audit-instance" in messages
+    assert "pool_id=audit-pool" in messages
+    assert "host=127.0.0.1" in messages
+    assert "port=8006" in messages
+    assert "node=proxmox" in messages
+
+
+@pytest.mark.asyncio
+async def test_task_cleanup_debug_log_excludes_config_password(caplog):
+    """Debug logging must not render the complete environment configuration."""
+    config = ProxmoxSandboxEnvironmentConfig(password=PASSWORD_SENTINEL)
+
+    with (
+        patch.object(InfraCommands, "_instances", {}),
+        caplog.at_level(logging.DEBUG, logger=ProxmoxSandboxEnvironment.logger.name),
+    ):
+        await ProxmoxSandboxEnvironment.task_cleanup(
+            task_name="audit",
+            config=config,
+            cleanup=True,
+        )
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert PASSWORD_SENTINEL not in messages
+    assert "password=" not in messages
+    assert "instance_pool_id=" not in messages
+    assert "config_type=ProxmoxSandboxEnvironmentConfig" in messages

--- a/tests/proxmoxsandboxtest/test_credential_redaction.py
+++ b/tests/proxmoxsandboxtest/test_credential_redaction.py
@@ -100,7 +100,7 @@ async def test_cleanup_failure_log_excludes_instance_password(caplog):
 
 @pytest.mark.asyncio
 async def test_task_cleanup_debug_log_excludes_config_password(caplog):
-    """Debug logging must not render the complete environment configuration."""
+    """Debug logging renders the config with the password masked by SecretStr."""
     config = ProxmoxSandboxEnvironmentConfig(password=PASSWORD_SENTINEL)
 
     with (
@@ -115,6 +115,4 @@ async def test_task_cleanup_debug_log_excludes_config_password(caplog):
 
     messages = "\n".join(record.getMessage() for record in caplog.records)
     assert PASSWORD_SENTINEL not in messages
-    assert "password=" not in messages
-    assert "instance_pool_id=" not in messages
-    assert "config_type=ProxmoxSandboxEnvironmentConfig" in messages
+    assert "password=SecretStr('**********')" in messages

--- a/tests/proxmoxsandboxtest/test_multi_instance_pools.py
+++ b/tests/proxmoxsandboxtest/test_multi_instance_pools.py
@@ -144,6 +144,13 @@ async def test_single_instance_single_sample(
             "test_task", config, {}
         )
 
+        mock_proxmox_api.assert_called_once_with(
+            host="10.0.1.10:8006",
+            user="root@pam",
+            password="test",
+            verify_tls=False,
+        )
+
         # Verify: Environment created, instance acquired from pool
         assert "default" in environments
         assert pool.qsize() == 0  # Instance taken from pool


### PR DESCRIPTION
Cleanup failures logged complete Proxmox instance and environment configurations at warning and debug levels. These included the configured password, commonly for `root@pam`, exposing control-plane credentials to log readers.

Store password fields as `SecretStr` and unwrap them only for API authentication. The `sample_cleanup` warning now lists explicit non-secret instance fields. The `task_cleanup` debug log records only intentional operational context (`config_type`, `instance_pool_id`, `host`, `port`, and `node`) rather than dumping the complete configuration.

Hide raw input values from rendered Pydantic validation errors so malformed instance configurations do not echo credentials in exception messages or tracebacks.

Add regression tests covering configuration representations, malformed configuration errors, both cleanup log paths, and the active `sample_init` and `cli_cleanup` authentication paths.

Tests:
- 106 non-live tests passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- The original audit probe now fails because the sentinel is absent