### PR TITLE
fix: large file/exec-output reads no longer crash with HTTP 597 Broken pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: reading a large or binary guest file / command output no longer crashes with a non-standard HTTP 597 "Broken pipe". Root cause: `pveproxy` gzips the file-read response when the client accepts compression, and a large *incompressible* body (a real binary — compressible content shrinks and slips under the limit) dies mid-transfer with a 597 that escaped the retry layer. Guest file reads now send `Accept-Encoding: identity` to opt out of that compression. Reads also moved from the default `decode=1` (content as Latin-1-mangled UTF-8, ~2-6x on the wire, requiring un-mangling) to `decode=0` (base64, ~4/3 the content size and lossless) with a bounded `count`, so oversized files/output surface as `OutputLimitExceededError` and the Latin-1 mangling-recovery path is removed.
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
 
 ## 0.11.0 - 2026-06-01

--- a/src/proxmoxsandbox/_impl/agent_commands.py
+++ b/src/proxmoxsandbox/_impl/agent_commands.py
@@ -1,11 +1,10 @@
 import asyncio
 import base64
 from logging import getLogger
-from typing import List
+from typing import List, Tuple
 
 import httpx
 from inspect_ai.util import (
-    SandboxEnvironmentLimits,
     trace_action,
 )
 
@@ -168,47 +167,35 @@ class AgentCommands:
                 lambda: self.async_proxmox.request("POST", path, json=data),
             )
 
-    async def read_file_or_blank(
-        self,
-        vm_id: int,
-        filepath: str,
-        max_size: int = SandboxEnvironmentLimits.MAX_READ_FILE_SIZE,
-    ):
+    async def read_file_capped(
+        self, vm_id: int, filepath: str, count: int
+    ) -> Tuple[bytes, bool]:
+        """Retried decode=0 read of up to `count` bytes; returns (data, truncated)."""
         with trace_action(
             self.logger,
             self.TRACE_NAME,
-            f"read_file_or_blank {vm_id=} {filepath=} {max_size=}",
+            f"read_file_capped {vm_id=} {filepath=} {count=}",
         ):
-            try:
-                return await self.read_file(vm_id, filepath, max_size)
-            except httpx.HTTPStatusError as e:
-                if (
-                    e.response.status_code == 500
-                    and "no such file" in e.response.reason_phrase.casefold()
-                ):
-                    return {"content": ""}
-                else:
-                    raise e
+            return await self._retry_on_qga_error(
+                f"read_file_capped vm={vm_id} {filepath}",
+                lambda: self.async_proxmox.read_file_capped(
+                    self.node, vm_id, filepath, count
+                ),
+            )
 
-    async def read_file(
-        self,
-        vm_id: int,
-        filepath: str,
-        max_size: int = SandboxEnvironmentLimits.MAX_READ_FILE_SIZE,
-    ):
-        # this is a hack; it would be better to use a type here with
-        # e.g. size_bytes and friendly_name
-        max_size_str = (
-            SandboxEnvironmentLimits.MAX_READ_FILE_SIZE_STR
-            if max_size == SandboxEnvironmentLimits.MAX_READ_FILE_SIZE
-            else SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE_STR
-        )
-        return await self._retry_on_qga_error(
-            f"read_file vm={vm_id} {filepath}",
-            lambda: self.async_proxmox.read_file(
-                self.node, vm_id, filepath, max_size, max_size_str
-            ),
-        )
+    async def read_file_capped_or_blank(
+        self, vm_id: int, filepath: str, count: int
+    ) -> Tuple[bytes, bool]:
+        """Like read_file_capped but returns (b"", False) for a missing file."""
+        try:
+            return await self.read_file_capped(vm_id, filepath, count)
+        except httpx.HTTPStatusError as e:
+            msg = str(e).casefold()
+            if e.response.status_code == 500 and (
+                "no such file" in msg or "failed to open file" in msg
+            ):
+                return b"", False
+            raise
 
     async def create_snapshot(self, vm_id: int, snapshot_name: str) -> None:
         path = f"/nodes/{self.node}/qemu/{vm_id}/snapshot"

--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -1,33 +1,22 @@
 import asyncio
+import base64
 import json
+import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import httpx
 import pycurl
 from inspect_ai.util import (
-    OutputLimitExceededError,
     trace_action,
 )
 from pydantic import BaseModel
-from pydantic_core import from_json
 
 ProxmoxJsonDataType = Dict[str, Union[str, List[str], int, bool, None]]
-
-
-def _parse_truncated_file_read(raw: bytes) -> str:
-    r"""Extract data.content from a QGA file-read body cut off at the size limit.
-
-    The cut can land inside a JSON `\\uXXXX` escape, so we let pydantic_core's
-    'trailing-strings' mode drop the incomplete trailing token. Hand-closing the
-    string with a `"` instead produced things like `\\u00"` -> invalid escape (#77).
-    """
-    parsed = from_json(raw, allow_partial="trailing-strings")
-    return parsed.get("data", {}).get("content", "") or ""
 
 
 class ProxmoxVersionInfo(BaseModel):
@@ -175,68 +164,57 @@ class AsyncProxmoxAPI:
     async def _ping_qemu_agent(self, node: str, vm_id: int):
         await self.request("POST", f"/nodes/{node}/qemu/{vm_id}/agent/ping")
 
-    async def read_file(
-        self, node: str, vm_id: int, filepath: str, max_size: int, max_size_str: str
-    ):
-        """Read a file from the VM using QEMU agent with optional size limit.
+    # decode=0 concatenates each ~1 MiB chunk's own base64 (chunks aren't
+    # 3-aligned, so each keeps its padding) - decode segment by segment, not in
+    # one pass.
+    _B64_SEGMENT = re.compile(rb"[A-Za-z0-9+/]+={0,2}")
 
-        Args:
-            node (str): The node name
-            vm_id (int): The VM ID
-            filepath (str): Path to the file to read
-            max_size (int, optional): Maximum number of bytes to read.
-                None means no limit.
-            max_size_str (str): Human-readable string of the max_size
+    async def read_file_capped(
+        self, node: str, vm_id: int, filepath: str, count: int
+    ) -> Tuple[bytes, bool]:
+        """Read up to `count` bytes of a guest file; return (data, truncated).
 
-        Returns:
-            dict: The file contents and metadata
-
-        Raises:
-            FileTooLargeError: If the file size exceeds max_size
+        Uses agent file-read decode=0 (base64), not the default decode=1:
+        decode=1 returns Latin-1-mangled UTF-8 that inflates binary ~2-6x, and
+        large responses then fail with an upstream "597 Broken pipe". API:
+        https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/agent/file-read
         """
         path = f"/nodes/{node}/qemu/{vm_id}/agent/file-read"
-
         async with httpx.AsyncClient(
             verify=self.verify_tls,
             timeout=httpx.Timeout(connect=15, read=60, write=60, pool=60),
         ) as client:
-            # ping to refresh token if needed, so we don't have to do it in the stream
             await self._ping_qemu_agent(node, vm_id)
-
-            async with client.stream(
-                "GET",
+            response = await client.get(
                 f"{self.api_base_url}{path}",
                 headers={
                     "Cookie": f"PVEAuthCookie={self.ticket}",
+                    # Opt out of pveproxy response compression: it truncates
+                    # large incompressible bodies mid-transfer, surfacing as an
+                    # upstream "597 Broken pipe".
+                    "Accept-Encoding": "identity",
                 },
-                params={"file": filepath},
-            ) as response:
-                response.raise_for_status()
-
-                # Check Content-Length if available
-                content_length = response.headers.get("content-length")
-                if content_length and max_size:
-                    if int(content_length) > max_size:
-                        await response.aclose()
-                        raise OutputLimitExceededError(max_size_str, None)
-
-                # Read the response in chunks
-                chunks = []
-                total_size = 0
-
-                async for chunk in response.aiter_bytes(chunk_size=8192):
-                    chunks.append(chunk)
-                    total_size += len(chunk)
-
-                    if max_size and total_size > max_size:
-                        await response.aclose()
-
-                        truncated_content = _parse_truncated_file_read(b"".join(chunks))
-                        raise OutputLimitExceededError(max_size_str, truncated_content)
-
-                # Combine chunks and parse JSON
-                full_response = b"".join(chunks)
-                return httpx.Response(200, content=full_response).json()["data"]
+                params={"file": filepath, "count": count, "decode": 0},
+            )
+            if response.is_error:
+                # Mirror request()'s error so callers can still match the agent's
+                # message text (e.g. "No such file", "Is a directory").
+                message = (
+                    f"HTTP response error: {response.status_code} "
+                    f"{response.reason_phrase}"
+                )
+                if response.text:
+                    message += f": {response.text}"
+                raise httpx.HTTPStatusError(
+                    message, request=response.request, response=response
+                )
+            data = response.json()["data"]
+        content: str = data.get("content") or ""
+        raw = b"".join(
+            base64.b64decode(seg)
+            for seg in self._B64_SEGMENT.findall(content.encode("ascii"))
+        )
+        return raw, bool(data.get("truncated"))
 
     async def upload_file_with_curl(
         self,

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -65,13 +65,6 @@ def _split_chunks(
 _EXEC_POLL_GRACE_SECONDS = _IN_GUEST_KILL_GRACE + 3
 
 
-def _recover_qga_bytes(mangled: str) -> bytes:
-    # Proxmox's file-read returns each raw file byte as a Latin-1 codepoint, then
-    # serialises that as UTF-8 JSON, so non-ASCII bytes arrive double-encoded
-    # (e.g. "é" -> "Ã©"). Encoding back to ISO-8859-1 recovers the original bytes.
-    return mangled.encode("iso-8859-1")
-
-
 class ReturnCodeNotWritten(Exception):
     """The exec wrapper exited without writing its returncode file."""
 
@@ -883,40 +876,30 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         reraise=True,
     )
     async def _read_return_code(self, tmp_start) -> int:
-        returncode_string = (
-            await self.agent_commands.read_file_or_blank(
-                vm_id=self.vm_id,
-                filepath=f"{tmp_start}script.returncode",
-                max_size=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
-            )
-        )["content"]
-        returncode_string_stripped = returncode_string.strip()
+        raw, _truncated = await self.agent_commands.read_file_capped_or_blank(
+            vm_id=self.vm_id,
+            filepath=f"{tmp_start}script.returncode",
+            count=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+        )
+        returncode_string_stripped = raw.decode("utf-8", errors="replace").strip()
         if len(returncode_string_stripped) == 0:
             raise ReturnCodeNotWritten()
         return int(returncode_string_stripped)
 
     async def _read_exec_output(self, filepath: str) -> str:
-        try:
-            response = await self.agent_commands.read_file_or_blank(
-                vm_id=self.vm_id,
-                filepath=filepath,
-                max_size=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+        # decode=0 gives raw bytes; decode UTF-8 errors="replace" (output is
+        # arbitrary bytes). Oversized output is flagged via `truncated`.
+        raw, truncated = await self.agent_commands.read_file_capped_or_blank(
+            vm_id=self.vm_id,
+            filepath=filepath,
+            count=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+        )
+        text = raw.decode("utf-8", errors="replace")
+        if truncated:
+            raise OutputLimitExceededError(
+                SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE_STR, text
             )
-        except OutputLimitExceededError as ex:
-            # truncated_output arrives in Proxmox's mangled wire form; decode it the
-            # same way as a full read so the truncated text matches what a non-truncated
-            # read would have produced, rather than leaking mojibake to the caller.
-            if ex.truncated_output is not None:
-                ex.truncated_output = self._decode_exec_output(ex.truncated_output)
-            raise
-        return self._decode_exec_output(response["content"])
-
-    @staticmethod
-    def _decode_exec_output(content: str) -> str:
-        # ExecResult.stdout/stderr are str, so undo Proxmox's file-read mangling
-        # (see _recover_qga_bytes) and decode as UTF-8. errors="replace" because
-        # a command's output can be arbitrary bytes, not necessarily valid UTF-8.
-        return _recover_qga_bytes(content).decode("utf-8", errors="replace")
+        return text
 
     # Platform-specific "file not found" messages from the QEMU guest agent.
     _FILE_NOT_FOUND_ERRORS = [
@@ -1176,13 +1159,14 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         """
         if self.vm_id is None:
             raise ValueError("VM ID is not set")
-        # Note, per https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vm_id}/agent/file-read
-        # read from proxmox API is limited to 16777216 bytes
+        # PVE caps agent file-read at 16 MiB; cap at the (test-overridable)
+        # Inspect limit, never above that.
+        cap = min(SandboxEnvironmentLimits.MAX_READ_FILE_SIZE, 16777216)
         try:
-            read_get_response = await self.agent_commands.read_file(
+            data_bytes, truncated = await self.agent_commands.read_file_capped(
                 vm_id=self.vm_id,
                 filepath=file,
-                max_size=min(SandboxEnvironmentLimits.MAX_READ_FILE_SIZE, 16777216),
+                count=cap,
             )
         except Exception as ex:
             if "Agent error" in str(ex):
@@ -1198,17 +1182,18 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                     raise ex
             else:
                 raise ex
-        if (
-            getattr(read_get_response, "truncated", False)
-            or len(read_get_response["content"])
-            >= SandboxEnvironmentLimits.MAX_READ_FILE_SIZE
-        ):
-            raise OutputLimitExceededError("Output size exceeds 16 MiB limit.", file)
-        bytes_data = _recover_qga_bytes(read_get_response["content"])
+        if truncated:
+            # File exceeds the cap; report the active limit (16 MiB or a test override).
+            limit_str = (
+                SandboxEnvironmentLimits.MAX_READ_FILE_SIZE_STR
+                if SandboxEnvironmentLimits.MAX_READ_FILE_SIZE <= 16777216
+                else "16 MiB"
+            )
+            raise OutputLimitExceededError(limit_str, None)
         if text:
-            return bytes_data.decode("utf-8")
+            return data_bytes.decode("utf-8")
         else:
-            return bytes_data
+            return data_bytes
 
     @override
     async def connection(self, *, user: str | None = None) -> SandboxConnection:

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -2,6 +2,7 @@ import hashlib
 from pathlib import Path
 from typing import List
 
+import httpx
 import pytest
 import tenacity
 from inspect_ai.util import OutputLimitExceededError
@@ -38,49 +39,128 @@ _EMOJI = "\U0001f600"
 _EMOJI_BYTES = _EMOJI.encode("utf-8")  # b"\xf0\x9f\x98\x80"
 
 
-@pytest.mark.parametrize("lead", ["", "a"], ids=["even-offset", "odd-offset"])
 async def test_exec_10mb_limit(
-    proxmox_sandbox_environment: ProxmoxSandboxEnvironment, lead: str
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
 ) -> None:
-    # Output over MAX_EXEC_OUTPUT_SIZE (10 MiB) must truncate cleanly, even when
-    # the cut lands in the middle of a multi-byte sequence (issue #77). An all-'a'
-    # version of this test never hit that: plain ASCII has no multi-byte sequences
-    # for the cut to split, so it always parsed cleanly.
-    #
-    # read_file streams the file-read response in 8192-byte chunks and stops once
-    # the total first exceeds 10 MiB, so the cut is at a fixed, even byte offset
-    # (1281*8192 = 10493952). Each non-ASCII output byte comes back as a 2-byte
-    # sequence on the wire (Proxmox re-encodes raw bytes via latin-1), and every
-    # byte of our emoji is non-ASCII, so the whole payload is 2-byte wire pairs.
-    # Whether the cut splits one of those pairs depends on the parity of the offset
-    # at which they start, which we can't predict exactly (the JSON field order is
-    # non-deterministic). So we run two outputs differing by a single leading byte:
-    # their pairs sit on opposite parities, so exactly one variant lands mid-sequence
-    # and reproduces the crash. Pre-fix that variant raised
-    # `ValueError: invalid unicode code point`; both must now truncate cleanly.
+    # Oversized exec output must surface as OutputLimitExceededError. decode=0
+    # reads whole bytes, so multi-byte output survives truncation (at most one
+    # trailing U+FFFD).
     if proxmox_sandbox_environment._is_windows():
-        pytest.skip("byte-level multi-byte boundary repro is Linux-only")
+        pytest.skip("multi-byte output repro is Linux-only")
 
     count = pow(2, 20) * 3  # 3 Mi emoji * 4 bytes = 12 MiB, well over the 10 MiB limit
     escaped = "".join(f"\\x{b:02x}" for b in _EMOJI_BYTES)
     exec_cmd = [
         "perl",
         "-e",
-        f'binmode STDOUT; print "{lead}", "{escaped}" x {count}',
+        f'binmode STDOUT; print "{escaped}" x {count}',
     ]
 
     with pytest.raises(OutputLimitExceededError) as exc_info:
         await proxmox_sandbox_environment.exec(exec_cmd, timeout=120)
 
-    # Partial output is recovered and decoded like a full read: the optional ASCII
-    # lead, then whole emoji. The size cut can fall inside a 4-byte sequence, leaving
-    # at most one trailing U+FFFD replacement char rather than crashing the parse.
     truncated = exc_info.value.truncated_output
     assert isinstance(truncated, str)
-    assert truncated.startswith(lead)
-    body = truncated[len(lead) :]
-    assert body.rstrip("�").strip(_EMOJI) == ""
-    assert len(body) > 1_000_000
+    assert truncated.rstrip("�").strip(_EMOJI) == ""
+    assert len(truncated) > 1_000_000
+
+
+async def test_exec_large_binary_output_surfaces_cleanly(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    """Oversized (binary) exec output raises OutputLimitExceededError, not a 597."""
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("binary stdout repro is Linux-only")
+
+    # 30 MiB of random bytes straight to stdout, well over the 10 MiB exec cap.
+    with pytest.raises(OutputLimitExceededError):
+        await proxmox_sandbox_environment.exec(
+            ["sh", "-c", "head -c 31457280 /dev/urandom"], timeout=120
+        )
+
+
+async def test_read_file_large_binary_surfaces_cleanly(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    """read_file round-trips a multi-MiB binary and rejects oversized files.
+
+    14 MiB round-trips byte-exact (also exercises the decode=0 segment-decode);
+    20 MiB (over the 16 MiB cap) raises OutputLimitExceededError, not a 597.
+    """
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("binary repro is Linux-only")
+    env = proxmox_sandbox_environment
+
+    # 14 MiB binary (multi-chunk, not 3-aligned) must round-trip byte-exact.
+    await env.exec(
+        ["sh", "-c", "head -c 14680064 /dev/urandom > /tmp/rf14"], timeout=60
+    )
+    md5_guest = (await env.exec(["md5sum", "/tmp/rf14"])).stdout.split()[0]
+    data = await env.read_file("/tmp/rf14", text=False)
+    assert isinstance(data, bytes) and len(data) == 14680064
+    assert hashlib.md5(data).hexdigest() == md5_guest
+
+    # 20 MiB (over the 16 MiB cap) must fail cleanly, not crash with a 597.
+    await env.exec(
+        ["sh", "-c", "head -c 20971520 /dev/urandom > /tmp/rf20"], timeout=60
+    )
+    with pytest.raises(OutputLimitExceededError):
+        await env.read_file("/tmp/rf20", text=False)
+
+
+async def test_file_read_597_is_response_compression(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    """Pin the upstream 597: it depends on negotiated response compression.
+
+    A large incompressible body truncates mid-transfer (597) when gzip is
+    accepted but delivers fine as `identity` - which is why read_file_capped
+    sends Accept-Encoding: identity. decode=1 here makes the body big enough to
+    trip it.
+    """
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("Linux-only")
+    env = proxmox_sandbox_environment
+    api = env.agent_commands.async_proxmox
+
+    # ~14 MiB of incompressible random -> decode=1 body well past the cliff.
+    await env.exec(
+        ["sh", "-c", "head -c 14680064 /dev/urandom > /tmp/incompressible"], timeout=60
+    )
+    await api.request("GET", "/version")  # ensure a ticket
+    url = (
+        f"{api.api_base_url}/nodes/{env.agent_commands.node}"
+        f"/qemu/{env.vm_id}/agent/file-read"
+    )
+
+    async def read_with(accept_encoding: str) -> httpx.Response:
+        async with httpx.AsyncClient(
+            verify=api.verify_tls,
+            timeout=httpx.Timeout(connect=15, read=120, write=60, pool=60),
+        ) as client:
+            return await client.get(
+                url,
+                headers={
+                    "Cookie": f"PVEAuthCookie={api.ticket}",
+                    "Accept-Encoding": accept_encoding,
+                },
+                params={"file": "/tmp/incompressible", "decode": 1},
+            )
+
+    # identity: the full body is delivered.
+    identity_resp = await read_with("identity")
+    assert identity_resp.status_code == 200
+    assert len(identity_resp.content) > 14_000_000
+
+    # any negotiated compression: pveproxy tears the large incompressible body
+    # down with a non-standard 596/597. (If a future Proxmox stops doing this,
+    # this assertion flips - which is the signal that the workaround can go.)
+    for accept_encoding in ("gzip", "gzip, deflate, br"):
+        resp = await read_with(accept_encoding)
+        assert resp.status_code in (596, 597), (
+            f"expected 596/597 for Accept-Encoding={accept_encoding!r}, "
+            f"got {resp.status_code}"
+        )
 
 
 CURRENT_DIR = Path(__file__).parent
@@ -150,8 +230,17 @@ async def test_self_check(
         "test_read_and_write_large_file_binary",
     ]
 
-    return await check_results_of_self_check(
+    results = await check_results_of_self_check(
         proxmox_sandbox_environment, known_failures
+    )
+
+    # 50 MiB can't round-trip (16 MiB cap) so it stays a known failure - but it
+    # must fail *gracefully* (OutputLimitExceededError), not a raw 597. The old
+    # outcome-blind exclusion is how the crash slipped through.
+    large_file_result = results["test_read_and_write_large_file_binary"]
+    assert "OutputLimitExceededError" in str(large_file_result), (
+        "Oversized read_file must fail with OutputLimitExceededError, got: "
+        f"{large_file_result!r}"
     )
 
 
@@ -177,3 +266,4 @@ async def check_results_of_self_check(sandbox_env, known_failures=[]):
             failures.append(f"Test {test_name} failed: {result}")
     if failures:
         assert False, "\n".join(failures)
+    return self_check_results

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -108,6 +108,35 @@ async def test_read_file_large_binary_surfaces_cleanly(
         await env.read_file("/tmp/rf20", text=False)
 
 
+async def test_read_file_under_cap_but_wire_expanding_round_trips(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    r"""A file under the 16 MiB cap whose content expanded on the wire (#81).
+
+    Under the old decode=1 path the limit was counted against JSON wire bytes,
+    not raw bytes. A control byte JSON-escapes to `\u00XX` (6x), so this 8 MiB
+    file ballooned to ~48 MiB on the wire and tripped the output limit - a file
+    well under any documented cap, rejected purely because of its content. With
+    decode=0 the limit is the raw-byte `count`, so it round-trips byte-exact.
+    """
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("byte-level wire-expansion repro is Linux-only")
+    env = proxmox_sandbox_environment
+
+    # 8 MiB of 0x01: raw is under the 16 MiB cap, but each byte is `\u0001`
+    # (6 chars) in the decode=1 JSON, so the old wire size was ~48 MiB.
+    size = 8 * 1024 * 1024
+    await env.exec(
+        ["sh", "-c", f"head -c {size} /dev/zero | tr '\\0' '\\1' > /tmp/rf_ctrl"],
+        timeout=60,
+    )
+    md5_guest = (await env.exec(["md5sum", "/tmp/rf_ctrl"])).stdout.split()[0]
+    data = await env.read_file("/tmp/rf_ctrl", text=False)
+    assert isinstance(data, bytes)
+    assert data == b"\x01" * size
+    assert hashlib.md5(data).hexdigest() == md5_guest
+
+
 async def test_file_read_597_is_response_compression(
     proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
 ) -> None:


### PR DESCRIPTION
## Problem

Reading a large or binary guest file (`read_file`) or command output (`exec`) fails with a non-standard **`HTTP 597 "Broken pipe"`**, retried 5× (deterministic, so every attempt fails), then propagates as an unhandled `HTTPStatusError` and crashes the caller.

## Root cause — pvedaemon self-aborts a large gzip'd response (isolated + instrumented on a live host)

Not body size per se, not the read, not `pveproxy` relaying — it's **response compression tripping a server-side timeout**:

| request (same 16 MiB random file) | result |
|---|---|
| `Accept-Encoding: gzip` (httpx default) | **597** |
| `Accept-Encoding: identity` | **200**, 34.5 MB body |
| 16 MiB *uniform* file, `gzip` | 200 (compresses to ~nothing) |

`pveproxy` forwards `Accept-Encoding: gzip` to `pvedaemon`, which builds the file-read response, then in `PVE::APIServer::AnyEvent::response()` **re-arms the client handle's 5 s inactivity timeout (`$self->{timeout}`) and only *then* runs `Compress::Zlib::memGzip` on the whole body**. For a large body `memGzip` blocks the event loop for >5 s, so when the loop resumes and `push_write`s the gzip'd body the timeout is **already overdue** and fires immediately.

Instrumented pvedaemon confirms it exactly:
```
RESP clen=22013635 gzip=1 → ABORT err=[Connection timed out] wbuf_remaining=19284451
```
The connection is torn down with 19.28 MB still unsent; only `22,013,635 − 19,284,451 = 2,729,184` bytes (one socket-buffer flush) reach the wire — a **truncated gzip stream** (I verified: `gunzip` yields "unexpected end of file"). `pvedaemon`'s `Content-Length` is *correct* (22 MB); the body is just cut short. Bumping that 5 s timeout to 60 s (nothing else changed) makes the same reads deliver the full body — intervention-level confirmation of the mechanism.

A lenient client (`curl`) takes the short body as `200` (partial, exit 18); **pveproxy's AnyEvent::HTTP sees body < Content-Length → 597**, which is what the sandbox client gets. The boundary is *sharp* (deterministic) because the thing being timed is CPU work (memGzip duration), not I/O — below ~5 s of memGzip the response delivers fully, above it truncates. `identity` skips memGzip, so it never blocks and delivers 34.5 MB fine.

This is an upstream Proxmox bug (arming a response timeout before a synchronous whole-body gzip). Proxmox documents only the 16 MiB *read* cap (→ truncation); this failure is undocumented.

## Fix

- **Send `Accept-Encoding: identity` on guest file reads** — opt out of pveproxy's response compression (the root cause). Even a 34.5 MB random body then transfers fine.
- **Move reads from `decode=1` to `decode=0`.** The default `decode=1` returns content as Latin-1-mangled UTF-8 (~2–6× on the wire, arriving corrupted and needing un-mangling). `decode=0` forwards base64 — **~4/3 the content size regardless of the bytes, and lossless.** Reads are bounded with `count`; oversized files/output surface as `OutputLimitExceededError` via Proxmox's `truncated` flag. PVE builds `decode=0` output by concatenating per-~1 MiB-chunk base64 (1 MiB isn't a multiple of 3, so segments carry their own `=` padding), so it's decoded segment-by-segment. `decode`/`count` are documented in the [PVE API viewer](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/agent/file-read).

`decode=0` also **removes the Latin-1 mangling machinery** (`_recover_qga_bytes`, `_parse_truncated_file_read`, `_decode_exec_output`, the decode=1 streaming read) and the fragile truncation handling for cuts landing inside a multi-byte sequence — issues #77 / #80 are no longer reachable. Net **−137 lines** in `src/`.

## Tests (run against a real Proxmox instance)

- `test_file_read_597_is_response_compression` — characterises the upstream behaviour across `Accept-Encoding` headers: `identity` delivers a 14 MiB incompressible body (200); `gzip` and `gzip, deflate, br` return 596/597. Pins the root cause and guards the `identity` workaround.
- `test_exec_large_binary_output_surfaces_cleanly` — 30 MiB stdout → `OutputLimitExceededError`, not 597.
- `test_read_file_large_binary_surfaces_cleanly` — 14 MiB binary round-trips byte-exact (md5); 20 MiB → `OutputLimitExceededError`.
- Tightened `test_self_check` — the 50 MiB `test_read_and_write_large_file_binary` known-failure must now fail with `OutputLimitExceededError` specifically. It was previously excluded with an outcome-blind check (any non-pass accepted), which is why the suite never flagged the crash.
- `test_exec_10mb_limit` simplified — decode=0 reads whole bytes, so the even/odd byte-boundary parametrization is no longer needed.

Full `test_proxmox_sandbox_agent_commands.py` passes; `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
