### PR TITLE
Generalise sandbox isolation: RFC 3927 link-local block + disable guest IPv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
+- Prevent sandbox VMs from accessing cloud instance metadata credentials when using the bundled provisioning scripts. Both provisioners enforce RFC 3927 section 7 (drop forwarded IPv4 link-local `169.254.0.0/16` — destination in `raw PREROUTING`, source in `FORWARD` so host replies are unaffected — covering AWS/GCP/Azure/Oracle/DO metadata) and disable IPv6 for sandbox guests. Rebuild existing Proxmox AMIs/templates or apply the documented host rules to install this protection
 
 ## 0.11.0 - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process
-- Prevent sandbox VMs from accessing cloud instance metadata credentials and Disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
+- Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
 
 ## 0.11.0 - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
-- Prevent sandbox VMs from accessing cloud instance metadata credentials when using the bundled provisioning scripts. Both provisioners enforce RFC 3927 section 7 (drop forwarded IPv4 link-local `169.254.0.0/16` — destination in `raw PREROUTING`, source in `FORWARD` so host replies are unaffected — covering AWS/GCP/Azure/Oracle/DO metadata) and disable IPv6 for sandbox guests. Rebuild existing Proxmox AMIs/templates or apply the documented host rules to install this protection
+- Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process
+- Prevent sandbox VMs from accessing cloud instance metadata credentials and Disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
 
 ## 0.11.0 - 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -52,17 +52,16 @@ them are isolated out of the box.
 If you provision Proxmox some other way, configure equivalent persistent rules
 **on the node**. The Proxmox rules accept management ports only on the
 default-route interface (where external callers arrive) and leave SDN DNS/DHCP
-open. The remaining rules enforce RFC 3927 section 7, which Linux's forward path
-ignores: a router must not forward IPv4 link-local (`169.254.0.0/16`) traffic, but
-Linux forwards it anyway, so dropping it stops a sandbox guest reaching the host's
-cloud metadata service — and any other link-local endpoint — over its on-link route. The
+open. The remaining rules enforce RFC 3927 section 7: a router must not forward IPv4 link-local (`169.254.0.0/16`) traffic.
+Dropping it stops a sandbox guest reaching the host's
+cloud metadata service — and any other link-local endpoint. The
 destination drop goes in `raw PREROUTING` (host requests are `OUTPUT`, never
 `PREROUTING`, so the host keeps its own access); the source drop goes in
 `FORWARD`, **not** `PREROUTING`, so the host's own replies (e.g. an IMDS or
 `169.254.169.253` DNS response, delivered to `INPUT`) are left intact — a
-`raw PREROUTING -s` rule would drop them and break the host. IPv6 is not
-supported for sandbox guests, so it is disabled on guest interfaces and
-forwarded v6 is dropped:
+`raw PREROUTING -s` rule would drop them and break the host. 
+
+We also recommend disabling forwarding of IPv6 for VMs, unless you really know what you are doing.
 
 ```bash
 NIC=$(ip route show default | awk '{print $5}' | head -1)

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ If you don't already have a Proxmox instance, see [CONTRIBUTING.md](CONTRIBUTING
 
 By default a sandbox VM can reach the Proxmox host's own services — the API
 (`pveproxy`, port 8006), SSH, etc. — via the SDN gateway, the `vmbr0` IP, or the
-host's external NIC. For cyber evals especially, you want those blocked so agents
-can't attack the Proxmox control plane.
+host's external NIC. Forwarded traffic can also reach cloud instance metadata
+services. For cyber evals especially, you want those blocked so agents can't
+attack the Proxmox or cloud control planes.
 
 This is **configured on the host at provisioning time, not by this library** — it
 needs the host's live routing table to know which interface external API/SSH
@@ -48,10 +49,20 @@ provisioning scripts in this repo (`scripts/virtualized_proxmox/build_proxmox_au
 and `scripts/ec2/userdata.sh`) set it up automatically, so hosts you create with
 them are isolated out of the box.
 
-If you provision Proxmox some other way, run these once **on the node**. They
-accept the management ports only on the default-route interface (where external
-callers arrive) and leave SDN DNS/DHCP open; sandbox VMs sit on other bridges and
-hit the default-deny policy:
+If you provision Proxmox some other way, configure equivalent persistent rules
+**on the node**. The Proxmox rules accept management ports only on the
+default-route interface (where external callers arrive) and leave SDN DNS/DHCP
+open. The remaining rules enforce RFC 3927 section 7, which Linux's forward path
+ignores: a router must not forward IPv4 link-local (`169.254.0.0/16`) traffic, but
+Linux forwards it anyway, so dropping it stops a sandbox guest reaching the host's
+cloud metadata service — and any other link-local endpoint — over its on-link route. The
+destination drop goes in `raw PREROUTING` (host requests are `OUTPUT`, never
+`PREROUTING`, so the host keeps its own access); the source drop goes in
+`FORWARD`, **not** `PREROUTING`, so the host's own replies (e.g. an IMDS or
+`169.254.169.253` DNS response, delivered to `INPUT`) are left intact — a
+`raw PREROUTING -s` rule would drop them and break the host. IPv6 is not
+supported for sandbox guests, so it is disabled on guest interfaces and
+forwarded v6 is dropped:
 
 ```bash
 NIC=$(ip route show default | awk '{print $5}' | head -1)
@@ -62,7 +73,29 @@ pvesh create /nodes/$(hostname)/firewall/rules --type in --action ACCEPT --proto
 pvesh create /nodes/$(hostname)/firewall/rules --type in --action ACCEPT --proto udp --dport 67 --enable 1
 pvesh set /nodes/$(hostname)/firewall/options --enable 1
 pvesh set /cluster/firewall/options --enable 1
+iptables -w -t raw -C PREROUTING -d 169.254.0.0/16 -j DROP 2>/dev/null \
+    || iptables -w -t raw -I PREROUTING 1 -d 169.254.0.0/16 -j DROP
+iptables -w -C FORWARD -s 169.254.0.0/16 -j DROP 2>/dev/null \
+    || iptables -w -I FORWARD 1 -s 169.254.0.0/16 -j DROP
+sysctl -w net.ipv6.conf.default.disable_ipv6=1   # new SDN bridges come up v6-off
+if command -v ip6tables >/dev/null; then
+    ip6tables -w -C FORWARD -j DROP 2>/dev/null || ip6tables -w -A FORWARD -j DROP
+fi
 ```
+
+Most clouds (AWS, GCP, Azure, Oracle, DigitalOcean) serve metadata from
+`169.254.169.254`, covered above. Two providers sit outside the link-local
+range: **Alibaba Cloud** uses `100.100.100.200`, and **Azure** exposes the
+WireServer at `168.63.129.16` (guest-agent goal state / extension settings). On
+those clouds, add a `-d <ip>/32 -j DROP` raw-table rule for each — the host
+keeps access since its own traffic doesn't traverse `PREROUTING`.
+
+You must persist these rules across reboots (the bundled provisioning scripts do
+this, if you need an example.)
+
+These work under either firewall backend (`pve-firewall` or the nftables
+`proxmox-firewall`); the latter won't touch these chains. On `iptables-legacy`
+hosts they won't show in `nft list ruleset` — use `iptables -t raw -S` / `-S FORWARD`.
 
 ### Single Proxmox Instance
 

--- a/src/proxmoxsandbox/scripts/ec2/README.md
+++ b/src/proxmoxsandbox/scripts/ec2/README.md
@@ -87,7 +87,7 @@ aws ec2 run-instances --region "$REGION" \
     --cpu-options "NestedVirtualization=enabled" \
     --subnet-id "$SUBNET_ID" \
     --security-group-ids "$SECURITY_GROUP_ID" \
-    --metadata-options "InstanceMetadataTags=enabled"
+    --metadata-options "HttpTokens=required,HttpPutResponseHopLimit=1,HttpProtocolIpv6=disabled,InstanceMetadataTags=enabled"
     # add --iam-instance-profile Name=<profile> if SSM access doesn't come from DHMC
 ```
 
@@ -122,6 +122,10 @@ outbound traffic via iptables MASQUERADE. VM gateway: `10.10.10.1`. DNS:
 `169.254.169.253` (VPC resolver). VMs can't bind directly to the VPC subnet
 because EC2 only routes to IPs on attached ENIs.
 
+Sandbox forwarding to the EC2 metadata endpoints (`169.254.169.254` and
+`fd00:ec2::254`) is blocked on the Proxmox host. Processes running directly on
+the host retain IMDS access. `HttpPutResponseHopLimit=1` is a backstop.
+
 ## Metrics (CloudWatch)
 
 The instance ships a localhost CloudWatch agent that forwards Proxmox's `pvestatd`
@@ -136,8 +140,8 @@ instance-id. It is additionally labelled with the instance `Name` tag **only if
 the launcher enables instance metadata tags**. Like the hostname and root
 password (see fixup services below), this is a per-launch attribute set at
 `run-instances` time — it is **not** baked into the AMI. Pass
-`--metadata-options InstanceMetadataTags=enabled` (as `launch.sh` does for the
-build instance, and as the everyday-launch example above does) or you get
+`InstanceMetadataTags=enabled` in `--metadata-options` (as `launch.sh` does for
+the build instance, and as the everyday-launch example above does) or you get
 instance-id only.
 
 ## EC2-specific bits handled by `userdata.sh`
@@ -151,6 +155,7 @@ instance-id only.
   (see <https://forum.proxmox.com/threads/ipam-reserving-dhcp-leases-via-mac-addresses.174704/>).
 - `/run/dnsmasq/resolv.conf` shim for SDN dnsmasq DNS forwarding.
 - AMI fixup services for hostname + SSL cert + root password regeneration on every boot.
+- A boot-time firewall rule blocking sandbox forwarding to EC2 instance metadata.
 - CloudWatch OTLP metrics collector for `pvestatd` metrics — see "Metrics (CloudWatch)" above.
 
 ## Other scripts

--- a/src/proxmoxsandbox/scripts/ec2/launch.sh
+++ b/src/proxmoxsandbox/scripts/ec2/launch.sh
@@ -66,9 +66,10 @@ RUN_ARGS=(
     --cpu-options "NestedVirtualization=enabled"
     --subnet-id "$SUBNET_ID"
     --security-group-ids "$SECURITY_GROUP_ID"
-    # Expose the instance's own tags (incl. Name) via IMDS so the OTel collector
-    # can label metrics with the Name (read at boot, no ec2:DescribeTags needed).
-    --metadata-options "InstanceMetadataTags=enabled"
+    # Require IMDSv2 and keep token responses on the host. A hop limit above 1
+    # allows nested sandbox VMs to retrieve host metadata credentials.
+    # InstanceMetadataTags lets the OTel collector read the instance Name.
+    --metadata-options "HttpTokens=required,HttpPutResponseHopLimit=1,HttpProtocolIpv6=disabled,InstanceMetadataTags=enabled"
     --block-device-mappings
         "DeviceName=/dev/xvda,Ebs={VolumeSize=1024,VolumeType=gp3,DeleteOnTermination=true}"
     --user-data "fileb://$USERDATA_GZ"

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -363,6 +363,60 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 FIXUP_NAT_UNIT
 
+# IPv6 is not supported for sandbox guests. SDN vnet bridges are created per
+# sample with generated names, so default.disable_ipv6 makes every interface
+# created after boot (i.e. the vnets) come up with no IPv6; the management NIC,
+# already up, keeps its own setting.
+cat > /etc/sysctl.d/99-inspect-proxmox-disable-ipv6.conf << 'SYSCTL_V6'
+net.ipv6.conf.default.disable_ipv6 = 1
+SYSCTL_V6
+
+# Confine sandbox guests at the host's forwarding layer. Kept identical to the
+# on-first-boot heredoc in scripts/virtualized_proxmox/build_proxmox_auto.sh.
+cat > /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh << 'BLOCK_METADATA'
+#!/bin/bash
+set -euo pipefail
+
+# Enforce RFC 3927: a router must not forward IPv4 link-local (169.254.0.0/16),
+# but Linux forwards it anyway, so a sandbox guest can otherwise reach the host's
+# metadata service over its on-link route. 169.254.169.254 covers
+# AWS/GCP/Azure/Oracle/DO; README notes Alibaba/Azure-WireServer outside the range.
+#
+# Destination drop in raw PREROUTING (interface-agnostic, ahead of any FORWARD
+# ACCEPT; host requests are OUTPUT so unaffected) -- this blocks the metadata vector.
+iptables -w -t raw -C PREROUTING -d 169.254.0.0/16 -j DROP 2>/dev/null \
+    || iptables -w -t raw -I PREROUTING 1 -d 169.254.0.0/16 -j DROP
+# Source drop in FORWARD, not raw PREROUTING: belt-and-braces for full RFC
+# conformance. FORWARD leaves the host's own on-link replies (IMDS/DNS, at INPUT)
+# intact; a raw PREROUTING -s rule would drop them and break the host.
+iptables -w -C FORWARD -s 169.254.0.0/16 -j DROP 2>/dev/null \
+    || iptables -w -I FORWARD 1 -s 169.254.0.0/16 -j DROP
+
+# Belt-and-braces for the unsupported IPv6 case: drop forwarded guest v6 outright.
+# FORWARD only sees transit traffic, so the host's own v6 (INPUT/OUTPUT) is intact.
+if command -v ip6tables >/dev/null; then
+    ip6tables -w -C FORWARD -j DROP 2>/dev/null \
+        || ip6tables -w -A FORWARD -j DROP
+fi
+BLOCK_METADATA
+chmod +x /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
+
+cat > /etc/systemd/system/inspect-proxmox-block-cloud-metadata.service << 'BLOCK_METADATA_UNIT'
+[Unit]
+Description=Confine sandbox guests (link-local forwarding block, IPv6 drop)
+After=network-online.target pve-firewall.service proxmox-firewall.service
+Wants=network-online.target
+Before=proxmox-ami-fixup-nat.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+BLOCK_METADATA_UNIT
+
 # Host isolation. See root README.
 # Re-applied every boot (no marker): the node name changes per launch, so any
 # node-scoped rules baked into the AMI are orphaned under the old node name, and
@@ -416,6 +470,7 @@ systemctl enable proxmox-ami-fixup-certs.service
 systemctl enable proxmox-ami-fixup-nat.service
 systemctl enable proxmox-ami-fixup-password.service
 systemctl enable proxmox-ami-fixup-firewall.service
+systemctl enable inspect-proxmox-block-cloud-metadata.service
 
 # ===== CloudWatch OTLP metrics collector =====
 # Ship pvestatd's metrics to the CloudWatch OTLP endpoint via a localhost CloudWatch

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -377,10 +377,7 @@ cat > /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh << 'BLOCK_METADATA'
 #!/bin/bash
 set -euo pipefail
 
-# Enforce RFC 3927: a router must not forward IPv4 link-local (169.254.0.0/16),
-# but Linux forwards it anyway, so a sandbox guest can otherwise reach the host's
-# metadata service over its on-link route. 169.254.169.254 covers
-# AWS/GCP/Azure/Oracle/DO; README notes Alibaba/Azure-WireServer outside the range.
+# Enforce RFC 3927: a router must not forward IPv4 link-local (169.254.0.0/16).
 #
 # Destination drop in raw PREROUTING (interface-agnostic, ahead of any FORWARD
 # ACCEPT; host requests are OUTPUT so unaffected) -- this blocks the metadata vector.

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -255,6 +255,63 @@ pvesh create /nodes/proxmox/firewall/rules --type in --action ACCEPT --proto udp
 pvesh set /nodes/proxmox/firewall/options --enable 1
 pvesh set /cluster/firewall/options --enable 1
 
+# IPv6 is not supported for sandbox guests on this provider. SDN vnet bridges are
+# created per sample with generated names, so we can't pin a rule to them; instead
+# default.disable_ipv6 makes every interface created after boot (i.e. the vnets)
+# come up with no IPv6. The already-up management NIC keeps its own setting.
+cat > /etc/sysctl.d/99-inspect-proxmox-disable-ipv6.conf << 'SYSCTL_V6'
+net.ipv6.conf.default.disable_ipv6 = 1
+SYSCTL_V6
+
+# Confine sandbox guests at the host's forwarding layer. Re-applied every boot
+# because the template is powered off below and later cloned into fresh instances;
+# iptables rules live in kernel state and don't survive the clone/reboot.
+cat > /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh << 'BLOCK_METADATA'
+#!/bin/bash
+set -euo pipefail
+
+# Enforce RFC 3927: a router must not forward IPv4 link-local (169.254.0.0/16),
+# but Linux forwards it anyway, so a sandbox guest can otherwise reach the host's
+# metadata service over its on-link route. 169.254.169.254 covers
+# AWS/GCP/Azure/Oracle/DO; README notes Alibaba/Azure-WireServer outside the range.
+#
+# Destination drop in raw PREROUTING (interface-agnostic, ahead of any FORWARD
+# ACCEPT; host requests are OUTPUT so unaffected) -- this blocks the metadata vector.
+iptables -w -t raw -C PREROUTING -d 169.254.0.0/16 -j DROP 2>/dev/null \
+    || iptables -w -t raw -I PREROUTING 1 -d 169.254.0.0/16 -j DROP
+# Source drop in FORWARD, not raw PREROUTING: belt-and-braces for full RFC
+# conformance. FORWARD leaves the host's own on-link replies (IMDS/DNS, at INPUT)
+# intact; a raw PREROUTING -s rule would drop them and break the host.
+iptables -w -C FORWARD -s 169.254.0.0/16 -j DROP 2>/dev/null \
+    || iptables -w -I FORWARD 1 -s 169.254.0.0/16 -j DROP
+
+# Belt-and-braces for the unsupported IPv6 case: drop forwarded guest v6 outright.
+# FORWARD only sees transit traffic, so the host's own v6 (INPUT/OUTPUT) is intact.
+if command -v ip6tables >/dev/null; then
+    ip6tables -w -C FORWARD -j DROP 2>/dev/null \
+        || ip6tables -w -A FORWARD -j DROP
+fi
+BLOCK_METADATA
+chmod +x /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
+
+cat > /etc/systemd/system/inspect-proxmox-block-cloud-metadata.service << 'BLOCK_METADATA_UNIT'
+[Unit]
+Description=Confine sandbox guests (link-local forwarding block, IPv6 drop)
+After=network-online.target pve-firewall.service proxmox-firewall.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+BLOCK_METADATA_UNIT
+
+systemctl daemon-reload
+systemctl enable inspect-proxmox-block-cloud-metadata.service
+
 touch /var/local/inspect-proxmox-on-first-boot.done
 
 # shut down to signal to virt-install that installation is complete

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -270,10 +270,7 @@ cat > /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh << 'BLOCK_METADATA'
 #!/bin/bash
 set -euo pipefail
 
-# Enforce RFC 3927: a router must not forward IPv4 link-local (169.254.0.0/16),
-# but Linux forwards it anyway, so a sandbox guest can otherwise reach the host's
-# metadata service over its on-link route. 169.254.169.254 covers
-# AWS/GCP/Azure/Oracle/DO; README notes Alibaba/Azure-WireServer outside the range.
+# Enforce RFC 3927: a router must not forward IPv4 link-local (169.254.0.0/16).
 #
 # Destination drop in raw PREROUTING (interface-agnostic, ahead of any FORWARD
 # ACCEPT; host requests are OUTPUT so unaffected) -- this blocks the metadata vector.

--- a/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
+++ b/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
@@ -15,12 +15,14 @@ from proxmoxsandbox._proxmox_sandbox_environment import (
 from .proxmox_sandbox_utils import setup_sandbox
 
 
-async def test_sandbox_vm_cannot_reach_pveproxy_or_ssh() -> None:
-    """A sandbox VM brought up via sample_init can't curl pveproxy or SSH.
+async def test_sandbox_vm_cannot_reach_host_or_cloud_metadata() -> None:
+    """A sandbox VM can't reach host services or cloud instance metadata.
 
     The VM reaches the host over its SDN bridge, so its packets never ingress
     on the host's management interface and hit the default-deny policy — even
-    when aimed at the SDN gateway IP where pveproxy also listens.
+    when aimed at the SDN gateway IP where pveproxy also listens. Metadata
+    traffic is forwarded rather than host-bound, so provisioning also installs
+    an explicit forwarding block for the fixed metadata endpoints.
     """
     task_name = "test_host_isolation_e2e"
     config = ProxmoxSandboxEnvironmentConfig()
@@ -70,6 +72,54 @@ async def test_sandbox_vm_cannot_reach_pveproxy_or_ssh() -> None:
         )
         assert ssh_res.stdout.strip() == "blocked", (
             f"SSH on {gw}:22 reachable from sandbox VM: {ssh_res.stdout!r}"
+        )
+
+        # A token PUT can time out solely because HttpPutResponseHopLimit=1,
+        # even when IMDS is reachable. A tokenless GET returns 401 when IMDSv2
+        # is required (or 200 when optional), so 000 specifically verifies that
+        # the host forwarding rule blocked the request.
+        metadata_get_res = await env.exec(
+            [
+                "curl",
+                "-sS",
+                "--max-time",
+                "5",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                "http://169.254.169.254/latest/meta-data/instance-id",
+            ],
+            timeout=15,
+        )
+        assert metadata_get_res.stdout.strip() == "000", (
+            "cloud instance metadata reachable from sandbox VM "
+            f"(curl returned http_code={metadata_get_res.stdout.strip()!r}). "
+            "Was the metadata forwarding block installed?"
+        )
+
+        metadata_token_res = await env.exec(
+            [
+                "curl",
+                "-sS",
+                "--max-time",
+                "5",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                "-X",
+                "PUT",
+                "-H",
+                "X-aws-ec2-metadata-token-ttl-seconds: 60",
+                "http://169.254.169.254/latest/api/token",
+            ],
+            timeout=15,
+        )
+        assert metadata_token_res.stdout.strip() == "000", (
+            "cloud instance metadata token endpoint reachable from sandbox VM "
+            f"(curl returned http_code={metadata_token_res.stdout.strip()!r}). "
+            "Was the metadata forwarding block installed?"
         )
 
     finally:

--- a/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
+++ b/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
@@ -85,7 +85,8 @@ async def test_sandbox_vm_cannot_reach_host_or_cloud_metadata() -> None:
         metadata_get_res = await env.exec(
             [
                 "curl",
-                "-sS",
+                "--silent",
+                "--show-error",
                 "--max-time",
                 "5",
                 "-o",

--- a/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
+++ b/tests/proxmoxsandboxtest/test_host_isolation_e2e.py
@@ -106,7 +106,8 @@ async def test_sandbox_vm_cannot_reach_host_or_cloud_metadata() -> None:
         metadata_token_res = await env.exec(
             [
                 "curl",
-                "-sS",
+                "--silent",
+                "--show-error",
                 "--max-time",
                 "5",
                 "-o",

--- a/tests/proxmoxsandboxtest/test_provisioning_security.py
+++ b/tests/proxmoxsandboxtest/test_provisioning_security.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[2]
+EC2_SCRIPTS = REPO_ROOT / "src" / "proxmoxsandbox" / "scripts" / "ec2"
+VIRTUALIZED_SCRIPT = (
+    REPO_ROOT
+    / "src"
+    / "proxmoxsandbox"
+    / "scripts"
+    / "virtualized_proxmox"
+    / "build_proxmox_auto.sh"
+)
+
+
+def test_ec2_launch_requires_imdsv2_with_one_hop() -> None:
+    launch = (EC2_SCRIPTS / "launch.sh").read_text()
+
+    assert (
+        "HttpTokens=required,HttpPutResponseHopLimit=1,"
+        "HttpProtocolIpv6=disabled,InstanceMetadataTags=enabled"
+    ) in launch
+
+
+@pytest.mark.parametrize(
+    "provisioner",
+    [
+        EC2_SCRIPTS / "userdata.sh",
+        VIRTUALIZED_SCRIPT,
+    ],
+)
+def test_provisioners_enforce_rfc3927_and_disable_ipv6(provisioner: Path) -> None:
+    # Both provisioners enforce RFC 3927 section 7 (a router must not forward IPv4
+    # link-local), rather than denylisting one cloud's metadata IP, and treat
+    # IPv6 as unsupported for sandbox guests. The two blocks are kept identical.
+    script = provisioner.read_text()
+
+    # Destination drop in raw PREROUTING (host requests are OUTPUT, unaffected).
+    assert "iptables -w -t raw -I PREROUTING 1 -d 169.254.0.0/16 -j DROP" in script
+    # Source drop in FORWARD, not PREROUTING, so the host's own link-local
+    # replies (INPUT) are left intact.
+    assert "iptables -w -I FORWARD 1 -s 169.254.0.0/16 -j DROP" in script
+    assert "iptables -w -t raw -I PREROUTING 1 -s 169.254.0.0/16 -j DROP" not in script
+    # IPv6 unsupported: disabled on guest interfaces + forwarded v6 dropped.
+    assert "net.ipv6.conf.default.disable_ipv6 = 1" in script
+    assert "ip6tables -w -A FORWARD -j DROP" in script
+    # Boot service installed and enabled.
+    assert "ExecStart=/usr/local/bin/inspect-proxmox-block-cloud-metadata.sh" in script
+    assert "systemctl enable inspect-proxmox-block-cloud-metadata.service" in script
+    # The single-cloud denylist is gone.
+    assert "169.254.169.254/32" not in script
+    assert "fd00:ec2::254" not in script

--- a/tests/proxmoxsandboxtest/test_provisioning_security.py
+++ b/tests/proxmoxsandboxtest/test_provisioning_security.py
@@ -14,7 +14,7 @@ VIRTUALIZED_SCRIPT = (
 )
 
 
-def test_ec2_launch_requires_imdsv2_with_one_hop() -> None:
+def test_launch_contains_expected_imds_settings() -> None:
     launch = (EC2_SCRIPTS / "launch.sh").read_text()
 
     assert (
@@ -30,7 +30,7 @@ def test_ec2_launch_requires_imdsv2_with_one_hop() -> None:
         VIRTUALIZED_SCRIPT,
     ],
 )
-def test_provisioners_enforce_rfc3927_and_disable_ipv6(provisioner: Path) -> None:
+def test_provisioners_contain_expected_iptables_rules(provisioner: Path) -> None:
     # Both provisioners enforce RFC 3927 section 7 (a router must not forward IPv4
     # link-local), rather than denylisting one cloud's metadata IP, and treat
     # IPv6 as unsupported for sandbox guests. The two blocks are kept identical.


### PR DESCRIPTION
## Summary

Supercedes #88: generalises the bundled provisioning scripts beyond EC2.

- **Enforce RFC 3927 in both provisioners** (`build_proxmox_auto.sh` and
  `scripts/ec2/userdata.sh`): a router must not forward IPv4 link-local
  `169.254.0.0/16`, but Linux forwards it anyway by default when routing
- **Disable IPv6 for sandbox guests** IPv6 is unsupported for guests on this provider, so this removes an unmanaged parallel stack 
## Verification

End-to-end against real **metal** (`build_proxmox_auto.sh` → vended) and
**nitrovirt** (`userdata.sh`) hosts:

- Full `pytest tests/` suite passes on both
- Host retains IMDS (`200`) with the shipped rules; moving the source drop to
  `raw PREROUTING` was shown to take host IMDS to `000` — the breakage the
  `FORWARD` placement avoids.
- Sandbox guest blocked from IMDS on both `vmbr0` and SDN vnets; removing the
  rules lets the guest reach IMDS (`401`), confirming the destination drop is
  load-bearing.

