### PR TITLE
test: centralize Proxmox pool/instance state reset in conftest

### DIFF
--- a/tests/proxmoxsandboxtest/conftest.py
+++ b/tests/proxmoxsandboxtest/conftest.py
@@ -31,6 +31,25 @@ from proxmoxsandbox.schema import VmConfig, VmSourceConfig
 WINDOWS_TEMPLATE_TAG = os.getenv("PROXMOX_WINDOWS_TEMPLATE_TAG")
 
 
+@pytest.fixture(autouse=True)
+def reset_global_pool_state():
+    """Reset process-global pool and instance registries around every test.
+
+    QueueBasedProxmoxPool._instance_pools and InfraCommands._instances are
+    class-level, so they persist for the whole session. initialize() is a no-op
+    for a pool_id that already exists, so a 'default' pool left behind by an
+    earlier test (e.g. an e2e test built from PROXMOX_HOST) would otherwise be
+    reused by a later test that meant to build its own config. Every pool
+    consumer is function-scoped and re-runs task_init, so resetting around each
+    test is safe and removes the need for per-test bookkeeping.
+    """
+    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
+    InfraCommands._instances.clear()
+    yield
+    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
+    InfraCommands._instances.clear()
+
+
 @pytest.fixture
 async def sandbox_env_config() -> ProxmoxSandboxEnvironmentConfig:
     return ProxmoxSandboxEnvironmentConfig()

--- a/tests/proxmoxsandboxtest/test_cli_cleanup.py
+++ b/tests/proxmoxsandboxtest/test_cli_cleanup.py
@@ -11,13 +11,6 @@ from proxmoxsandbox._impl.infra_commands import InfraCommands
 from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
 
 
-@pytest.fixture(autouse=True)
-def cleanup_infra_instances():
-    """Clear InfraCommands._instances after each test."""
-    yield
-    InfraCommands._instances.clear()
-
-
 @pytest.fixture
 def multi_instance_config_file():
     """Create config file with multiple instances across different pools."""
@@ -129,7 +122,6 @@ async def test_cli_cleanup_all_instances(multi_instance_config_file):
     finally:
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -169,7 +161,6 @@ async def test_cli_cleanup_empty_config():
         os.unlink(temp_path)
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -239,7 +230,6 @@ async def test_cli_cleanup_handles_cleanup_error():
         os.unlink(temp_path)
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -302,4 +292,3 @@ async def test_cli_cleanup_pools_created_correctly():
         os.unlink(temp_path)
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()

--- a/tests/proxmoxsandboxtest/test_multi_instance_pools.py
+++ b/tests/proxmoxsandboxtest/test_multi_instance_pools.py
@@ -68,13 +68,6 @@ def mock_infra_commands():
         yield infra
 
 
-@pytest.fixture(autouse=True)
-def cleanup_infra_instances():
-    """Clear InfraCommands._instances after each test."""
-    yield
-    InfraCommands._instances.clear()
-
-
 @pytest.fixture
 def simple_config_file():
     """Create config file with one instance."""
@@ -172,8 +165,6 @@ async def test_single_instance_single_sample(
         # Cleanup
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        # Clear pools for next test
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.fixture
@@ -332,7 +323,6 @@ async def test_two_pools_two_configs(
         # Cleanup
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -358,7 +348,6 @@ async def test_wrong_pool_id_raises_error(
     finally:
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -402,7 +391,6 @@ async def test_pool_exhaustion_blocks(
     finally:
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -441,7 +429,6 @@ async def test_sample_error_releases_instance(
         finally:
             if "PROXMOX_CONFIG_FILE" in os.environ:
                 del os.environ["PROXMOX_CONFIG_FILE"]
-            ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -471,7 +458,6 @@ async def test_empty_instances_list():
         os.unlink(temp_path)
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -499,7 +485,6 @@ async def test_concurrent_task_init_calls(multi_pool_config_file):
     finally:
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -538,4 +523,3 @@ async def test_cleanup_with_interrupted_flag(
     finally:
         if "PROXMOX_CONFIG_FILE" in os.environ:
             del os.environ["PROXMOX_CONFIG_FILE"]
-        ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()

--- a/tests/proxmoxsandboxtest/test_sample_init_cleanup.py
+++ b/tests/proxmoxsandboxtest/test_sample_init_cleanup.py
@@ -32,13 +32,6 @@ def mock_proxmox_api():
         yield mock
 
 
-@pytest.fixture(autouse=True)
-def cleanup_infra_instances():
-    """Clear InfraCommands._instances after each test."""
-    yield
-    InfraCommands._instances.clear()
-
-
 def _make_infra_mock(**overrides):
     """Create a mock InfraCommands with sensible defaults.
 
@@ -91,7 +84,6 @@ async def test_sample_init_cleanup_on_create_sdn_failure(
     5. Then release the instance back to pool
     """
     os.environ["PROXMOX_CONFIG_FILE"] = simple_config_file
-    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
     error_msg = "Duplicate IP ranges found: [('10.129.0.0/24', '10.129.0.0/24')]"
     infra = _make_infra_mock(
@@ -128,7 +120,6 @@ async def test_sample_init_cleanup_on_create_sdn_failure(
         finally:
             if "PROXMOX_CONFIG_FILE" in os.environ:
                 del os.environ["PROXMOX_CONFIG_FILE"]
-            ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -142,7 +133,6 @@ async def test_sample_init_no_cleanup_on_early_failure(
     should be attempted since nothing was created.
     """
     os.environ["PROXMOX_CONFIG_FILE"] = simple_config_file
-    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
     infra = _make_infra_mock(
         find_proxmox_ids_start=AsyncMock(
@@ -171,7 +161,6 @@ async def test_sample_init_no_cleanup_on_early_failure(
         finally:
             if "PROXMOX_CONFIG_FILE" in os.environ:
                 del os.environ["PROXMOX_CONFIG_FILE"]
-            ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -189,7 +178,6 @@ async def test_sample_init_precheck_cleans_dirty_instance(
     intentionally ignored — see test_sample_init_precheck_ignores_pre_existing_vnets.
     """
     os.environ["PROXMOX_CONFIG_FILE"] = simple_config_file
-    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
     sdn_mock = MagicMock()
     # Both vnets live in a zone whose name matches ZONE_REGEX
@@ -226,7 +214,6 @@ async def test_sample_init_precheck_cleans_dirty_instance(
         finally:
             if "PROXMOX_CONFIG_FILE" in os.environ:
                 del os.environ["PROXMOX_CONFIG_FILE"]
-            ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -242,7 +229,6 @@ async def test_sample_init_precheck_ignores_pre_existing_vnets(
     doesn't risk wiping user state via cleanup_no_id.
     """
     os.environ["PROXMOX_CONFIG_FILE"] = simple_config_file
-    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
     sdn_mock = MagicMock()
     # Pre-existing user vnets in user-named zones; neither matches ZONE_REGEX.
@@ -278,7 +264,6 @@ async def test_sample_init_precheck_ignores_pre_existing_vnets(
         finally:
             if "PROXMOX_CONFIG_FILE" in os.environ:
                 del os.environ["PROXMOX_CONFIG_FILE"]
-            ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -292,7 +277,6 @@ async def test_sample_init_precheck_cleanup_fails_but_continues(
     and continue (not raise).
     """
     os.environ["PROXMOX_CONFIG_FILE"] = simple_config_file
-    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
     sdn_mock = MagicMock()
     sdn_mock.read_all_vnets = AsyncMock(
@@ -324,7 +308,6 @@ async def test_sample_init_precheck_cleanup_fails_but_continues(
         finally:
             if "PROXMOX_CONFIG_FILE" in os.environ:
                 del os.environ["PROXMOX_CONFIG_FILE"]
-            ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -338,7 +321,6 @@ async def test_sample_init_precheck_read_vnets_fails_but_continues(
     (not raise).
     """
     os.environ["PROXMOX_CONFIG_FILE"] = simple_config_file
-    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
     sdn_mock = MagicMock()
     sdn_mock.read_all_vnets = AsyncMock(
@@ -371,7 +353,6 @@ async def test_sample_init_precheck_read_vnets_fails_but_continues(
         finally:
             if "PROXMOX_CONFIG_FILE" in os.environ:
                 del os.environ["PROXMOX_CONFIG_FILE"]
-            ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
 
 @pytest.mark.asyncio
@@ -387,7 +368,6 @@ async def test_sample_init_dirty_instance_not_returned_when_cleanup_fails(
     - This prevents cascading failures across samples
     """
     os.environ["PROXMOX_CONFIG_FILE"] = simple_config_file
-    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
 
     infra = _make_infra_mock(
         create_sdn_and_vms=AsyncMock(
@@ -427,4 +407,3 @@ async def test_sample_init_dirty_instance_not_returned_when_cleanup_fails(
         finally:
             if "PROXMOX_CONFIG_FILE" in os.environ:
                 del os.environ["PROXMOX_CONFIG_FILE"]
-            ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()


### PR DESCRIPTION
## Problem

`QueueBasedProxmoxPool._instance_pools` and `InfraCommands._instances` are class-level, so they persist for the whole pytest session. `initialize()` is a no-op for a `pool_id` that already exists, so a `default` pool created by an e2e test (built from `PROXMOX_HOST` when `.env` is sourced) was silently reused by later mock tests that meant to build their own config from `PROXMOX_CONFIG_FILE`.

## Fix

A single autouse fixture in `conftest.py` that resets both registries before and after every test, and drop the now-redundant per-module `cleanup_infra_instances` fixtures and 28 scattered `clear_pools()` calls.

Every pool consumer is function-scoped and re-runs `task_init`, so resetting around each test is safe.
