### PR TITLE
Verify disk_controller against clone source for non-OVA VMs

### DIFF
--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -2,7 +2,7 @@ import abc
 import re
 import tarfile
 from logging import getLogger
-from typing import Collection, Dict, List, Set
+from typing import Collection, Dict, List, Literal, Set
 
 import httpx
 import tenacity
@@ -217,6 +217,57 @@ class QemuCommands(abc.ABC):
         is_template = vm.get("template") == 1
         return template == is_template
 
+    @staticmethod
+    def _detect_disk_controller(vm_config: dict) -> Literal["scsi", "ide"]:
+        """Infer the data-disk controller from a Proxmox VM/template config.
+
+        Data disks live on scsiN/ideN keys; the CD-ROM (sata5) and EFI vars
+        disk (efidisk0) sit on other buses and are ignored, as is any scsiN/ideN
+        entry that is itself a CD-ROM. Raises if the data disks span both
+        controllers or none are found, since there is then no single answer.
+        """
+        controllers: Set[str] = set()
+        for key, value in vm_config.items():
+            match = re.fullmatch(r"(scsi|ide)\d+", key)
+            if match is None:
+                continue
+            if "media=cdrom" in str(value).split(","):
+                continue
+            controllers.add(match.group(1))
+        if controllers == {"scsi"}:
+            return "scsi"
+        if controllers == {"ide"}:
+            return "ide"
+        if controllers:
+            problem = (
+                "its data disks span multiple controllers "
+                f"({', '.join(sorted(controllers))})"
+            )
+        else:
+            problem = "no scsi or ide data disks were found"
+        raise ValueError(
+            f"Cannot determine a single disk controller because {problem}. "
+            "If you want to clone it, leave disk_controller unspecified."
+        )
+
+    async def _verify_disk_controller(
+        self, vm_config: VmConfig, vm_id: int, source_desc: str
+    ) -> None:
+        """Check a requested disk_controller against the VM we're about to clone.
+
+        Cloning can't change the controller, so for the built-in and template-tag
+        sources we verify the clone target already matches rather than applying it.
+        No-op if the config didn't request a specific controller.
+        """
+        if vm_config.disk_controller is None:
+            return
+        actual = self._detect_disk_controller(await self.read_vm(vm_id))
+        if actual != vm_config.disk_controller:
+            raise ValueError(
+                f"disk_controller={vm_config.disk_controller!r} was requested "
+                f"but {source_desc} uses {actual!r}"
+            )
+
     async def _find_inspect_template_id(self, tag: str) -> int | None:
         existing_vms = await self.list_vms()
         filtered = [
@@ -240,12 +291,6 @@ class QemuCommands(abc.ABC):
         built_in_vm_ids: Dict[str, int],
     ) -> int:
         if (
-            vm_config.disk_controller is not None
-            and vm_config.vm_source_config.ova is None
-        ):
-            raise NotImplementedError("disk_controller is only supported for OVA")
-
-        if (
             vm_config.os_type != "l26"
             and vm_config.vm_source_config.ova is None
             and vm_config.vm_source_config.existing_vm_template_tag is None
@@ -259,6 +304,11 @@ class QemuCommands(abc.ABC):
 
         if vm_config.vm_source_config.built_in:
             vm_id_to_clone = built_in_vm_ids[vm_config.vm_source_config.built_in]
+            await self._verify_disk_controller(
+                vm_config,
+                vm_id_to_clone,
+                source_desc=f"built-in {vm_config.vm_source_config.built_in!r}",
+            )
             preserve_tags = False
         elif vm_config.vm_source_config.ova is not None:
             ova_size = vm_config.vm_source_config.ova.stat().st_size
@@ -356,6 +406,10 @@ class QemuCommands(abc.ABC):
 
             if found_id is None:
                 raise ValueError(f"Couldn't find VM with tag {tag}")
+
+            await self._verify_disk_controller(
+                vm_config, found_id, source_desc=f"template with tag {tag!r}"
+            )
 
             vm_id_to_clone = found_id
             preserve_tags = True

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -183,7 +183,11 @@ class VmConfig(BaseModel, frozen=True):
             It must have the qemu-guest-agent installed
         uefi_boot: if True, the VM will boot in UEFI mode. In theory, this is already
             specified by OVA, but Proxmox doesn't seem to respect it.
-        disk_controller: The disk controller type. If unset, defaults to "scsi"
+        disk_controller: The disk controller type. If unset, defaults to "scsi".
+            For an OVA this selects the controller the imported disks are attached
+            to. For an existing_vm_template_tag or built_in source it cannot be
+            changed, so it is instead verified against the source VM and raises if
+            they disagree.
         nic_controller: The NIC controller type. If unset, defaults to "virtio".
             This is applied to all virtual network interfaces.
         firewall: if True, enables the Proxmox firewall on all network interfaces.

--- a/tests/proxmoxsandboxtest/test_detect_disk_controller.py
+++ b/tests/proxmoxsandboxtest/test_detect_disk_controller.py
@@ -1,0 +1,61 @@
+import pytest
+
+from proxmoxsandbox._impl.qemu_commands import QemuCommands
+
+
+def test_detects_scsi():
+    config = {
+        "scsi0": "local-lvm:vm-100-disk-0,size=32G",
+        "sata5": "none,media=cdrom",
+        "net0": "virtio,bridge=vmbr0",
+    }
+    assert QemuCommands._detect_disk_controller(config) == "scsi"
+
+
+def test_detects_ide():
+    config = {
+        "ide0": "local-lvm:vm-100-disk-0,size=32G",
+        "ide1": "local-lvm:vm-100-disk-1,size=8G",
+        "sata5": "none,media=cdrom",
+    }
+    assert QemuCommands._detect_disk_controller(config) == "ide"
+
+
+def test_ignores_cdrom_on_scsi_ide_buses():
+    # A CD-ROM attached to ide2 must not be mistaken for a data disk.
+    config = {
+        "ide2": "none,media=cdrom",
+        "scsi0": "local-lvm:vm-100-disk-0,size=32G",
+    }
+    assert QemuCommands._detect_disk_controller(config) == "scsi"
+
+
+def test_ignores_efidisk():
+    config = {
+        "efidisk0": "local-lvm:vm-100-disk-1,efitype=4m,pre-enrolled-keys=0",
+        "scsi0": "local-lvm:vm-100-disk-0,size=32G",
+    }
+    assert QemuCommands._detect_disk_controller(config) == "scsi"
+
+
+def test_raises_on_mixed_controllers():
+    config = {
+        "scsi0": "local-lvm:vm-100-disk-0,size=32G",
+        "ide0": "local-lvm:vm-100-disk-1,size=8G",
+    }
+    with pytest.raises(ValueError, match="span multiple controllers") as exc_info:
+        QemuCommands._detect_disk_controller(config)
+    # The user's way out of an unverifiable template is to stop requesting a
+    # specific controller, so the error must say so.
+    assert "leave disk_controller unspecified" in str(exc_info.value)
+
+
+def test_raises_when_no_data_disks():
+    # e.g. a virtio-backed template, plus only a CD-ROM on a scsi/ide bus.
+    config = {
+        "virtio0": "local-lvm:vm-100-disk-0,size=32G",
+        "ide2": "none,media=cdrom",
+    }
+    with pytest.raises(ValueError, match="no scsi or ide data disks") as exc_info:
+        QemuCommands._detect_disk_controller(config)
+    assert "leave disk_controller unspecified" in str(exc_info.value)

--- a/tests/proxmoxsandboxtest/test_qemu_commands.py
+++ b/tests/proxmoxsandboxtest/test_qemu_commands.py
@@ -234,6 +234,73 @@ async def test_empty_nic_from_built_in(
     await qemu_commands.destroy_vm(new_vm_id)
 
 
+async def test_disk_controller_match_from_built_in(
+    qemu_commands: QemuCommands,
+    auto_sdn_vnet_aliases: VnetAliases,
+    built_in_vm: BuiltInVM,
+):
+    built_in_ubuntu = VmSourceConfig(built_in="ubuntu24.04")
+
+    await built_in_vm.ensure_exists("ubuntu24.04")
+
+    # Built-ins are created on scsi, so requesting "scsi" must be accepted and
+    # the clone must still come out on scsi.
+    new_vm_id = await qemu_commands.create_and_start_vm(
+        sdn_vnet_aliases=auto_sdn_vnet_aliases,
+        vm_config=VmConfig(
+            vm_source_config=built_in_ubuntu,
+            disk_controller="scsi",
+            is_sandbox=False,
+        ),
+        built_in_vm_ids=await built_in_vm.known_builtins(),
+    )
+
+    new_vm = await qemu_commands.read_vm(new_vm_id)
+    assert "scsi0" in new_vm
+
+    await qemu_commands.destroy_vm(new_vm_id)
+
+
+async def test_disk_controller_mismatch_from_built_in_raises(
+    qemu_commands: QemuCommands,
+    built_in_vm: BuiltInVM,
+):
+    built_in_ubuntu = VmSourceConfig(built_in="ubuntu24.04")
+
+    await built_in_vm.ensure_exists("ubuntu24.04")
+
+    # Built-ins are scsi, so requesting "ide" is unsatisfiable and must raise
+    # before any VM is created (hence no cleanup needed).
+    with pytest.raises(ValueError, match="disk_controller"):
+        await qemu_commands.create_and_start_vm(
+            sdn_vnet_aliases=[],
+            vm_config=VmConfig(
+                vm_source_config=built_in_ubuntu,
+                disk_controller="ide",
+            ),
+            built_in_vm_ids=await built_in_vm.known_builtins(),
+        )
+
+
+async def test_disk_controller_mismatch_from_template_tag_raises(
+    qemu_commands: QemuCommands,
+    built_in_vm: BuiltInVM,
+):
+    await built_in_vm.ensure_exists("ubuntu24.04")
+
+    with pytest.raises(ValueError, match="disk_controller"):
+        await qemu_commands.create_and_start_vm(
+            sdn_vnet_aliases=[],
+            vm_config=VmConfig(
+                vm_source_config=VmSourceConfig(
+                    existing_vm_template_tag="builtin-ubuntu24.04"
+                ),
+                disk_controller="ide",
+            ),
+            built_in_vm_ids=await built_in_vm.known_builtins(),
+        )
+
+
 async def test_from_ova_local(qemu_commands: QemuCommands):
     new_vm_id = await qemu_commands.create_and_start_vm(
         sdn_vnet_aliases=[],


### PR DESCRIPTION
The motivation here is that I want to write my `disk_controller` into my `VmConfig` and not have to comment it out when I flip between `existing_vm_template_tag` and `ova`. But at the same time, `existing_vm_template_tag` can't *change* the `disk_controller` of the template, and I don't want a `VmConfig` that says `disk_controller` that doesn't produce a VM with that controller.

The solution is to validate the `disk_controller`, so that I can look at a config and know that because it works it's correct, and swapping in an equivalent `ova` won't burn me.

I don't know if this is worth the complexity? I think conceptually it makes sense but I don't *need* it.

I've run the `req_proxmox` tests manually and they seem fine.