### PR TITLE
refactor: unify guest reads on decode=0, dropping the Latin-1 mangling path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: reading a guest file or command output larger than ~10 MiB no longer crashes with a non-standard HTTP 597 "Broken pipe". The agent file-read was issued without a `count` cap, so Proxmox tried to return the whole file in one base64-inflated JSON body that the `pveproxy`→`pvedaemon` hop could not deliver. `read_file()` now reads via the agent's `decode=0` mode (a compact, content-independent response body) so a full 16 MiB read stays deliverable and oversized files surface as `OutputLimitExceededError`; `exec()` output reads are capped at the output limit so they cannot overrun the proxy either.
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
 
 ## 0.11.0 - 2026-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Internal: all guest reads (`read_file` and command stdout/stderr) now use the agent file-read `decode=0` mode (content forwarded as base64) instead of the default `decode=1` (Latin-1-mangled UTF-8). decode=1 inflated binary 2-6x on the wire — the 597 root cause — and required un-mangling on read; decode=0 keeps the wire body at ~4/3 the content size regardless of the bytes and is lossless, removing the mangling-recovery path entirely.
 - Fix: reading a guest file or command output larger than ~10 MiB no longer crashes with a non-standard HTTP 597 "Broken pipe". The agent file-read was issued without a `count` cap, so Proxmox tried to return the whole file in one base64-inflated JSON body that the `pveproxy`→`pvedaemon` hop could not deliver. `read_file()` now reads via the agent's `decode=0` mode (a compact, content-independent response body) so a full 16 MiB read stays deliverable and oversized files surface as `OutputLimitExceededError`; `exec()` output reads are capped at the output limit so they cannot overrun the proxy either.
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
 

--- a/src/proxmoxsandbox/_impl/agent_commands.py
+++ b/src/proxmoxsandbox/_impl/agent_commands.py
@@ -210,6 +210,15 @@ class AgentCommands:
             ),
         )
 
+    async def read_file_capped(self, vm_id: int, filepath: str, count: int):
+        """Retried decode=0 read; returns (data_bytes, truncated)."""
+        return await self._retry_on_qga_error(
+            f"read_file_capped vm={vm_id} {filepath}",
+            lambda: self.async_proxmox.read_file_capped(
+                self.node, vm_id, filepath, count
+            ),
+        )
+
     async def create_snapshot(self, vm_id: int, snapshot_name: str) -> None:
         path = f"/nodes/{self.node}/qemu/{vm_id}/snapshot"
         data: ProxmoxJsonDataType = {"snapname": snapshot_name, "vmstate": 1}

--- a/src/proxmoxsandbox/_impl/agent_commands.py
+++ b/src/proxmoxsandbox/_impl/agent_commands.py
@@ -1,11 +1,10 @@
 import asyncio
 import base64
 from logging import getLogger
-from typing import List
+from typing import List, Tuple
 
 import httpx
 from inspect_ai.util import (
-    SandboxEnvironmentLimits,
     trace_action,
 )
 
@@ -168,56 +167,35 @@ class AgentCommands:
                 lambda: self.async_proxmox.request("POST", path, json=data),
             )
 
-    async def read_file_or_blank(
-        self,
-        vm_id: int,
-        filepath: str,
-        max_size: int = SandboxEnvironmentLimits.MAX_READ_FILE_SIZE,
-    ):
+    async def read_file_capped(
+        self, vm_id: int, filepath: str, count: int
+    ) -> Tuple[bytes, bool]:
+        """Retried decode=0 read of up to `count` bytes; returns (data, truncated)."""
         with trace_action(
             self.logger,
             self.TRACE_NAME,
-            f"read_file_or_blank {vm_id=} {filepath=} {max_size=}",
+            f"read_file_capped {vm_id=} {filepath=} {count=}",
         ):
-            try:
-                return await self.read_file(vm_id, filepath, max_size)
-            except httpx.HTTPStatusError as e:
-                if (
-                    e.response.status_code == 500
-                    and "no such file" in e.response.reason_phrase.casefold()
-                ):
-                    return {"content": ""}
-                else:
-                    raise e
+            return await self._retry_on_qga_error(
+                f"read_file_capped vm={vm_id} {filepath}",
+                lambda: self.async_proxmox.read_file_capped(
+                    self.node, vm_id, filepath, count
+                ),
+            )
 
-    async def read_file(
-        self,
-        vm_id: int,
-        filepath: str,
-        max_size: int = SandboxEnvironmentLimits.MAX_READ_FILE_SIZE,
-    ):
-        # this is a hack; it would be better to use a type here with
-        # e.g. size_bytes and friendly_name
-        max_size_str = (
-            SandboxEnvironmentLimits.MAX_READ_FILE_SIZE_STR
-            if max_size == SandboxEnvironmentLimits.MAX_READ_FILE_SIZE
-            else SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE_STR
-        )
-        return await self._retry_on_qga_error(
-            f"read_file vm={vm_id} {filepath}",
-            lambda: self.async_proxmox.read_file(
-                self.node, vm_id, filepath, max_size, max_size_str
-            ),
-        )
-
-    async def read_file_capped(self, vm_id: int, filepath: str, count: int):
-        """Retried decode=0 read; returns (data_bytes, truncated)."""
-        return await self._retry_on_qga_error(
-            f"read_file_capped vm={vm_id} {filepath}",
-            lambda: self.async_proxmox.read_file_capped(
-                self.node, vm_id, filepath, count
-            ),
-        )
+    async def read_file_capped_or_blank(
+        self, vm_id: int, filepath: str, count: int
+    ) -> Tuple[bytes, bool]:
+        """Like read_file_capped but returns (b"", False) for a missing file."""
+        try:
+            return await self.read_file_capped(vm_id, filepath, count)
+        except httpx.HTTPStatusError as e:
+            msg = str(e).casefold()
+            if e.response.status_code == 500 and (
+                "no such file" in msg or "failed to open file" in msg
+            ):
+                return b"", False
+            raise
 
     async def create_snapshot(self, vm_id: int, snapshot_name: str) -> None:
         path = f"/nodes/{self.node}/qemu/{vm_id}/snapshot"

--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -12,24 +12,11 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 import httpx
 import pycurl
 from inspect_ai.util import (
-    OutputLimitExceededError,
     trace_action,
 )
 from pydantic import BaseModel
-from pydantic_core import from_json
 
 ProxmoxJsonDataType = Dict[str, Union[str, List[str], int, bool, None]]
-
-
-def _parse_truncated_file_read(raw: bytes) -> str:
-    r"""Extract data.content from a QGA file-read body cut off at the size limit.
-
-    The cut can land inside a JSON `\\uXXXX` escape, so we let pydantic_core's
-    'trailing-strings' mode drop the incomplete trailing token. Hand-closing the
-    string with a `"` instead produced things like `\\u00"` -> invalid escape (#77).
-    """
-    parsed = from_json(raw, allow_partial="trailing-strings")
-    return parsed.get("data", {}).get("content", "") or ""
 
 
 class ProxmoxVersionInfo(BaseModel):
@@ -177,80 +164,6 @@ class AsyncProxmoxAPI:
     async def _ping_qemu_agent(self, node: str, vm_id: int):
         await self.request("POST", f"/nodes/{node}/qemu/{vm_id}/agent/ping")
 
-    async def read_file(
-        self, node: str, vm_id: int, filepath: str, max_size: int, max_size_str: str
-    ):
-        """Read a file from the VM using QEMU agent with optional size limit.
-
-        Args:
-            node (str): The node name
-            vm_id (int): The VM ID
-            filepath (str): Path to the file to read
-            max_size (int, optional): Maximum number of bytes to read.
-                None means no limit.
-            max_size_str (str): Human-readable string of the max_size
-
-        Returns:
-            dict: The file contents and metadata
-
-        Raises:
-            FileTooLargeError: If the file size exceeds max_size
-        """
-        path = f"/nodes/{node}/qemu/{vm_id}/agent/file-read"
-
-        async with httpx.AsyncClient(
-            verify=self.verify_tls,
-            timeout=httpx.Timeout(connect=15, read=60, write=60, pool=60),
-        ) as client:
-            # ping to refresh token if needed, so we don't have to do it in the stream
-            await self._ping_qemu_agent(node, vm_id)
-
-            # Cap the read at max_size via the API's `count` param. Without it
-            # PVE reads up to its 16 MiB default and tries to ship the whole
-            # file back in one base64-inflated JSON body; for content over
-            # ~10 MiB the pveproxy->pvedaemon hop tears that body down and
-            # returns a non-standard "597 Broken pipe", which escapes the retry
-            # layer and crashes the sample. Bounding the read keeps the response
-            # deliverable, so an oversized file surfaces as a clean
-            # OutputLimitExceededError (below) instead.
-            params: Dict[str, Union[str, int]] = {"file": filepath}
-            if max_size:
-                params["count"] = max_size
-            async with client.stream(
-                "GET",
-                f"{self.api_base_url}{path}",
-                headers={
-                    "Cookie": f"PVEAuthCookie={self.ticket}",
-                },
-                params=params,
-            ) as response:
-                response.raise_for_status()
-
-                # Check Content-Length if available
-                content_length = response.headers.get("content-length")
-                if content_length and max_size:
-                    if int(content_length) > max_size:
-                        await response.aclose()
-                        raise OutputLimitExceededError(max_size_str, None)
-
-                # Read the response in chunks
-                chunks = []
-                total_size = 0
-
-                async for chunk in response.aiter_bytes(chunk_size=8192):
-                    chunks.append(chunk)
-                    total_size += len(chunk)
-
-                    if max_size and total_size > max_size:
-                        await response.aclose()
-
-                        truncated_content = _parse_truncated_file_read(b"".join(chunks))
-                        raise OutputLimitExceededError(max_size_str, truncated_content)
-
-                # Combine chunks and parse JSON
-                full_response = b"".join(chunks)
-                return httpx.Response(200, content=full_response).json()["data"]
-
     # `decode=0` content is the concatenation of each ~1 MiB read chunk's own
     # base64; 1 MiB is not a multiple of 3, so segments carry their own `=`
     # padding and the whole string won't decode in one pass. Each maximal
@@ -262,14 +175,16 @@ class AsyncProxmoxAPI:
     ) -> Tuple[bytes, bool]:
         """Read up to `count` bytes of a guest file; return (data, truncated).
 
-        Uses the agent file-read `decode=0` mode (content forwarded as base64)
-        rather than `decode=1` (content as Latin-1-mangled UTF-8). decode=1
-        inflates binary 2-6x on the wire, so for files over ~10 MiB the JSON
-        body overruns the pveproxy->pvedaemon hop and returns a non-standard
-        "597 Broken pipe" that escapes the retry layer and crashes the caller.
-        decode=0 keeps the body at ~4/3 the content size regardless of the
-        bytes, so a full 16 MiB read stays deliverable. `count` bounds the read;
-        PVE sets `truncated` when the file holds more than that.
+        Uses the agent file-read `decode`/`count` params, documented at
+        https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/agent/file-read
+        (also limits any read to 16 MiB). `decode=0` forwards content as base64;
+        the default `decode=1` returns it as Latin-1-mangled UTF-8 that inflates
+        binary 2-6x on the wire, so for files over ~10 MiB the JSON body overruns
+        the pveproxy->pvedaemon hop and returns a non-standard "597 Broken pipe"
+        that escapes the retry layer and crashes the caller. `decode=0` keeps the
+        body at ~4/3 the content size regardless of the bytes, so a full 16 MiB
+        read stays deliverable. `count` bounds the read; PVE sets `truncated`
+        when the file holds more than that.
         """
         path = f"/nodes/{node}/qemu/{vm_id}/agent/file-read"
         async with httpx.AsyncClient(

--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -1,11 +1,13 @@
 import asyncio
+import base64
 import json
+import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import httpx
 import pycurl
@@ -203,13 +205,24 @@ class AsyncProxmoxAPI:
             # ping to refresh token if needed, so we don't have to do it in the stream
             await self._ping_qemu_agent(node, vm_id)
 
+            # Cap the read at max_size via the API's `count` param. Without it
+            # PVE reads up to its 16 MiB default and tries to ship the whole
+            # file back in one base64-inflated JSON body; for content over
+            # ~10 MiB the pveproxy->pvedaemon hop tears that body down and
+            # returns a non-standard "597 Broken pipe", which escapes the retry
+            # layer and crashes the sample. Bounding the read keeps the response
+            # deliverable, so an oversized file surfaces as a clean
+            # OutputLimitExceededError (below) instead.
+            params: Dict[str, Union[str, int]] = {"file": filepath}
+            if max_size:
+                params["count"] = max_size
             async with client.stream(
                 "GET",
                 f"{self.api_base_url}{path}",
                 headers={
                     "Cookie": f"PVEAuthCookie={self.ticket}",
                 },
-                params={"file": filepath},
+                params=params,
             ) as response:
                 response.raise_for_status()
 
@@ -237,6 +250,57 @@ class AsyncProxmoxAPI:
                 # Combine chunks and parse JSON
                 full_response = b"".join(chunks)
                 return httpx.Response(200, content=full_response).json()["data"]
+
+    # `decode=0` content is the concatenation of each ~1 MiB read chunk's own
+    # base64; 1 MiB is not a multiple of 3, so segments carry their own `=`
+    # padding and the whole string won't decode in one pass. Each maximal
+    # base64 run (optionally padding-terminated) is one segment.
+    _B64_SEGMENT = re.compile(rb"[A-Za-z0-9+/]+={0,2}")
+
+    async def read_file_capped(
+        self, node: str, vm_id: int, filepath: str, count: int
+    ) -> Tuple[bytes, bool]:
+        """Read up to `count` bytes of a guest file; return (data, truncated).
+
+        Uses the agent file-read `decode=0` mode (content forwarded as base64)
+        rather than `decode=1` (content as Latin-1-mangled UTF-8). decode=1
+        inflates binary 2-6x on the wire, so for files over ~10 MiB the JSON
+        body overruns the pveproxy->pvedaemon hop and returns a non-standard
+        "597 Broken pipe" that escapes the retry layer and crashes the caller.
+        decode=0 keeps the body at ~4/3 the content size regardless of the
+        bytes, so a full 16 MiB read stays deliverable. `count` bounds the read;
+        PVE sets `truncated` when the file holds more than that.
+        """
+        path = f"/nodes/{node}/qemu/{vm_id}/agent/file-read"
+        async with httpx.AsyncClient(
+            verify=self.verify_tls,
+            timeout=httpx.Timeout(connect=15, read=60, write=60, pool=60),
+        ) as client:
+            await self._ping_qemu_agent(node, vm_id)
+            response = await client.get(
+                f"{self.api_base_url}{path}",
+                headers={"Cookie": f"PVEAuthCookie={self.ticket}"},
+                params={"file": filepath, "count": count, "decode": 0},
+            )
+            if response.is_error:
+                # Mirror request()'s error so callers can still match the agent's
+                # message text (e.g. "No such file", "Is a directory").
+                message = (
+                    f"HTTP response error: {response.status_code} "
+                    f"{response.reason_phrase}"
+                )
+                if response.text:
+                    message += f": {response.text}"
+                raise httpx.HTTPStatusError(
+                    message, request=response.request, response=response
+                )
+            data = response.json()["data"]
+        content: str = data.get("content") or ""
+        raw = b"".join(
+            base64.b64decode(seg)
+            for seg in self._B64_SEGMENT.findall(content.encode("ascii"))
+        )
+        return raw, bool(data.get("truncated"))
 
     async def upload_file_with_curl(
         self,

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -65,13 +65,6 @@ def _split_chunks(
 _EXEC_POLL_GRACE_SECONDS = _IN_GUEST_KILL_GRACE + 3
 
 
-def _recover_qga_bytes(mangled: str) -> bytes:
-    # Proxmox's file-read returns each raw file byte as a Latin-1 codepoint, then
-    # serialises that as UTF-8 JSON, so non-ASCII bytes arrive double-encoded
-    # (e.g. "é" -> "Ã©"). Encoding back to ISO-8859-1 recovers the original bytes.
-    return mangled.encode("iso-8859-1")
-
-
 class ReturnCodeNotWritten(Exception):
     """The exec wrapper exited without writing its returncode file."""
 
@@ -883,40 +876,32 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         reraise=True,
     )
     async def _read_return_code(self, tmp_start) -> int:
-        returncode_string = (
-            await self.agent_commands.read_file_or_blank(
-                vm_id=self.vm_id,
-                filepath=f"{tmp_start}script.returncode",
-                max_size=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
-            )
-        )["content"]
-        returncode_string_stripped = returncode_string.strip()
+        raw, _truncated = await self.agent_commands.read_file_capped_or_blank(
+            vm_id=self.vm_id,
+            filepath=f"{tmp_start}script.returncode",
+            count=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+        )
+        returncode_string_stripped = raw.decode("utf-8", errors="replace").strip()
         if len(returncode_string_stripped) == 0:
             raise ReturnCodeNotWritten()
         return int(returncode_string_stripped)
 
     async def _read_exec_output(self, filepath: str) -> str:
-        try:
-            response = await self.agent_commands.read_file_or_blank(
-                vm_id=self.vm_id,
-                filepath=filepath,
-                max_size=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+        # ExecResult.stdout/stderr are str. decode=0 returns raw bytes, so decode
+        # as UTF-8 with errors="replace" (command output is arbitrary bytes, not
+        # necessarily valid UTF-8). Output over the cap is reported via the
+        # truncated flag - the returned text already holds the first MAX bytes.
+        raw, truncated = await self.agent_commands.read_file_capped_or_blank(
+            vm_id=self.vm_id,
+            filepath=filepath,
+            count=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+        )
+        text = raw.decode("utf-8", errors="replace")
+        if truncated:
+            raise OutputLimitExceededError(
+                SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE_STR, text
             )
-        except OutputLimitExceededError as ex:
-            # truncated_output arrives in Proxmox's mangled wire form; decode it the
-            # same way as a full read so the truncated text matches what a non-truncated
-            # read would have produced, rather than leaking mojibake to the caller.
-            if ex.truncated_output is not None:
-                ex.truncated_output = self._decode_exec_output(ex.truncated_output)
-            raise
-        return self._decode_exec_output(response["content"])
-
-    @staticmethod
-    def _decode_exec_output(content: str) -> str:
-        # ExecResult.stdout/stderr are str, so undo Proxmox's file-read mangling
-        # (see _recover_qga_bytes) and decode as UTF-8. errors="replace" because
-        # a command's output can be arbitrary bytes, not necessarily valid UTF-8.
-        return _recover_qga_bytes(content).decode("utf-8", errors="replace")
+        return text
 
     # Platform-specific "file not found" messages from the QEMU guest agent.
     _FILE_NOT_FOUND_ERRORS = [

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -1176,13 +1176,18 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         """
         if self.vm_id is None:
             raise ValueError("VM ID is not set")
-        # Note, per https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vm_id}/agent/file-read
-        # read from proxmox API is limited to 16777216 bytes
+        # Per https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vm_id}/agent/file-read
+        # the agent file-read API is hard-limited to 16777216 bytes. We cap the
+        # read at the (possibly test-overridden) Inspect limit, never above
+        # 16 MiB. Passing `count` also keeps PVE from trying to return the whole
+        # file in one oversized body, which for content over ~10 MiB triggers a
+        # "597 Broken pipe" from the proxy hop (see read_file_capped).
+        cap = min(SandboxEnvironmentLimits.MAX_READ_FILE_SIZE, 16777216)
         try:
-            read_get_response = await self.agent_commands.read_file(
+            data_bytes, truncated = await self.agent_commands.read_file_capped(
                 vm_id=self.vm_id,
                 filepath=file,
-                max_size=min(SandboxEnvironmentLimits.MAX_READ_FILE_SIZE, 16777216),
+                count=cap,
             )
         except Exception as ex:
             if "Agent error" in str(ex):
@@ -1198,17 +1203,19 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                     raise ex
             else:
                 raise ex
-        if (
-            getattr(read_get_response, "truncated", False)
-            or len(read_get_response["content"])
-            >= SandboxEnvironmentLimits.MAX_READ_FILE_SIZE
-        ):
-            raise OutputLimitExceededError("Output size exceeds 16 MiB limit.", file)
-        bytes_data = _recover_qga_bytes(read_get_response["content"])
+        if truncated:
+            # File has more bytes than the cap. Report the active limit (the
+            # 16 MiB Proxmox ceiling, or a smaller test-overridden one).
+            limit_str = (
+                SandboxEnvironmentLimits.MAX_READ_FILE_SIZE_STR
+                if SandboxEnvironmentLimits.MAX_READ_FILE_SIZE <= 16777216
+                else "16 MiB"
+            )
+            raise OutputLimitExceededError(limit_str, None)
         if text:
-            return bytes_data.decode("utf-8")
+            return data_bytes.decode("utf-8")
         else:
-            return bytes_data
+            return data_bytes
 
     @override
     async def connection(self, *, user: str | None = None) -> SandboxConnection:

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -83,6 +83,63 @@ async def test_exec_10mb_limit(
     assert len(body) > 1_000_000
 
 
+async def test_exec_large_binary_output_surfaces_cleanly(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    """Oversized exec output must raise OutputLimitExceededError, not crash.
+
+    Regression for the "597 Broken pipe" sample crash: the file-read of
+    script.stdout was issued without a `count` cap, so PVE tried to return the
+    whole (binary, base64-inflated) stdout in one JSON body and the
+    pveproxy->pvedaemon hop tore it down with a non-standard "597 Broken pipe"
+    that escaped the retry layer and propagated. High-entropy binary is the
+    worst case (it inflates ~2x on the wire), so this reproduces the original
+    `cat <binary>` shape rather than plain ASCII. With the read capped at
+    max_size the response stays deliverable and the overflow surfaces cleanly.
+    """
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("binary stdout repro is Linux-only")
+
+    # 30 MiB of random bytes straight to stdout, well over the 10 MiB exec cap.
+    with pytest.raises(OutputLimitExceededError):
+        await proxmox_sandbox_environment.exec(
+            ["sh", "-c", "head -c 31457280 /dev/urandom"], timeout=120
+        )
+
+
+async def test_read_file_large_binary_surfaces_cleanly(
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
+) -> None:
+    """read_file round-trips a multi-MiB binary file and rejects oversized ones.
+
+    Same "597 Broken pipe" root cause as the exec regression, on the read_file
+    path: a >~10 MiB binary read used to inflate past the proxy hop's limit and
+    crash. The fix reads via decode=0 (compact, content-independent body) so a
+    full 16 MiB read stays deliverable and an oversized file raises
+    OutputLimitExceededError instead. The 14 MiB case also guards the decode=0
+    segment-decode (PVE concatenates per-1 MiB-chunk base64).
+    """
+    if proxmox_sandbox_environment._is_windows():
+        pytest.skip("binary repro is Linux-only")
+    env = proxmox_sandbox_environment
+
+    # 14 MiB binary (multi-chunk, not 3-aligned) must round-trip byte-exact.
+    await env.exec(
+        ["sh", "-c", "head -c 14680064 /dev/urandom > /tmp/rf14"], timeout=60
+    )
+    md5_guest = (await env.exec(["md5sum", "/tmp/rf14"])).stdout.split()[0]
+    data = await env.read_file("/tmp/rf14", text=False)
+    assert isinstance(data, bytes) and len(data) == 14680064
+    assert hashlib.md5(data).hexdigest() == md5_guest
+
+    # 20 MiB (over the 16 MiB cap) must fail cleanly, not crash with a 597.
+    await env.exec(
+        ["sh", "-c", "head -c 20971520 /dev/urandom > /tmp/rf20"], timeout=60
+    )
+    with pytest.raises(OutputLimitExceededError):
+        await env.read_file("/tmp/rf20", text=False)
+
+
 CURRENT_DIR = Path(__file__).parent
 
 
@@ -150,8 +207,19 @@ async def test_self_check(
         "test_read_and_write_large_file_binary",
     ]
 
-    return await check_results_of_self_check(
+    results = await check_results_of_self_check(
         proxmox_sandbox_environment, known_failures
+    )
+
+    # The 16 MiB hard cap means we can't round-trip the 50 MiB file this test
+    # writes, so it stays a known failure - but it must fail *gracefully* with
+    # OutputLimitExceededError, not a raw transport crash. That distinction is
+    # exactly what the original "597 Broken pipe" sample crash slipped through:
+    # the known-failure exclusion was outcome-blind.
+    large_file_result = results["test_read_and_write_large_file_binary"]
+    assert "OutputLimitExceededError" in str(large_file_result), (
+        "Oversized read_file must fail with OutputLimitExceededError, got: "
+        f"{large_file_result!r}"
     )
 
 
@@ -177,3 +245,4 @@ async def check_results_of_self_check(sandbox_env, known_failures=[]):
             failures.append(f"Test {test_name} failed: {result}")
     if failures:
         assert False, "\n".join(failures)
+    return self_check_results

--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -38,49 +38,33 @@ _EMOJI = "\U0001f600"
 _EMOJI_BYTES = _EMOJI.encode("utf-8")  # b"\xf0\x9f\x98\x80"
 
 
-@pytest.mark.parametrize("lead", ["", "a"], ids=["even-offset", "odd-offset"])
 async def test_exec_10mb_limit(
-    proxmox_sandbox_environment: ProxmoxSandboxEnvironment, lead: str
+    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
 ) -> None:
-    # Output over MAX_EXEC_OUTPUT_SIZE (10 MiB) must truncate cleanly, even when
-    # the cut lands in the middle of a multi-byte sequence (issue #77). An all-'a'
-    # version of this test never hit that: plain ASCII has no multi-byte sequences
-    # for the cut to split, so it always parsed cleanly.
-    #
-    # read_file streams the file-read response in 8192-byte chunks and stops once
-    # the total first exceeds 10 MiB, so the cut is at a fixed, even byte offset
-    # (1281*8192 = 10493952). Each non-ASCII output byte comes back as a 2-byte
-    # sequence on the wire (Proxmox re-encodes raw bytes via latin-1), and every
-    # byte of our emoji is non-ASCII, so the whole payload is 2-byte wire pairs.
-    # Whether the cut splits one of those pairs depends on the parity of the offset
-    # at which they start, which we can't predict exactly (the JSON field order is
-    # non-deterministic). So we run two outputs differing by a single leading byte:
-    # their pairs sit on opposite parities, so exactly one variant lands mid-sequence
-    # and reproduces the crash. Pre-fix that variant raised
-    # `ValueError: invalid unicode code point`; both must now truncate cleanly.
+    # Output over MAX_EXEC_OUTPUT_SIZE (10 MiB) must truncate cleanly and surface
+    # as OutputLimitExceededError. The read uses decode=0 (raw bytes), so the
+    # truncated output is whole bytes decoded as UTF-8 - multi-byte sequences
+    # round-trip and a cut inside a 4-byte char leaves at most one trailing
+    # U+FFFD, never a parse crash (the byte-boundary fragility of decode=1, and
+    # its even/odd-offset test, are gone).
     if proxmox_sandbox_environment._is_windows():
-        pytest.skip("byte-level multi-byte boundary repro is Linux-only")
+        pytest.skip("multi-byte output repro is Linux-only")
 
     count = pow(2, 20) * 3  # 3 Mi emoji * 4 bytes = 12 MiB, well over the 10 MiB limit
     escaped = "".join(f"\\x{b:02x}" for b in _EMOJI_BYTES)
     exec_cmd = [
         "perl",
         "-e",
-        f'binmode STDOUT; print "{lead}", "{escaped}" x {count}',
+        f'binmode STDOUT; print "{escaped}" x {count}',
     ]
 
     with pytest.raises(OutputLimitExceededError) as exc_info:
         await proxmox_sandbox_environment.exec(exec_cmd, timeout=120)
 
-    # Partial output is recovered and decoded like a full read: the optional ASCII
-    # lead, then whole emoji. The size cut can fall inside a 4-byte sequence, leaving
-    # at most one trailing U+FFFD replacement char rather than crashing the parse.
     truncated = exc_info.value.truncated_output
     assert isinstance(truncated, str)
-    assert truncated.startswith(lead)
-    body = truncated[len(lead) :]
-    assert body.rstrip("�").strip(_EMOJI) == ""
-    assert len(body) > 1_000_000
+    assert truncated.rstrip("�").strip(_EMOJI) == ""
+    assert len(truncated) > 1_000_000
 
 
 async def test_exec_large_binary_output_surfaces_cleanly(


### PR DESCRIPTION
SLOP ALERT

**Stacked on #93** (base branch `fix/large-read-597-broken-pipe`) — review/merge that first; this diff is against it.

## What

Unify all guest reads — `read_file` and command stdout/stderr — onto a single agent file-read `decode=0` path, and delete the `decode=1` Latin-1 mangling that #93 worked around.

## Why

`decode=1` (the PVE API default the code inherited) reinterprets each file byte as a Latin-1 codepoint and serialises it as a JSON string. That:
- inflates the wire body — `0x80–0xFF` → 2 bytes each (~2× for binary), control bytes → `\uXXXX` 6 bytes each (up to 6×) — which is the root cause of the HTTP 597 in #93, and
- arrives mangled (`é` → `Ã©`), requiring `_recover_qga_bytes` to undo, plus fragile truncation handling for cuts landing mid-`\uXXXX` / mid-UTF-8-sequence (issues #77 / #80).

`decode=0` forwards the agent's base64 untouched: **~4/3 the content size regardless of the bytes, and lossless.** (The agent already base64-encodes internally, so `decode=1` was doing extra work to produce a *larger*, corrupted blob.) Params documented in the [PVE API viewer](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/agent/file-read).

## Changes

- Removed: `async_proxmox.read_file` (decode=1 streaming), `_parse_truncated_file_read`, `_recover_qga_bytes`, `_decode_exec_output`, `agent_commands.read_file` / `read_file_or_blank`.
- Added: `agent_commands.read_file_capped_or_blank`.
- `read_file` and exec output reads both go through `read_file_capped` (decode=0); oversized reads surface as `OutputLimitExceededError` via the `truncated` flag.
- `test_exec_10mb_limit` drops its even/odd byte-boundary parametrization (decode=0 reads whole bytes, so a multi-byte sequence can't be split into a parse error — at most one trailing `U+FFFD`).

Net **−137 lines**. Removes the mojibake-recovery machinery, makes issues #77/#80 unreachable, and closes the pathological-content 597 edge that #93 left on the exec path (binary output is now bounded regardless of byte distribution).

## Tests (against a real Proxmox instance)

Full `test_proxmox_sandbox_agent_commands.py` passes — incl. `test_exec_10mb_limit` (emoji output truncates cleanly), the large-binary exec/`read_file` regressions, and `self_check`. `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
