### PR TITLE
Log acquired pool instance at INFO for host attribution (captured in the .eval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Log the acquired pool instance (`host`/`port`/`node`) at `INFO` so a sample can be attributed to its Proxmox server from the `.eval` transcript; the provider opts its own logger into `INFO` for this (suppress with `--log-level-transcript warning`)
+- Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
+- Opt logger into `INFO` level for consistency with Inspect core
 - Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
 - Fix: reading a large or binary guest file / command output no longer crashes with HTTP 597 "Broken pipe".
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Log the acquired pool instance (`host`/`port`/`node`) at `INFO` so a sample can be attributed to its Proxmox server from the `.eval` transcript; the provider opts its own logger into `INFO` for this (suppress with `--log-level-transcript warning`)
 - Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
 - Fix: reading a large or binary guest file / command output no longer crashes with HTTP 597 "Broken pipe".
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ export PROXMOX_CONFIG_FILE=/path/to/instances.json
 
 Instances with the same `pool_id` form a pool. Each eval sample acquires one instance from its pool, uses it exclusively, and releases it back when done. Concurrency is automatically limited to the total number of instances.
 
+Each sample records the instance it acquired in the Inspect sample store, under the keys `proxmox:instance_id`, `proxmox:host`, `proxmox:port`, `proxmox:node` and `proxmox:pool_id` — check `sample.store` in the `.eval` log to attribute a sample to a Proxmox server. Do not use the `host`/`port`/`node` fields of the sample's serialised sandbox config for this: with a pool those fields are not connected to the instance the sample ran on.
+
 ## Configuring
 
 Here is a full example sandbox configuration. 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,6 @@ export PROXMOX_CONFIG_FILE=/path/to/instances.json
 
 Instances with the same `pool_id` form a pool. Each eval sample acquires one instance from its pool, uses it exclusively, and releases it back when done. Concurrency is automatically limited to the total number of instances.
 
-Each sample logs the instance it acquired at `INFO` level (`Acquired instance <id> from pool '<pool>': host=<host> port=<port> node=<node>`), which lands in the sample transcript of the `.eval` log — check it to attribute a sample to a Proxmox server. Do not use the `host`/`port`/`node` fields of the sample's serialised sandbox config for this: with a pool those fields are not connected to the instance the sample ran on. To suppress these lines, run with `--log-level-transcript warning`.
-
 ## Configuring
 
 Here is a full example sandbox configuration. 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ export PROXMOX_CONFIG_FILE=/path/to/instances.json
 
 Instances with the same `pool_id` form a pool. Each eval sample acquires one instance from its pool, uses it exclusively, and releases it back when done. Concurrency is automatically limited to the total number of instances.
 
-Each sample records the instance it acquired in the Inspect sample store, under the keys `proxmox:instance_id`, `proxmox:host`, `proxmox:port`, `proxmox:node` and `proxmox:pool_id` — check `sample.store` in the `.eval` log to attribute a sample to a Proxmox server. Do not use the `host`/`port`/`node` fields of the sample's serialised sandbox config for this: with a pool those fields are not connected to the instance the sample ran on.
+Each sample logs the instance it acquired at `INFO` level (`Acquired instance <id> from pool '<pool>': host=<host> port=<port> node=<node>`) — check the logs to attribute a sample to a Proxmox server. Do not use the `host`/`port`/`node` fields of the sample's serialised sandbox config for this: with a pool those fields are not connected to the instance the sample ran on.
 
 ## Configuring
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ export PROXMOX_CONFIG_FILE=/path/to/instances.json
 
 Instances with the same `pool_id` form a pool. Each eval sample acquires one instance from its pool, uses it exclusively, and releases it back when done. Concurrency is automatically limited to the total number of instances.
 
-Each sample logs the instance it acquired at `INFO` level (`Acquired instance <id> from pool '<pool>': host=<host> port=<port> node=<node>`) — check the logs to attribute a sample to a Proxmox server. Do not use the `host`/`port`/`node` fields of the sample's serialised sandbox config for this: with a pool those fields are not connected to the instance the sample ran on.
+Each sample logs the instance it acquired at `INFO` level (`Acquired instance <id> from pool '<pool>': host=<host> port=<port> node=<node>`), which lands in the sample transcript of the `.eval` log — check it to attribute a sample to a Proxmox server. Do not use the `host`/`port`/`node` fields of the sample's serialised sandbox config for this: with a pool those fields are not connected to the instance the sample ran on. To suppress these lines, run with `--log-level-transcript warning`.
 
 ## Configuring
 

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -4,7 +4,7 @@ import errno
 import re
 import shlex
 import time
-from logging import INFO, getLogger
+from logging import INFO, NOTSET, getLogger
 from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, Generator, List, Tuple, Type, Union
 
@@ -41,7 +41,10 @@ from proxmoxsandbox.schema import (
 # third-party provider's INFO never reaches the .eval transcript. As an Inspect
 # extension we opt our own logger in; a user can still silence it with
 # --log-level-transcript warning (that gate is downstream of this level).
-getLogger("proxmoxsandbox").setLevel(INFO)
+# Guarded on NOTSET so we never clobber a level a host application set before
+# this module was imported (e.g. someone who wants proxmoxsandbox at DEBUG).
+if getLogger("proxmoxsandbox").level == NOTSET:
+    getLogger("proxmoxsandbox").setLevel(INFO)
 
 # Above this many raw stdin bytes, exec() writes stdin to a file and redirects
 # from it instead of inlining base64 into the shell script — see exec() below.

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -18,6 +18,7 @@ from inspect_ai.util import (
     SandboxEnvironmentLimits,
     concurrency,
     sandboxenv,
+    store,
     trace_action,
 )
 from pydantic import BaseModel
@@ -325,6 +326,16 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         cls.logger.info(
             f"Acquired instance {instance.instance_id} from pool '{pool_id}'"
         )
+
+        # The frozen config's host/port/node are env-var defaults, not the
+        # acquired instance, so they misattribute pooled samples. Record the
+        # real instance in the sample store, which lands in the .eval log.
+        sample_store = store()
+        sample_store.set("proxmox:instance_id", instance.instance_id)
+        sample_store.set("proxmox:host", instance.host)
+        sample_store.set("proxmox:port", instance.port)
+        sample_store.set("proxmox:node", instance.node)
+        sample_store.set("proxmox:pool_id", pool_id)
 
         # Track variables for cleanup on failure
         infra_commands = None

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -4,7 +4,7 @@ import errno
 import re
 import shlex
 import time
-from logging import getLogger
+from logging import INFO, getLogger
 from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, Generator, List, Tuple, Type, Union
 
@@ -36,6 +36,12 @@ from proxmoxsandbox.schema import (
     ProxmoxInstanceConfig,
     ProxmoxSandboxEnvironmentConfig,
 )
+
+# Inspect only lowers its own package loggers below the root WARNING default, so a
+# third-party provider's INFO never reaches the .eval transcript. As an Inspect
+# extension we opt our own logger in; a user can still silence it with
+# --log-level-transcript warning (that gate is downstream of this level).
+getLogger("proxmoxsandbox").setLevel(INFO)
 
 # Above this many raw stdin bytes, exec() writes stdin to a file and redirects
 # from it instead of inlining base64 into the shell script — see exec() below.

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -18,7 +18,6 @@ from inspect_ai.util import (
     SandboxEnvironmentLimits,
     concurrency,
     sandboxenv,
-    store,
     trace_action,
 )
 from pydantic import BaseModel
@@ -323,19 +322,14 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
 
         # ACQUIRE instance from pool (blocks if all in use)
         instance = await cls.proxmox_pool.acquire_instance(pool_id)
-        cls.logger.info(
-            f"Acquired instance {instance.instance_id} from pool '{pool_id}'"
-        )
 
         # The frozen config's host/port/node are env-var defaults, not the
-        # acquired instance, so they misattribute pooled samples. Record the
-        # real instance in the sample store, which lands in the .eval log.
-        sample_store = store()
-        sample_store.set("proxmox:instance_id", instance.instance_id)
-        sample_store.set("proxmox:host", instance.host)
-        sample_store.set("proxmox:port", instance.port)
-        sample_store.set("proxmox:node", instance.node)
-        sample_store.set("proxmox:pool_id", pool_id)
+        # acquired instance, so they misattribute pooled samples. Log the real
+        # instance so a sample can be attributed to a Proxmox server.
+        cls.logger.info(
+            f"Acquired instance {instance.instance_id} from pool '{pool_id}': "
+            f"host={instance.host} port={instance.port} node={instance.node}"
+        )
 
         # Track variables for cleanup on failure
         infra_commands = None

--- a/tests/proxmoxsandboxtest/test_host_attribution.py
+++ b/tests/proxmoxsandboxtest/test_host_attribution.py
@@ -23,6 +23,18 @@ from proxmoxsandbox.schema import ProxmoxSandboxEnvironmentConfig
 
 LOGGER_NAME = "proxmoxsandbox._proxmox_sandbox_environment"
 
+
+def test_provider_logger_opted_into_info():
+    """The provider lowers its own logger to INFO so its lines reach the .eval.
+
+    Inspect leaves third-party package loggers at the root WARNING default, so
+    without this the attribution line would never be created under a default
+    `inspect eval`. Users can still suppress via --log-level-transcript warning.
+    """
+    assert logging.getLogger("proxmoxsandbox").level == logging.INFO
+    assert logging.getLogger(LOGGER_NAME).isEnabledFor(logging.INFO)
+
+
 # Sentinel env default: TEST-NET-3, provably not a real pool instance.
 ENV_SENTINEL_HOST = "203.0.113.255"
 

--- a/tests/proxmoxsandboxtest/test_host_attribution.py
+++ b/tests/proxmoxsandboxtest/test_host_attribution.py
@@ -1,0 +1,242 @@
+"""Tests that each sample durably records the pool instance it actually ran on.
+
+The frozen ProxmoxSandboxEnvironmentConfig defaults host/port/node from
+process env vars, and that config is what Inspect serialises into each
+sample's `sandbox` field — so with a pool, every sample used to be
+attributed to the single PROXMOX_HOST env default regardless of which
+instance it acquired. sample_init now stamps the acquired instance into the
+Inspect sample store (`proxmox:*` keys), which lands in the .eval log.
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from inspect_ai.util._store import Store, init_subtask_store
+
+from proxmoxsandbox._impl.infra_commands import InfraCommands
+from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
+from proxmoxsandbox.schema import ProxmoxSandboxEnvironmentConfig
+
+# Sentinel env default: TEST-NET-3, provably not a real pool instance.
+ENV_SENTINEL_HOST = "203.0.113.255"
+
+
+def _make_mock_infra():
+    infra = MagicMock()
+    vm_config_mock = MagicMock()
+    vm_config_mock.is_sandbox = True
+    vm_config_mock.name = None
+    vm_config_mock.os_type = None
+    infra.create_sdn_and_vms = AsyncMock(
+        return_value=(
+            [(101, vm_config_mock)],
+            "zone1",
+            (),
+        )
+    )
+    infra.delete_sdn_and_vms = AsyncMock()
+    infra.deregister_resources = MagicMock()
+    infra.task_cleanup = AsyncMock()
+    infra.find_proxmox_ids_start = AsyncMock(return_value="tst100")
+    infra.cleanup_no_id = AsyncMock()
+    infra.sdn_commands = MagicMock()
+    infra.sdn_commands.read_all_vnets = AsyncMock(return_value=[])
+    infra.qemu_commands = MagicMock()
+    infra.task_wrapper = MagicMock()
+    infra.built_in_vm = AsyncMock()
+    infra.built_in_vm.ensure_exists = AsyncMock()
+    infra.async_proxmox = AsyncMock()
+    infra.node = "pve1"
+    return infra
+
+
+@pytest.fixture
+def mock_proxmox_api():
+    with patch("proxmoxsandbox._proxmox_sandbox_environment.AsyncProxmoxAPI") as mock:
+        api_instance = AsyncMock()
+        api_instance.get.return_value = {"version": "8.0"}
+        mock.return_value = api_instance
+        yield mock
+
+
+@pytest.fixture
+def mock_infra_commands():
+    infra = _make_mock_infra()
+    with (
+        patch.object(
+            InfraCommands, "get_instance", side_effect=LookupError("not found")
+        ),
+        patch.object(InfraCommands, "build", return_value=infra),
+        patch.object(InfraCommands, "set_instance"),
+    ):
+        yield infra
+
+
+@pytest.fixture(autouse=True)
+def cleanup_state():
+    """Isolate pool/infra class state and the sentinel env vars per test."""
+    saved = {
+        var: os.environ.get(var)
+        for var in ("PROXMOX_HOST", "PROXMOX_NODE", "PROXMOX_CONFIG_FILE")
+    }
+    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
+    yield
+    for var, value in saved.items():
+        if value is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = value
+    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
+    InfraCommands._instances.clear()
+
+
+def _config_file(instances: list[dict]) -> str:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump({"instances": instances}, f)
+        return f.name
+
+
+def _instance(instance_id: str, host: str, node: str) -> dict:
+    return {
+        "instance_id": instance_id,
+        "pool_id": "default",
+        "host": host,
+        "port": 8006,
+        "user": "root",
+        "user_realm": "pam",
+        "password": "test",
+        "node": node,
+        "verify_tls": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_sample_records_acquired_instance_not_env_default(
+    mock_proxmox_api, mock_infra_commands
+):
+    """The store must record the acquired pool instance, not the env default."""
+    config_file = _config_file([_instance("pool-inst-1", "10.0.1.10", "pve1")])
+    os.environ["PROXMOX_CONFIG_FILE"] = config_file
+    os.environ["PROXMOX_HOST"] = ENV_SENTINEL_HOST
+    os.environ["PROXMOX_NODE"] = "env-default-sentinel"
+    try:
+        await ProxmoxSandboxEnvironment.task_init("test_task", None)
+        config = ProxmoxSandboxEnvironmentConfig()
+
+        sample_store = Store()
+        init_subtask_store(sample_store)
+        environments = await ProxmoxSandboxEnvironment.sample_init(
+            "test_task", config, {}
+        )
+
+        # The bug: the frozen config field is the env default. Documented
+        # here as the trap — do not use it for host attribution.
+        assert config.host == ENV_SENTINEL_HOST
+        assert config.node == "env-default-sentinel"
+
+        # The fix: the store records the instance actually acquired.
+        assert sample_store.get("proxmox:instance_id") == "pool-inst-1"
+        assert sample_store.get("proxmox:host") == "10.0.1.10"
+        assert sample_store.get("proxmox:port") == 8006
+        assert sample_store.get("proxmox:node") == "pve1"
+        assert sample_store.get("proxmox:pool_id") == "default"
+
+        await ProxmoxSandboxEnvironment.sample_cleanup(
+            "test_task", config, environments, False
+        )
+    finally:
+        os.unlink(config_file)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_samples_record_distinct_instances(
+    mock_proxmox_api, mock_infra_commands
+):
+    """Two concurrent samples over a 2-instance pool record different hosts.
+
+    Mirrors the incident: concurrent epochs each logged host=PROXMOX_HOST
+    even though they provably ran on different Proxmox servers.
+    """
+    config_file = _config_file(
+        [
+            _instance("pool-inst-1", "10.0.1.10", "pve1"),
+            _instance("pool-inst-2", "10.0.1.11", "pve2"),
+        ]
+    )
+    os.environ["PROXMOX_CONFIG_FILE"] = config_file
+    os.environ["PROXMOX_HOST"] = ENV_SENTINEL_HOST
+    try:
+        await ProxmoxSandboxEnvironment.task_init("test_task", None)
+        config = ProxmoxSandboxEnvironmentConfig()
+
+        hold_both = asyncio.Barrier(2)
+
+        async def run_sample(sample_store: Store) -> None:
+            # Each asyncio task has its own context, so this store is
+            # per-sample — the same isolation Inspect's task runner provides.
+            init_subtask_store(sample_store)
+            environments = await ProxmoxSandboxEnvironment.sample_init(
+                "test_task", config, {}
+            )
+            # Hold the instance until the other sample has acquired its own,
+            # forcing the pool to hand out both instances.
+            await hold_both.wait()
+            await ProxmoxSandboxEnvironment.sample_cleanup(
+                "test_task", config, environments, False
+            )
+
+        store_a, store_b = Store(), Store()
+        await asyncio.gather(run_sample(store_a), run_sample(store_b))
+
+        by_id = {
+            "pool-inst-1": ("10.0.1.10", "pve1"),
+            "pool-inst-2": ("10.0.1.11", "pve2"),
+        }
+        recorded_ids = set()
+        for sample_store in (store_a, store_b):
+            instance_id = sample_store.get("proxmox:instance_id")
+            recorded_ids.add(instance_id)
+            expected_host, expected_node = by_id[instance_id]
+            assert sample_store.get("proxmox:host") == expected_host
+            assert sample_store.get("proxmox:node") == expected_node
+            assert sample_store.get("proxmox:host") != ENV_SENTINEL_HOST
+
+        assert recorded_ids == {"pool-inst-1", "pool-inst-2"}, (
+            f"both samples recorded the same instance: {recorded_ids}"
+        )
+    finally:
+        os.unlink(config_file)
+
+
+@pytest.mark.asyncio
+async def test_failed_sample_init_still_records_instance(
+    mock_proxmox_api, mock_infra_commands
+):
+    """Samples that fail during VM creation still record which instance they used.
+
+    Attribution matters most for failure forensics (the motivating incident
+    was diagnosed from QGA retry warnings), so the stamp happens immediately
+    after acquisition, before anything can fail.
+    """
+    config_file = _config_file([_instance("pool-inst-1", "10.0.1.10", "pve1")])
+    os.environ["PROXMOX_CONFIG_FILE"] = config_file
+    try:
+        mock_infra_commands.create_sdn_and_vms = AsyncMock(
+            side_effect=ValueError("boom")
+        )
+        await ProxmoxSandboxEnvironment.task_init("test_task", None)
+        config = ProxmoxSandboxEnvironmentConfig()
+
+        sample_store = Store()
+        init_subtask_store(sample_store)
+        with pytest.raises(ValueError, match="boom"):
+            await ProxmoxSandboxEnvironment.sample_init("test_task", config, {})
+
+        assert sample_store.get("proxmox:instance_id") == "pool-inst-1"
+        assert sample_store.get("proxmox:host") == "10.0.1.10"
+    finally:
+        os.unlink(config_file)

--- a/tests/proxmoxsandboxtest/test_host_attribution.py
+++ b/tests/proxmoxsandboxtest/test_host_attribution.py
@@ -1,25 +1,27 @@
-"""Tests that each sample durably records the pool instance it actually ran on.
+"""Tests that each sample logs the pool instance it actually ran on.
 
 The frozen ProxmoxSandboxEnvironmentConfig defaults host/port/node from
 process env vars, and that config is what Inspect serialises into each
-sample's `sandbox` field — so with a pool, every sample used to be
-attributed to the single PROXMOX_HOST env default regardless of which
-instance it acquired. sample_init now stamps the acquired instance into the
-Inspect sample store (`proxmox:*` keys), which lands in the .eval log.
+sample's `sandbox` field — so with a pool, every sample would be attributed
+to the single PROXMOX_HOST env default regardless of which instance it
+acquired. sample_init now logs the acquired instance at INFO level so a
+sample can be attributed to the Proxmox server it ran on.
 """
 
 import asyncio
 import json
+import logging
 import os
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from inspect_ai.util._store import Store, init_subtask_store
 
 from proxmoxsandbox._impl.infra_commands import InfraCommands
 from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
 from proxmoxsandbox.schema import ProxmoxSandboxEnvironmentConfig
+
+LOGGER_NAME = "proxmoxsandbox._proxmox_sandbox_environment"
 
 # Sentinel env default: TEST-NET-3, provably not a real pool instance.
 ENV_SENTINEL_HOST = "203.0.113.255"
@@ -115,10 +117,10 @@ def _instance(instance_id: str, host: str, node: str) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_sample_records_acquired_instance_not_env_default(
-    mock_proxmox_api, mock_infra_commands
+async def test_sample_logs_acquired_instance_not_env_default(
+    mock_proxmox_api, mock_infra_commands, caplog
 ):
-    """The store must record the acquired pool instance, not the env default."""
+    """The log must name the acquired pool instance, not the env default."""
     config_file = _config_file([_instance("pool-inst-1", "10.0.1.10", "pve1")])
     os.environ["PROXMOX_CONFIG_FILE"] = config_file
     os.environ["PROXMOX_HOST"] = ENV_SENTINEL_HOST
@@ -127,23 +129,26 @@ async def test_sample_records_acquired_instance_not_env_default(
         await ProxmoxSandboxEnvironment.task_init("test_task", None)
         config = ProxmoxSandboxEnvironmentConfig()
 
-        sample_store = Store()
-        init_subtask_store(sample_store)
-        environments = await ProxmoxSandboxEnvironment.sample_init(
-            "test_task", config, {}
-        )
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            environments = await ProxmoxSandboxEnvironment.sample_init(
+                "test_task", config, {}
+            )
 
-        # The bug: the frozen config field is the env default. Documented
-        # here as the trap — do not use it for host attribution.
+        # The trap: the frozen config field is the env default. Do not use it
+        # for host attribution.
         assert config.host == ENV_SENTINEL_HOST
         assert config.node == "env-default-sentinel"
 
-        # The fix: the store records the instance actually acquired.
-        assert sample_store.get("proxmox:instance_id") == "pool-inst-1"
-        assert sample_store.get("proxmox:host") == "10.0.1.10"
-        assert sample_store.get("proxmox:port") == 8006
-        assert sample_store.get("proxmox:node") == "pve1"
-        assert sample_store.get("proxmox:pool_id") == "default"
+        # The fix: the log records the instance actually acquired.
+        acquired = [r for r in caplog.records if "Acquired instance" in r.message]
+        assert len(acquired) == 1
+        message = acquired[0].message
+        assert "pool-inst-1" in message
+        assert "host=10.0.1.10" in message
+        assert "port=8006" in message
+        assert "node=pve1" in message
+        assert ENV_SENTINEL_HOST not in message
+        assert "env-default-sentinel" not in message
 
         await ProxmoxSandboxEnvironment.sample_cleanup(
             "test_task", config, environments, False
@@ -153,10 +158,10 @@ async def test_sample_records_acquired_instance_not_env_default(
 
 
 @pytest.mark.asyncio
-async def test_concurrent_samples_record_distinct_instances(
-    mock_proxmox_api, mock_infra_commands
+async def test_concurrent_samples_log_distinct_instances(
+    mock_proxmox_api, mock_infra_commands, caplog
 ):
-    """Two concurrent samples over a 2-instance pool record different hosts.
+    """Two concurrent samples over a 2-instance pool log different hosts.
 
     Mirrors the incident: concurrent epochs each logged host=PROXMOX_HOST
     even though they provably ran on different Proxmox servers.
@@ -175,10 +180,7 @@ async def test_concurrent_samples_record_distinct_instances(
 
         hold_both = asyncio.Barrier(2)
 
-        async def run_sample(sample_store: Store) -> None:
-            # Each asyncio task has its own context, so this store is
-            # per-sample — the same isolation Inspect's task runner provides.
-            init_subtask_store(sample_store)
+        async def run_sample() -> None:
             environments = await ProxmoxSandboxEnvironment.sample_init(
                 "test_task", config, {}
             )
@@ -189,37 +191,42 @@ async def test_concurrent_samples_record_distinct_instances(
                 "test_task", config, environments, False
             )
 
-        store_a, store_b = Store(), Store()
-        await asyncio.gather(run_sample(store_a), run_sample(store_b))
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await asyncio.gather(run_sample(), run_sample())
+
+        acquired = [
+            r.message for r in caplog.records if "Acquired instance" in r.message
+        ]
+        assert len(acquired) == 2
 
         by_id = {
-            "pool-inst-1": ("10.0.1.10", "pve1"),
-            "pool-inst-2": ("10.0.1.11", "pve2"),
+            "pool-inst-1": ("host=10.0.1.10", "node=pve1"),
+            "pool-inst-2": ("host=10.0.1.11", "node=pve2"),
         }
         recorded_ids = set()
-        for sample_store in (store_a, store_b):
-            instance_id = sample_store.get("proxmox:instance_id")
+        for message in acquired:
+            instance_id = next(i for i in by_id if i in message)
             recorded_ids.add(instance_id)
             expected_host, expected_node = by_id[instance_id]
-            assert sample_store.get("proxmox:host") == expected_host
-            assert sample_store.get("proxmox:node") == expected_node
-            assert sample_store.get("proxmox:host") != ENV_SENTINEL_HOST
+            assert expected_host in message
+            assert expected_node in message
+            assert ENV_SENTINEL_HOST not in message
 
         assert recorded_ids == {"pool-inst-1", "pool-inst-2"}, (
-            f"both samples recorded the same instance: {recorded_ids}"
+            f"both samples logged the same instance: {recorded_ids}"
         )
     finally:
         os.unlink(config_file)
 
 
 @pytest.mark.asyncio
-async def test_failed_sample_init_still_records_instance(
-    mock_proxmox_api, mock_infra_commands
+async def test_failed_sample_init_still_logs_instance(
+    mock_proxmox_api, mock_infra_commands, caplog
 ):
-    """Samples that fail during VM creation still record which instance they used.
+    """Samples that fail during VM creation still log which instance they used.
 
     Attribution matters most for failure forensics (the motivating incident
-    was diagnosed from QGA retry warnings), so the stamp happens immediately
+    was diagnosed from QGA retry warnings), so the log happens immediately
     after acquisition, before anything can fail.
     """
     config_file = _config_file([_instance("pool-inst-1", "10.0.1.10", "pve1")])
@@ -231,12 +238,15 @@ async def test_failed_sample_init_still_records_instance(
         await ProxmoxSandboxEnvironment.task_init("test_task", None)
         config = ProxmoxSandboxEnvironmentConfig()
 
-        sample_store = Store()
-        init_subtask_store(sample_store)
-        with pytest.raises(ValueError, match="boom"):
-            await ProxmoxSandboxEnvironment.sample_init("test_task", config, {})
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            with pytest.raises(ValueError, match="boom"):
+                await ProxmoxSandboxEnvironment.sample_init("test_task", config, {})
 
-        assert sample_store.get("proxmox:instance_id") == "pool-inst-1"
-        assert sample_store.get("proxmox:host") == "10.0.1.10"
+        acquired = [
+            r.message for r in caplog.records if "Acquired instance" in r.message
+        ]
+        assert len(acquired) == 1
+        assert "pool-inst-1" in acquired[0]
+        assert "host=10.0.1.10" in acquired[0]
     finally:
         os.unlink(config_file)


### PR DESCRIPTION
With an instance pool, the `sandbox.config.host/port/node` recorded in each sample's eval log are whatever the env vars (or the eval's explicit config) said at construction — never the instance the sample acquired. `ProxmoxSandboxEnvironmentConfig` is frozen and defaults those fields from process env vars, so with a pool they can't attribute a sample to a server. An eval log showed every sample attributed to the same host while QGA retry warnings proved they were running on different servers.

`sample_init` now logs the acquired instance at INFO, immediately after acquisition (before anything can fail):

```
Acquired instance <id> from pool '<pool>': host=<host> port=<port> node=<node>
```

## Making INFO actually land in the `.eval`

Inspect's transcript captures `info`+ — but only for loggers it configures. `init_logger` sets the **root** logger to the `warning` default and lowers only `inspect_ai`'s own package loggers; a registered extension like this one inherits root=`warning`, so `logger.info(...)` is filtered at the source and never reaches the transcript. (Confirmed empirically: a default `inspect eval` captured zero logger events; the line only appeared when `--log-level info` was passed.)

So the provider opts its own logger in at import: `getLogger("proxmoxsandbox").setLevel(INFO)`. This is downstream-overridable — `--log-level-transcript warning` (or `INSPECT_LOG_LEVEL_TRANSCRIPT=warning`) still drops it, and the console stays quiet by default (the display gate is `--log-level`, still `warning`).

Do not use the serialised `sandbox.config` host/port/node for attribution in pool mode — the README says so.

## Verification

Real `inspect eval` against a Proxmox at `172.31.106.106`, three log-level configs:

| config | in `.eval` transcript | console |
| --- | --- | --- |
| default | present | quiet |
| `--log-level-transcript warning` | absent | quiet |
| `--log-level info` | present | present |

A full `ctf4` run (`message_limit=20`, 42 model turns / 42 tool calls, 248 transcript events) produced 15 INFO lines total — all one-time VM lifecycle (acquire / create / ready / QGA ping / cleanup / release); the count does not scale with agent activity. The sentinel and concurrent-distinct-instances cases are covered by unit tests in `test_host_attribution.py`, which fail without the fix.

Follow-ups: consider excluding the credential fields from the serialised config entirely, since in pool mode they are pure misdirection; cyber-register's `_load_proxmox_creds` (which stamps `instances[0]` creds into the config, producing the real-looking wrong host in the incident log) can likewise stop setting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
