### PR TITLE
Protect the Proxmox host from sandbox network floods (conntrack + DoS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ These work under either firewall backend (`pve-firewall` or the nftables
 `proxmox-firewall`); the latter won't touch these chains. On `iptables-legacy`
 hosts they won't show in `nft list ruleset` — use `iptables -t raw -S` / `-S FORWARD`.
 
+The provisioners also install two host-level controls that keep the host *available* if
+a sandbox guest floods the network (conntrack control-plane immunity + a per-tap rate
+policer) — see [docs/host-network-protection.md](docs/host-network-protection.md).
+
 ### Single Proxmox Instance
 
 Set the following environment variables (e.g. in a [`.env`](https://dotenvx.com/docs/env-file) file):

--- a/docs/host-network-protection.md
+++ b/docs/host-network-protection.md
@@ -1,0 +1,61 @@
+# Keeping the host available under a hostile guest
+
+The [host firewall isolation](../README.md#host-firewall-isolation) keeps guests *off*
+the host control plane. Two further host-level controls, installed automatically by the
+provisioning scripts (`scripts/virtualized_proxmox/build_proxmox_auto.sh`,
+`scripts/ec2/userdata.sh`), keep the host *available* when a sandbox guest floods the
+network — e.g. an in-range `nmap`/`masscan` in a cyber eval. Both live on the host.
+
+## 1. Control-plane conntrack immunity (NOTRACK)
+
+Each sandbox network is an SDN "simple" zone with a host gateway + SNAT, so every guest
+connection is routed/NAT'd by the host and consumes an entry in the host's global
+`nf_conntrack` table (default 262144). A guest that opens many flows fills it, and the
+kernel then drops *new* connections host-wide (`nf_conntrack: table full, dropping
+packet`). Since this provider opens a fresh connection to `pveproxy:8006` per request,
+Inspect's own control connection gets dropped — the eval loses the host and retries for
+minutes. With the Proxmox firewall on, `br_netfilter` conntracks even intra-range
+guest↔guest traffic, so internal scans do this too.
+
+The provisioners exempt the control-plane ports (8006, 22) from connection tracking — a
+`raw` `NOTRACK` rule in both directions — so those packets need no table slot and
+survive a full table:
+
+```bash
+for _port in 8006 22; do
+    iptables -w -t raw -C PREROUTING -p tcp --dport "$_port" -j CT --notrack 2>/dev/null \
+        || iptables -w -t raw -I PREROUTING 1 -p tcp --dport "$_port" -j CT --notrack
+    iptables -w -t raw -C OUTPUT -p tcp --sport "$_port" -j CT --notrack 2>/dev/null \
+        || iptables -w -t raw -I OUTPUT 1 -p tcp --sport "$_port" -j CT --notrack
+done
+```
+
+This deliberately does **not** raise `nf_conntrack_max`: a bigger table only delays
+exhaustion, it doesn't protect the control plane.
+
+## 2. Per-tap ingress rate policer (DoS bound)
+
+NOTRACK stops the control-plane connection being *dropped*, but not the host CPU a flood
+burns processing new flows in softirq. A guest scanning fast enough (many cores,
+`masscan`) can still saturate the host and starve pveproxy — a DoS NOTRACK can't stop,
+and which raising `nf_conntrack_max` makes *worse* (bigger table, longer to drain).
+
+So the provisioners cap each sandbox VM's guest→host packet rate with a `tc` **ingress
+policer on the tap**, which drops excess *before* conntrack. (A `connlimit` cap in
+`FORWARD` doesn't work here: it runs *after* the per-packet conntrack processing, so the
+host still pays the cost that causes the DoS.) Tap names are per-VM and dynamic, so a
+udev rule applies the policer to each tap as it appears:
+
+- `/usr/local/bin/inspect-proxmox-tap-policer.sh <tap>` — adds a `tc` ingress qdisc and a
+  `matchall action police pkts_rate <PPS> drop` filter. It re-asserts for a few seconds
+  because Proxmox's NIC bring-up wipes a qdisc applied at the udev `add` event.
+- a templated systemd service (`inspect-proxmox-tap-policer@.service`) plus a udev rule
+  (`KERNEL=="tap*i*"`) that starts it per tap.
+
+The `PPS` cap is generous for real scanning but well below what saturates a multi-core
+host; a determined flood just hits the ceiling instead of taking the host down. Requires
+a kernel with `tc` packet-rate policing (`police pkts_rate`) — PVE 9 has it.
+
+If you provision Proxmox some other way, replicate both controls on the node and persist
+them across reboots (the NOTRACK rules are re-applied each boot by a systemd oneshot; the
+policer is re-applied per tap by the udev rule).

--- a/poc/conntrack_control_plane_poc.py
+++ b/poc/conntrack_control_plane_poc.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""PoC: can an in-range nmap sever Inspect's control connection to Proxmox?
+
+Runs a real Inspect eval against the proxmox sandbox provider. The solver launches an
+nmap in the guest that fills the host's nf_conntrack table, then -- while the scan runs
+-- probes two things each second and times them:
+
+  * a raw HTTPS connection to pveproxy (:8006)  -- the control plane. This is the exact
+    thing the incident dropped, so it is the clean signal for the conntrack effect the
+    NOTRACK fix targets.
+  * sandbox().read_file()                        -- a real Inspect operation. It rides
+    the same :8006 -> qemu-guest-agent path, so it FOLLOWS the :8006 result: when a full
+    table drops :8006 SYNs, read_file's connections drop too. (The guest agent itself
+    stays responsive under the scan -- a local `qm agent ping` succeeds throughout -- so
+    this is not guest-CPU starvation. read_file can look noisier than the raw probe
+    because the provider retries it internally.)
+
+Against a host WITHOUT the fix, the :8006 probe stalls/fails once the table fills (the
+incident). Against a fixed host (NOTRACK on :8006/22), it stays healthy with the table
+full -- UNLESS the scan's packet rate is high enough to saturate the host's own
+forwarding softirq, which slows pveproxy regardless of conntrack. That second regime is
+a host-capacity limit, not this bug, and NOTRACK does not address it; where its
+threshold sits relative to real scanners (nmap rate, masscan, guest core count) is
+not characterised here.
+
+Runs with sandbox_cleanup=False, so the VM (and nmap) keep running afterwards for manual
+poking; the cleanup command is printed at the end.
+
+Usage:
+    source env-<host>            # the PROXMOX_* env this provider reads
+    uv run python poc/conntrack_control_plane_poc.py [--scan-target 198.18.0.0/16] \
+        [--duration 60]
+
+--scan-target defaults to 198.18.0.0/16 (RFC 2544 benchmarking range, a routable
+blackhole that belongs to nobody) so the scan fills the host table via the SNAT path
+without hitting real hosts.
+"""
+
+import argparse
+import asyncio
+import os
+import time
+
+import httpx
+from inspect_ai import Task, eval, task
+from inspect_ai.dataset import Sample
+from inspect_ai.solver import Solver, TaskState, solver
+from inspect_ai.util import sandbox
+
+DEFAULT_SCAN_TARGET = "198.18.0.0/16"
+DEFAULT_DURATION = 60
+
+
+@solver
+def _scan_and_probe(scan_target: str, duration: int) -> Solver:
+    async def solve(state: TaskState, generate):  # type: ignore[no-untyped-def]
+        sb = sandbox()
+
+        # nmap -sS needs raw sockets; QGA exec runs as root in the guest.
+        await sb.exec(
+            [
+                "bash",
+                "-lc",
+                "command -v nmap >/dev/null || "
+                "{ apt-get update && apt-get install -y nmap; }",
+            ],
+            timeout=300,
+        )
+        # Detached, a single nmap -- a realistic agent scan. -Pn/-n skip discovery/DNS
+        # and --max-retries 0 stops backoff against the blackhole, so it fills the host
+        # conntrack table in ~20s. Deliberately not parallelised: several nmaps fill
+        # faster but also peg the host CPU, which adds pveproxy latency unrelated to
+        # conntrack and confounds the control-plane signal.
+        await sb.exec(
+            [
+                "bash",
+                "-lc",
+                "nohup nmap -sS -Pn -n -T5 --min-rate 30000 --max-retries 0 "
+                f"-p- {scan_target} >/dev/null 2>&1 & echo launched",
+            ],
+            timeout=30,
+        )
+
+        host = os.environ["PROXMOX_HOST"]
+        port = os.environ.get("PROXMOX_PORT", "8006")
+        api_url = f"https://{host}:{port}/"
+
+        await asyncio.sleep(20)  # let the scan fill the table
+
+        # Split timeout isolates the conntrack signal from host-CPU noise: a full
+        # conntrack table DROPS the connection's SYN, so a short connect timeout fails
+        # on an unfixed host but succeeds on a NOTRACK'd one. The generous read timeout
+        # absorbs transient pveproxy slowness during nmap's fill burst (host CPU)
+        # without misreading it as the conntrack failure.
+        probes: list[dict] = []
+        print("\n  t   API :8006 (control plane)   read_file (also guest-CPU bound)")
+        timeout = httpx.Timeout(connect=4.0, read=12.0, write=12.0, pool=12.0)
+        async with httpx.AsyncClient(verify=False, timeout=timeout) as client:
+            for i in range(duration):
+                t0 = time.monotonic()
+                try:
+                    await client.get(api_url)
+                    api_ok, api_ms = True, (time.monotonic() - t0) * 1000
+                except Exception:
+                    api_ok, api_ms = False, (time.monotonic() - t0) * 1000
+
+                t1 = time.monotonic()
+                try:
+                    await asyncio.wait_for(sb.read_file("/etc/hostname"), timeout=5)
+                    rf_ok, rf_ms = True, (time.monotonic() - t1) * 1000
+                except Exception:
+                    rf_ok, rf_ms = False, (time.monotonic() - t1) * 1000
+
+                probes.append(
+                    {"t": i, "api_ok": api_ok, "api_ms": api_ms,
+                     "rf_ok": rf_ok, "rf_ms": rf_ms}
+                )
+                print(
+                    f" {i:3d}s  {'OK  ' if api_ok else 'FAIL'} {api_ms:6.0f}ms"
+                    f"            {'OK  ' if rf_ok else 'FAIL'} {rf_ms:6.0f}ms"
+                )
+                await asyncio.sleep(1)
+
+        state.metadata["probes"] = probes
+        return state
+
+    return solve
+
+
+@task
+def _poc_task(scan_target: str, duration: int) -> Task:
+    return Task(
+        dataset=[Sample(input="poc", target="poc")],
+        solver=[_scan_and_probe(scan_target, duration)],
+        sandbox="proxmox",
+    )
+
+
+def main() -> None:
+    """Run the PoC eval against the configured host and print the verdict."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--scan-target", default=DEFAULT_SCAN_TARGET)
+    ap.add_argument("--duration", type=int, default=DEFAULT_DURATION)
+    args = ap.parse_args()
+
+    host = os.environ.get("PROXMOX_HOST", "<unset>")
+    print(
+        f'watch the host fill up with:  ssh {host} "watch -n1 cat '
+        '/proc/sys/net/netfilter/nf_conntrack_count"'
+    )
+
+    logs = eval(
+        tasks=[_poc_task(args.scan_target, args.duration)],
+        model="mockllm/model",
+        sandbox_cleanup=False,
+        display="plain",
+    )
+
+    probes = logs[0].samples[0].metadata.get("probes", [])
+    api_fail = sum(1 for p in probes if not p["api_ok"])
+    rf_fail = sum(1 for p in probes if not p["rf_ok"])
+
+    print("\n==== result ====")
+    print(
+        f"probes: {len(probes)}   :8006 connect failures: {api_fail}   "
+        f"read_file failures: {rf_fail}"
+    )
+    print(
+        "How to read this:\n"
+        "  * UNFIXED host: :8006 connect failures are SUSTAINED for as long as the\n"
+        "    table stays full -- that is the incident (Inspect loses the host).\n"
+        "  * FIXED host: :8006 stays reachable; expect at most a few blips during\n"
+        "    nmap's fill burst (host CPU spikes, not conntrack -- NOTRACK can't help\n"
+        "    that and it clears once the scan throttles against the full table).\n"
+        "  * read_file rides the same :8006 path, so it FOLLOWS :8006 -- it fails\n"
+        "    when :8006 drops and recovers with it. The guest agent itself stays up\n"
+        "    (a local `qm agent ping` succeeds under the scan); read_file only looks\n"
+        "    noisier because the provider retries it internally.\n"
+        "For an unambiguous check, probe :8006 from outside while the table is full\n"
+        "and steady (see the host conntrack watch command above)."
+    )
+
+    print("\nVM left running (sandbox_cleanup=False) and still scanning.")
+    print("clean up with:  inspect sandbox cleanup proxmox")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -395,6 +395,15 @@ if command -v ip6tables >/dev/null; then
     ip6tables -w -C FORWARD -j DROP 2>/dev/null \
         || ip6tables -w -A FORWARD -j DROP
 fi
+
+# Keep pveproxy (8006) and ssh (22) reachable when a guest fills the host conntrack
+# table (e.g. an in-range nmap): NOTRACK'd packets need no table slot. See root README.
+for _port in 8006 22; do
+    iptables -w -t raw -C PREROUTING -p tcp --dport "$_port" -j CT --notrack 2>/dev/null \
+        || iptables -w -t raw -I PREROUTING 1 -p tcp --dport "$_port" -j CT --notrack
+    iptables -w -t raw -C OUTPUT -p tcp --sport "$_port" -j CT --notrack 2>/dev/null \
+        || iptables -w -t raw -I OUTPUT 1 -p tcp --sport "$_port" -j CT --notrack
+done
 BLOCK_METADATA
 chmod +x /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
 
@@ -468,6 +477,44 @@ systemctl enable proxmox-ami-fixup-nat.service
 systemctl enable proxmox-ami-fixup-password.service
 systemctl enable proxmox-ami-fixup-firewall.service
 systemctl enable inspect-proxmox-block-cloud-metadata.service
+
+# Bound each sandbox VM's guest->host packet rate at its tap. A flooding guest (a
+# high-rate nmap/masscan) otherwise drives host conntrack + softirq hard enough to
+# starve the control plane -- a DoS the NOTRACK rules above do not stop. An ingress
+# policer drops the excess BEFORE conntrack; a udev rule applies it to every tap as
+# it appears (tap names are per-VM and dynamic, so this can't be a static rule). See
+# root README.
+cat > /usr/local/bin/inspect-proxmox-tap-policer.sh << 'TAP_POLICER'
+#!/bin/bash
+set -euo pipefail
+IFACE="$1"
+PPS=20000
+# Proxmox's NIC bring-up wipes an ingress qdisc applied at the udev 'add' event, so
+# re-assert for a few seconds until it sticks (verified: single-shot gets cleared).
+for _ in $(seq 1 8); do
+    tc qdisc add dev "$IFACE" handle ffff: ingress 2>/dev/null || true
+    tc filter replace dev "$IFACE" parent ffff: matchall \
+        action police pkts_rate "$PPS" pkts_burst "$PPS" drop 2>/dev/null || true
+    sleep 1
+done
+TAP_POLICER
+chmod +x /usr/local/bin/inspect-proxmox-tap-policer.sh
+
+cat > /etc/systemd/system/inspect-proxmox-tap-policer@.service << 'TAP_POLICER_UNIT'
+[Unit]
+Description=Rate-limit sandbox VM tap %i (guest->host flood protection)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/inspect-proxmox-tap-policer.sh %i
+TAP_POLICER_UNIT
+
+cat > /etc/udev/rules.d/99-inspect-proxmox-tap-policer.rules << 'TAP_POLICER_UDEV'
+SUBSYSTEM=="net", ACTION=="add", KERNEL=="tap*i*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="inspect-proxmox-tap-policer@$name.service"
+TAP_POLICER_UDEV
+
+systemctl daemon-reload
+udevadm control --reload 2>/dev/null || true
 
 # ===== CloudWatch OTLP metrics collector =====
 # Ship pvestatd's metrics to the CloudWatch OTLP endpoint via a localhost CloudWatch

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -288,6 +288,15 @@ if command -v ip6tables >/dev/null; then
     ip6tables -w -C FORWARD -j DROP 2>/dev/null \
         || ip6tables -w -A FORWARD -j DROP
 fi
+
+# Keep pveproxy (8006) and ssh (22) reachable when a guest fills the host conntrack
+# table (e.g. an in-range nmap): NOTRACK'd packets need no table slot. See root README.
+for _port in 8006 22; do
+    iptables -w -t raw -C PREROUTING -p tcp --dport "$_port" -j CT --notrack 2>/dev/null \
+        || iptables -w -t raw -I PREROUTING 1 -p tcp --dport "$_port" -j CT --notrack
+    iptables -w -t raw -C OUTPUT -p tcp --sport "$_port" -j CT --notrack 2>/dev/null \
+        || iptables -w -t raw -I OUTPUT 1 -p tcp --sport "$_port" -j CT --notrack
+done
 BLOCK_METADATA
 chmod +x /usr/local/bin/inspect-proxmox-block-cloud-metadata.sh
 
@@ -308,6 +317,44 @@ BLOCK_METADATA_UNIT
 
 systemctl daemon-reload
 systemctl enable inspect-proxmox-block-cloud-metadata.service
+
+# Bound each sandbox VM's guest->host packet rate at its tap. A flooding guest (a
+# high-rate nmap/masscan) otherwise drives host conntrack + softirq hard enough to
+# starve the control plane -- a DoS the NOTRACK rules above do not stop. An ingress
+# policer drops the excess BEFORE conntrack; a udev rule applies it to every tap as
+# it appears (tap names are per-VM and dynamic, so this can't be a static rule). See
+# root README.
+cat > /usr/local/bin/inspect-proxmox-tap-policer.sh << 'TAP_POLICER'
+#!/bin/bash
+set -euo pipefail
+IFACE="$1"
+PPS=20000
+# Proxmox's NIC bring-up wipes an ingress qdisc applied at the udev 'add' event, so
+# re-assert for a few seconds until it sticks (verified: single-shot gets cleared).
+for _ in $(seq 1 8); do
+    tc qdisc add dev "$IFACE" handle ffff: ingress 2>/dev/null || true
+    tc filter replace dev "$IFACE" parent ffff: matchall \
+        action police pkts_rate "$PPS" pkts_burst "$PPS" drop 2>/dev/null || true
+    sleep 1
+done
+TAP_POLICER
+chmod +x /usr/local/bin/inspect-proxmox-tap-policer.sh
+
+cat > /etc/systemd/system/inspect-proxmox-tap-policer@.service << 'TAP_POLICER_UNIT'
+[Unit]
+Description=Rate-limit sandbox VM tap %i (guest->host flood protection)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/inspect-proxmox-tap-policer.sh %i
+TAP_POLICER_UNIT
+
+cat > /etc/udev/rules.d/99-inspect-proxmox-tap-policer.rules << 'TAP_POLICER_UDEV'
+SUBSYSTEM=="net", ACTION=="add", KERNEL=="tap*i*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="inspect-proxmox-tap-policer@$name.service"
+TAP_POLICER_UDEV
+
+systemctl daemon-reload
+udevadm control --reload 2>/dev/null || true
 
 touch /var/local/inspect-proxmox-on-first-boot.done
 

--- a/tests/proxmoxsandboxtest/test_provisioning_security.py
+++ b/tests/proxmoxsandboxtest/test_provisioning_security.py
@@ -45,9 +45,60 @@ def test_provisioners_contain_expected_iptables_rules(provisioner: Path) -> None
     # IPv6 unsupported: disabled on guest interfaces + forwarded v6 dropped.
     assert "net.ipv6.conf.default.disable_ipv6 = 1" in script
     assert "ip6tables -w -A FORWARD -j DROP" in script
+    # Control-plane conntrack immunity: pveproxy (8006) and ssh (22) are exempt from
+    # conntrack (raw NOTRACK, both directions), so a guest that fills the host
+    # conntrack table can't get Inspect's connection dropped by "table full".
+    assert "for _port in 8006 22; do" in script
+    assert (
+        'iptables -w -t raw -I PREROUTING 1 -p tcp --dport "$_port" -j CT --notrack'
+        in script
+    )
+    assert (
+        'iptables -w -t raw -I OUTPUT 1 -p tcp --sport "$_port" -j CT --notrack'
+        in script
+    )
     # Boot service installed and enabled.
     assert "ExecStart=/usr/local/bin/inspect-proxmox-block-cloud-metadata.sh" in script
     assert "systemctl enable inspect-proxmox-block-cloud-metadata.service" in script
+    # Anti-DoS: a udev-triggered ingress policer caps each sandbox tap's guest->host
+    # packet rate, so a flooding guest can't exhaust host conntrack/softirq. The
+    # policer drops before conntrack (tc ingress), which NOTRACK/connlimit can't do.
+    assert 'KERNEL=="tap*i*"' in script
+    assert "inspect-proxmox-tap-policer@$name.service" in script
+    assert "action police pkts_rate" in script
+    assert "handle ffff: ingress" in script
     # The single-cloud denylist is gone.
     assert "169.254.169.254/32" not in script
     assert "fd00:ec2::254" not in script
+
+
+def _extract_block_metadata(script: str) -> str:
+    """Body of the `<< 'BLOCK_METADATA'` heredoc that both provisioners emit."""
+    marker_open = "<< 'BLOCK_METADATA'\n"
+    start = script.index(marker_open) + len(marker_open)
+    end = script.index("\nBLOCK_METADATA\n", start)
+    return script[start:end]
+
+
+def _extract_heredoc(script: str, marker: str) -> str:
+    open_m = f"<< '{marker}'\n"
+    start = script.index(open_m) + len(open_m)
+    end = script.index(f"\n{marker}\n", start)
+    return script[start:end]
+
+
+def test_block_metadata_script_identical_across_provisioners() -> None:
+    # The confine-guests script (link-local block, IPv6 drop, control-plane NOTRACK)
+    # is duplicated into both provisioners and must stay byte-identical; drift means
+    # one host family silently loses an isolation or availability control.
+    ec2 = (EC2_SCRIPTS / "userdata.sh").read_text()
+    virt = VIRTUALIZED_SCRIPT.read_text()
+    assert _extract_block_metadata(ec2) == _extract_block_metadata(virt)
+
+
+def test_tap_policer_identical_across_provisioners() -> None:
+    # The tap ingress policer (guest->host flood / DoS protection) is likewise
+    # duplicated and must not drift between host families.
+    ec2 = (EC2_SCRIPTS / "userdata.sh").read_text()
+    virt = VIRTUALIZED_SCRIPT.read_text()
+    assert _extract_heredoc(ec2, "TAP_POLICER") == _extract_heredoc(virt, "TAP_POLICER")


### PR DESCRIPTION
SLOP ALERT

## Problem

A sandbox guest that floods the network (e.g. an in-range `nmap` in a cyber eval) can take the Proxmox host down. It first surfaced as Inspect losing its connection to the API for ~5 min, with `nf_conntrack: table full, dropping packet` in the host journal.

## Two failure modes (both reproduced on a real host)

1. **Conntrack exhaustion of the control plane.** Each sandbox is an SDN "simple" zone with a host gateway + SNAT, so every guest connection consumes a host `nf_conntrack` entry (default 262144). A guest that opens many flows fills the table; the kernel then drops *new* connections host-wide. This provider opens a fresh `:8006` connection per request, so Inspect's control connection is what gets dropped. (With the firewall on, `br_netfilter` conntracks intra-range guest↔guest traffic too, so internal scans do it.)
2. **Softirq DoS.** Even with (1) handled, the *rate* of new-flow conntrack processing in softirq starves pveproxy — it times out under load at only `load1 ≈ 0.4` (softirq isn't a runnable task, so it never shows in loadavg). Raising `nf_conntrack_max` makes this worse, not better.

## Fix — two host-level controls, in both provisioners

1. **NOTRACK on the control-plane ports (8006, 22)** — `raw` table, both directions. Those connections need no conntrack slot, so they survive a full table. Does **not** raise `nf_conntrack_max` (a bigger table only delays exhaustion).
2. **Per-tap `tc` ingress packet-rate policer** — drops excess *before* conntrack (a `connlimit` cap in `FORWARD` is too late; it pays the per-packet conntrack cost first). Applied to each sandbox tap by a udev rule, since tap names are per-VM; re-asserted for a few seconds because Proxmox's NIC bring-up wipes a qdisc set at the udev `add` event.

## Evidence

- **NOTRACK:** guest fills the table to 262144/262144; without NOTRACK a new `:8006` connection is dropped (`000`, timeout), with NOTRACK it returns HTTP 200 in ~11 ms.
- **Policer:** 8-core guest running 8× `nmap --min-rate 50000`; the policer (auto-applied via udev) drops ~485k pps at ingress and **pveproxy stays 200/11 ms, load 0.32** — vs sustained 5 s timeouts without it.
- `poc/conntrack_control_plane_poc.py` reproduces the control-plane loss end-to-end via a full `inspect eval` (nmap from the guest while probing `:8006`).

## Notes for reviewers

- The confine-guests block and the tap-policer script are each duplicated byte-identical across `build_proxmox_auto.sh` and `ec2/userdata.sh`; tests assert neither drifts.
- Existing hosts need re-provisioning to pick this up (NOTRACK re-applied each boot by a systemd oneshot; policer re-applied per tap by the udev rule).
- The policer needs a kernel with `tc ... police pkts_rate` (PVE 9 has it). `PPS` is a hardcoded sane default — generous for real scans, well below host saturation.
- Full mechanism writeup: `docs/host-network-protection.md`.

## Further testing before merge

All validation so far exercised the *mechanisms* (NOTRACK rules, tc ingress policer, udev trigger) by applying them **by hand** on a live PVE 9.2.3 / kernel 7.0.12 host. What hasn't been exercised:

- **The actual provisioning paths end-to-end.** Neither `build_proxmox_auto.sh` (build a template → clone → boot a fresh instance) nor `ec2/userdata.sh` (cloud-init on a fresh EC2 instance) has been run. Confirm on a freshly provisioned host that: the NOTRACK rules come up each boot (systemd oneshot), and the udev rule + templated service + policer script survive the template clone / land via userdata and fire per tap on real sandbox VMs. Only `bash -n` syntax was checked here.
- **`firewall=True` topology.** Tested with the provider default (`firewall=False`, tap attached directly to the vnet). With the per-VM firewall on, the tap is moved into an `fwbr`; confirm the tap-ingress policer still sits on the guest's egress path (the udev `tap*i*` match still fires, but verify the policing point relative to `fwbr`/`fwln`).
- **Steady-state soak.** The policer run was ~8 s (conntrack still climbing). Let a rate-limited flood run until conntrack reaches max and confirm pveproxy stays healthy at steady full-table, not just during fill.
- **The `PPS=20000` default.** Validated safe on a 16-core host; not on smaller hosts (lower saturation point) and not against real eval workloads. Confirm it doesn't throttle legitimate use — note a pps cap also bounds throughput (~20k × 1500 B ≈ 240 Mbit/s), which could matter for bulk transfer in a sandbox.
- **Kernel support / failure visibility.** The policer needs `tc ... action police pkts_rate`; if a host's kernel lacks it the filter silently doesn't apply (no protection, no alert). Worth a provisioning-time check or a smoke test that the qdisc/filter is present on a tap.
- **Multi-NIC / multi-VM samples.** The udev rule policies every `tap*i*` independently; a sample with several VMs or NICs wasn't explicitly tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
