### PR TITLE
Drop misleading single-instance fields from ProxmoxSandboxEnvironmentConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove the unused single-instance fields (`host` etc.) from `ProxmoxSandboxEnvironmentConfig`; infrastructure is configured via `PROXMOX_CONFIG_FILE` or `PROXMOX_*` environment variables only. Passing these fields is now silently ignored (pydantic drops extra kwargs), and old `.eval` logs still deserialize.
 - Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
 - Opt logger into `INFO` level for consistency with Inspect core
 - Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)

--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -16,6 +16,8 @@ from inspect_ai.util import (
 )
 from pydantic import BaseModel
 
+from proxmoxsandbox.schema import ProxmoxInstanceConfig
+
 ProxmoxJsonDataType = Dict[str, Union[str, List[str], int, bool, None]]
 
 
@@ -51,6 +53,15 @@ class AsyncProxmoxAPI:
         self.username = user
         self.password = password
         self.verify_tls = verify_tls
+
+    @classmethod
+    def from_instance_config(cls, instance: ProxmoxInstanceConfig):
+        return cls(
+            host=f"{instance.host}:{instance.port}",
+            user=f"{instance.user}@{instance.user_realm}",
+            password=instance.password.get_secret_value(),
+            verify_tls=instance.verify_tls,
+        )
 
     def __hash__(self):
         return hash((self.api_base_url, self.username, self.password, self.verify_tls))

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -331,13 +331,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         proxmox_ids_start = None
 
         try:
-            # Create API using acquired instance's credentials
-            async_proxmox_api = AsyncProxmoxAPI(
-                host=f"{instance.host}:{instance.port}",
-                user=f"{instance.user}@{instance.user_realm}",
-                password=instance.password.get_secret_value(),
-                verify_tls=instance.verify_tls,
-            )
+            async_proxmox_api = AsyncProxmoxAPI.from_instance_config(instance)
 
             target = ProxmoxTarget(
                 host=instance.host, port=instance.port, node=instance.node
@@ -488,17 +482,6 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 )
 
             raise
-
-    @classmethod
-    def _create_async_proxmox_api(
-        cls, config: ProxmoxSandboxEnvironmentConfig
-    ) -> AsyncProxmoxAPI:
-        return AsyncProxmoxAPI(
-            host=f"{config.host}:{config.port}",
-            user=f"{config.user}@{config.user_realm}",
-            password=config.password.get_secret_value(),
-            verify_tls=config.verify_tls,
-        )
 
     @classmethod
     async def _ensure_instance_clean(
@@ -655,12 +638,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         if id is None:
             await cls.create_proxmox_instance_pools()
             for instance in cls.proxmox_pool.all_instances():
-                async_proxmox_api = AsyncProxmoxAPI(
-                    host=f"{instance.host}:{instance.port}",
-                    user=f"{instance.user}@{instance.user_realm}",
-                    password=instance.password.get_secret_value(),
-                    verify_tls=instance.verify_tls,
-                )
+                async_proxmox_api = AsyncProxmoxAPI.from_instance_config(instance)
                 infra_commands = InfraCommands.build(
                     async_proxmox_api,
                     instance.node,

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -607,10 +607,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             cls.logger.debug(
                 f"task cleanup activated; {cleanup=}; "
                 f"config_type={config_type}; "
-                f"instance_pool_id={config.instance_pool_id}; "
-                f"host={config.host}; "
-                f"port={config.port}; "
-                f"node={config.node}"
+                f"instance_pool_id={config.instance_pool_id}"
             )
         else:
             cls.logger.debug(

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -328,19 +328,6 @@ class ProxmoxSandboxEnvironmentConfig(BaseModel):
         VmConfig(vm_source_config=VmSourceConfig(built_in="ubuntu24.04")),
     )
 
-    # Single-instance fields (used when configuring via environment variables)
-    host: str = Field(default_factory=lambda: getenv("PROXMOX_HOST", "localhost"))
-    port: int = Field(default_factory=lambda: int(getenv("PROXMOX_PORT", "8006")))
-    user: str = Field(default_factory=lambda: getenv("PROXMOX_USER", "root"))
-    user_realm: str = Field(default_factory=lambda: getenv("PROXMOX_REALM", "pam"))
-    password: SecretStr = Field(
-        default_factory=lambda: SecretStr(getenv("PROXMOX_PASSWORD", "password"))
-    )
-    node: str = Field(default_factory=lambda: getenv("PROXMOX_NODE", "proxmox"))
-    verify_tls: bool = Field(
-        default_factory=lambda: getenv("PROXMOX_VERIFY_TLS", "1") == "1"
-    )
-
     image_storage: str = Field(
         default_factory=lambda: getenv("PROXMOX_IMAGE_STORAGE", "local-lvm")
     )

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -308,13 +308,6 @@ class ProxmoxSandboxEnvironmentConfig(BaseModel):
             normally.
         sdn_config: Software-defined networking configuration
         vms_config: Configurations for virtual machines
-        host: The hostname or IP address of the Proxmox server
-        port: The port number for the Proxmox API, usually 8006
-        user: The username for Proxmox authentication
-        user_realm: The authentication realm for the Proxmox user
-        password: The password for Proxmox authentication
-        node: The name of the Proxmox node
-        verify_tls: Whether to verify the Proxmox server's TLS certificate
     """
 
     model_config = ConfigDict(frozen=True, hide_input_in_errors=True)

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -248,6 +248,26 @@ class ProxmoxInstanceConfig(BaseModel):
     verify_tls: bool
 
 
+def _load_single_instance_from_env() -> ProxmoxInstanceConfig:
+    """
+    Load a single Proxmox instance configuration from environment variables.
+
+    Returns:
+        ProxmoxInstanceConfig object
+    """
+    return ProxmoxInstanceConfig(
+        instance_id="default",
+        pool_id="default",
+        host=getenv("PROXMOX_HOST", "localhost"),
+        port=int(getenv("PROXMOX_PORT", "8006")),
+        user=getenv("PROXMOX_USER", "root"),
+        user_realm=getenv("PROXMOX_REALM", "pam"),
+        password=getenv("PROXMOX_PASSWORD", "password"),
+        node=getenv("PROXMOX_NODE", "proxmox"),
+        verify_tls=getenv("PROXMOX_VERIFY_TLS", "1") == "1",
+    )
+
+
 def _load_instances_from_env_or_file() -> Tuple[ProxmoxInstanceConfig, ...]:
     """
     Load Proxmox instance configurations from file or environment variables.
@@ -268,21 +288,8 @@ def _load_instances_from_env_or_file() -> Tuple[ProxmoxInstanceConfig, ...]:
             return tuple(ProxmoxInstanceConfig(**inst) for inst in instances_data)
 
     # Priority 2: Single instance from env vars
-    host = getenv("PROXMOX_HOST")
-    if host:
-        return (
-            ProxmoxInstanceConfig(
-                instance_id="default",
-                pool_id="default",
-                host=host,
-                port=int(getenv("PROXMOX_PORT", "8006")),
-                user=getenv("PROXMOX_USER", "root"),
-                user_realm=getenv("PROXMOX_REALM", "pam"),
-                password=getenv("PROXMOX_PASSWORD", "password"),
-                node=getenv("PROXMOX_NODE", "proxmox"),
-                verify_tls=getenv("PROXMOX_VERIFY_TLS", "1") == "1",
-            ),
-        )
+    if getenv("PROXMOX_HOST"):
+        return (_load_single_instance_from_env(),)
 
     # No configuration found - return empty tuple
     return ()

--- a/tests/proxmoxsandboxtest/conftest.py
+++ b/tests/proxmoxsandboxtest/conftest.py
@@ -22,7 +22,12 @@ from proxmoxsandbox._proxmox_sandbox_environment import (
     ProxmoxSandboxEnvironment,
     ProxmoxSandboxEnvironmentConfig,
 )
-from proxmoxsandbox.schema import VmConfig, VmSourceConfig
+from proxmoxsandbox.schema import (
+    ProxmoxInstanceConfig,
+    VmConfig,
+    VmSourceConfig,
+    _load_single_instance_from_env,
+)
 
 # Set PROXMOX_WINDOWS_TEMPLATE_TAG to run tests against a Windows VM.
 # The value should match the tag on an existing Proxmox VM template.
@@ -37,29 +42,30 @@ async def sandbox_env_config() -> ProxmoxSandboxEnvironmentConfig:
 
 
 @pytest.fixture
+async def instance_config() -> ProxmoxInstanceConfig:
+    return _load_single_instance_from_env()
+
+
+@pytest.fixture
 async def async_proxmox_api(
-    sandbox_env_config: ProxmoxSandboxEnvironmentConfig,
+    instance_config: ProxmoxInstanceConfig,
 ) -> AsyncGenerator[AsyncProxmoxAPI, None]:
-    yield AsyncProxmoxAPI(
-        host=f"{sandbox_env_config.host}:{sandbox_env_config.port}",
-        user=f"{sandbox_env_config.user}@{sandbox_env_config.user_realm}",
-        password=sandbox_env_config.password.get_secret_value(),
-        verify_tls=sandbox_env_config.verify_tls,
-    )
+    yield AsyncProxmoxAPI.from_instance_config(instance_config)
 
 
 @pytest.fixture
 async def infra_commands(
     async_proxmox_api: AsyncProxmoxAPI,
     sandbox_env_config: ProxmoxSandboxEnvironmentConfig,
+    instance_config: ProxmoxInstanceConfig,
 ) -> InfraCommands:
     target = ProxmoxTarget(
-        host=sandbox_env_config.host,
-        port=sandbox_env_config.port,
-        node=sandbox_env_config.node,
+        host=instance_config.host,
+        port=instance_config.port,
+        node=instance_config.node,
     )
     instance = InfraCommands.build(
-        async_proxmox_api, sandbox_env_config.node, sandbox_env_config.image_storage
+        async_proxmox_api, instance_config.node, sandbox_env_config.image_storage
     )
     InfraCommands.set_instance(target, instance)
     return instance
@@ -73,12 +79,10 @@ async def sdn_commands(infra_commands: InfraCommands) -> SdnCommands:
 @pytest.fixture
 async def storage_commands(
     async_proxmox_api: AsyncProxmoxAPI,
-    sandbox_env_config: ProxmoxSandboxEnvironmentConfig,
+    instance_config: ProxmoxInstanceConfig,
 ) -> LocalStorageCommands:
     task_wrapper = TaskWrapper(async_proxmox_api)
-    return LocalStorageCommands(
-        async_proxmox_api, sandbox_env_config.node, task_wrapper
-    )
+    return LocalStorageCommands(async_proxmox_api, instance_config.node, task_wrapper)
 
 
 @pytest.fixture

--- a/tests/proxmoxsandboxtest/test_cli_cleanup.py
+++ b/tests/proxmoxsandboxtest/test_cli_cleanup.py
@@ -9,6 +9,7 @@ import pytest
 
 from proxmoxsandbox._impl.infra_commands import InfraCommands
 from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
+from proxmoxsandbox.schema import ProxmoxInstanceConfig
 
 
 @pytest.fixture(autouse=True)
@@ -91,29 +92,50 @@ async def test_cli_cleanup_all_instances(multi_instance_config_file):
         ):
             await ProxmoxSandboxEnvironment.cli_cleanup(id=None)
 
-            mock_proxmox_api.assert_has_calls(
+            mock_proxmox_api.from_instance_config.assert_has_calls(
                 [
                     call(
-                        host="10.0.1.10:8006",
-                        user="root@pam",
-                        password="test",
-                        verify_tls=False,
+                        ProxmoxInstanceConfig(
+                            instance_id="server-1",
+                            pool_id="pool-a",
+                            host="10.0.1.10",
+                            port=8006,
+                            user="root",
+                            user_realm="pam",
+                            password="test",
+                            node="pve1",
+                            verify_tls=False,
+                        )
                     ),
                     call(
-                        host="10.0.1.11:8006",
-                        user="root@pam",
-                        password="test",
-                        verify_tls=False,
+                        ProxmoxInstanceConfig(
+                            instance_id="server-2",
+                            pool_id="pool-a",
+                            host="10.0.1.11",
+                            port=8006,
+                            user="root",
+                            user_realm="pam",
+                            password="test",
+                            node="pve2",
+                            verify_tls=False,
+                        )
                     ),
                     call(
-                        host="10.0.1.20:8006",
-                        user="root@pam",
-                        password="test",
-                        verify_tls=False,
+                        ProxmoxInstanceConfig(
+                            instance_id="server-3",
+                            pool_id="pool-b",
+                            host="10.0.1.20",
+                            port=8006,
+                            user="root",
+                            user_realm="pam",
+                            password="test",
+                            node="pve3",
+                            verify_tls=False,
+                        )
                     ),
                 ]
             )
-            assert mock_proxmox_api.call_count == 3
+            assert mock_proxmox_api.from_instance_config.call_count == 3
 
             # Verify InfraCommands.build was called for each instance
             assert len(mock_infra_instances) == 3

--- a/tests/proxmoxsandboxtest/test_credential_redaction.py
+++ b/tests/proxmoxsandboxtest/test_credential_redaction.py
@@ -7,13 +7,11 @@ import pytest
 from pydantic import SecretStr, ValidationError
 
 from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI
-from proxmoxsandbox._impl.infra_commands import InfraCommands
 from proxmoxsandbox._proxmox_sandbox_environment import (
     ProxmoxSandboxEnvironment,
 )
 from proxmoxsandbox.schema import (
     ProxmoxInstanceConfig,
-    ProxmoxSandboxEnvironmentConfig,
 )
 
 PASSWORD_SENTINEL = "audit-password-sentinel-do-not-log"
@@ -102,26 +100,3 @@ async def test_cleanup_failure_log_excludes_instance_password(caplog):
     assert "host=127.0.0.1" in messages
     assert "port=8006" in messages
     assert "node=proxmox" in messages
-
-
-@pytest.mark.asyncio
-async def test_task_cleanup_debug_log_uses_safe_field_list(caplog):
-    """Debug logging includes useful context from an explicit safe field list."""
-    config = ProxmoxSandboxEnvironmentConfig(instance_pool_id="audit-pool")
-
-    with (
-        patch.object(InfraCommands, "_instances", {}),
-        caplog.at_level(logging.DEBUG, logger=ProxmoxSandboxEnvironment.logger.name),
-    ):
-        await ProxmoxSandboxEnvironment.task_cleanup(
-            task_name="audit",
-            config=config,
-            cleanup=True,
-        )
-
-    messages = "\n".join(record.getMessage() for record in caplog.records)
-    assert "config=ProxmoxSandboxEnvironmentConfig" not in messages
-    assert "vms_config=" not in messages
-    assert "sdn_config=" not in messages
-    assert "config_type=ProxmoxSandboxEnvironmentConfig" in messages
-    assert "instance_pool_id=audit-pool" in messages

--- a/tests/proxmoxsandboxtest/test_credential_redaction.py
+++ b/tests/proxmoxsandboxtest/test_credential_redaction.py
@@ -35,17 +35,13 @@ def _instance_config() -> ProxmoxInstanceConfig:
 
 def test_passwords_are_redacted_in_config_representations():
     """Config repr, str, and JSON serialization must not contain passwords."""
-    configs = (
-        _instance_config(),
-        ProxmoxSandboxEnvironmentConfig(password=PASSWORD_SENTINEL),
-    )
+    config = _instance_config()
 
-    for config in configs:
-        assert isinstance(config.password, SecretStr)
-        assert config.password.get_secret_value() == PASSWORD_SENTINEL
-        assert PASSWORD_SENTINEL not in repr(config)
-        assert PASSWORD_SENTINEL not in str(config)
-        assert PASSWORD_SENTINEL not in config.model_dump_json()
+    assert isinstance(config.password, SecretStr)
+    assert config.password.get_secret_value() == PASSWORD_SENTINEL
+    assert PASSWORD_SENTINEL not in repr(config)
+    assert PASSWORD_SENTINEL not in str(config)
+    assert PASSWORD_SENTINEL not in config.model_dump_json()
 
 
 def test_validation_error_messages_hide_raw_instance_config():
@@ -109,15 +105,9 @@ async def test_cleanup_failure_log_excludes_instance_password(caplog):
 
 
 @pytest.mark.asyncio
-async def test_task_cleanup_debug_log_excludes_config_password(caplog):
+async def test_task_cleanup_debug_log_uses_safe_field_list(caplog):
     """Debug logging includes useful context from an explicit safe field list."""
-    config = ProxmoxSandboxEnvironmentConfig(
-        instance_pool_id="audit-pool",
-        host="127.0.0.1",
-        port=8006,
-        password=PASSWORD_SENTINEL,
-        node="proxmox",
-    )
+    config = ProxmoxSandboxEnvironmentConfig(instance_pool_id="audit-pool")
 
     with (
         patch.object(InfraCommands, "_instances", {}),
@@ -130,13 +120,8 @@ async def test_task_cleanup_debug_log_excludes_config_password(caplog):
         )
 
     messages = "\n".join(record.getMessage() for record in caplog.records)
-    assert PASSWORD_SENTINEL not in messages
-    assert "password=" not in messages
     assert "config=ProxmoxSandboxEnvironmentConfig" not in messages
     assert "vms_config=" not in messages
     assert "sdn_config=" not in messages
     assert "config_type=ProxmoxSandboxEnvironmentConfig" in messages
     assert "instance_pool_id=audit-pool" in messages
-    assert "host=127.0.0.1" in messages
-    assert "port=8006" in messages
-    assert "node=proxmox" in messages

--- a/tests/proxmoxsandboxtest/test_credential_redaction.py
+++ b/tests/proxmoxsandboxtest/test_credential_redaction.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import SecretStr, ValidationError
 
+from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI
 from proxmoxsandbox._impl.infra_commands import InfraCommands
 from proxmoxsandbox._proxmox_sandbox_environment import (
     ProxmoxSandboxEnvironment,
@@ -60,9 +61,7 @@ def test_validation_error_messages_hide_raw_instance_config():
 
 def test_password_is_unwrapped_only_for_api_authentication():
     """The API client still receives the configured plaintext credential."""
-    config = ProxmoxSandboxEnvironmentConfig(password=PASSWORD_SENTINEL)
-
-    api = ProxmoxSandboxEnvironment._create_async_proxmox_api(config)
+    api = AsyncProxmoxAPI.from_instance_config(_instance_config())
 
     assert api.password == PASSWORD_SENTINEL
 

--- a/tests/proxmoxsandboxtest/test_host_attribution.py
+++ b/tests/proxmoxsandboxtest/test_host_attribution.py
@@ -1,11 +1,7 @@
 """Tests that each sample logs the pool instance it actually ran on.
 
-The frozen ProxmoxSandboxEnvironmentConfig defaults host/port/node from
-process env vars, and that config is what Inspect serialises into each
-sample's `sandbox` field — so with a pool, every sample would be attributed
-to the single PROXMOX_HOST env default regardless of which instance it
-acquired. sample_init now logs the acquired instance at INFO level so a
-sample can be attributed to the Proxmox server it ran on.
+sample_init logs the acquired instance at INFO level so a sample can be
+attributed to the Proxmox server it ran on.
 """
 
 import asyncio
@@ -94,8 +90,7 @@ def mock_infra_commands():
 def cleanup_state():
     """Isolate pool/infra class state and the sentinel env vars per test."""
     saved = {
-        var: os.environ.get(var)
-        for var in ("PROXMOX_HOST", "PROXMOX_NODE", "PROXMOX_CONFIG_FILE")
+        var: os.environ.get(var) for var in ("PROXMOX_HOST", "PROXMOX_CONFIG_FILE")
     }
     ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
     yield
@@ -126,47 +121,6 @@ def _instance(instance_id: str, host: str, node: str) -> dict:
         "node": node,
         "verify_tls": False,
     }
-
-
-@pytest.mark.asyncio
-async def test_sample_logs_acquired_instance_not_env_default(
-    mock_proxmox_api, mock_infra_commands, caplog
-):
-    """The log must name the acquired pool instance, not the env default."""
-    config_file = _config_file([_instance("pool-inst-1", "10.0.1.10", "pve1")])
-    os.environ["PROXMOX_CONFIG_FILE"] = config_file
-    os.environ["PROXMOX_HOST"] = ENV_SENTINEL_HOST
-    os.environ["PROXMOX_NODE"] = "env-default-sentinel"
-    try:
-        await ProxmoxSandboxEnvironment.task_init("test_task", None)
-        config = ProxmoxSandboxEnvironmentConfig()
-
-        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
-            environments = await ProxmoxSandboxEnvironment.sample_init(
-                "test_task", config, {}
-            )
-
-        # The trap: the frozen config field is the env default. Do not use it
-        # for host attribution.
-        assert config.host == ENV_SENTINEL_HOST
-        assert config.node == "env-default-sentinel"
-
-        # The fix: the log records the instance actually acquired.
-        acquired = [r for r in caplog.records if "Acquired instance" in r.message]
-        assert len(acquired) == 1
-        message = acquired[0].message
-        assert "pool-inst-1" in message
-        assert "host=10.0.1.10" in message
-        assert "port=8006" in message
-        assert "node=pve1" in message
-        assert ENV_SENTINEL_HOST not in message
-        assert "env-default-sentinel" not in message
-
-        await ProxmoxSandboxEnvironment.sample_cleanup(
-            "test_task", config, environments, False
-        )
-    finally:
-        os.unlink(config_file)
 
 
 @pytest.mark.asyncio

--- a/tests/proxmoxsandboxtest/test_multi_instance_pools.py
+++ b/tests/proxmoxsandboxtest/test_multi_instance_pools.py
@@ -10,7 +10,10 @@ import pytest
 
 from proxmoxsandbox._impl.infra_commands import InfraCommands
 from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
-from proxmoxsandbox.schema import ProxmoxSandboxEnvironmentConfig
+from proxmoxsandbox.schema import (
+    ProxmoxInstanceConfig,
+    ProxmoxSandboxEnvironmentConfig,
+)
 
 
 def _make_mock_infra():
@@ -144,11 +147,18 @@ async def test_single_instance_single_sample(
             "test_task", config, {}
         )
 
-        mock_proxmox_api.assert_called_once_with(
-            host="10.0.1.10:8006",
-            user="root@pam",
-            password="test",
-            verify_tls=False,
+        mock_proxmox_api.from_instance_config.assert_called_once_with(
+            ProxmoxInstanceConfig(
+                instance_id="test-1",
+                pool_id="default",
+                host="10.0.1.10",
+                port=8006,
+                user="root",
+                user_realm="pam",
+                password="test",
+                node="pve1",
+                verify_tls=False,
+            )
         )
 
         # Verify: Environment created, instance acquired from pool


### PR DESCRIPTION
As you'll see in the changes, these aren't *entirely* unused, but the remaining uses were all misleading and/or easily replaced.

The config compatibility story is surprisingly good. We stop serialising the dropped fields. Because they all had defaults, old code keeps being able to read new serialisations. Because pydantic ignores unknown fields by default, new code continues to be able to read old serialisations (but ignores the values in the extra fields, so they won't roundtrip).

# Testing

Unit tests pass. I haven't yet had time to run either the `req_proxmox` tests nor run a real range against this and confirm that doesn't break either.