### PR TITLE
fix: don't retry fatal QGA file-read errors (e.g. "Is a directory")

### DIFF
--- a/src/proxmoxsandbox/_impl/agent_commands.py
+++ b/src/proxmoxsandbox/_impl/agent_commands.py
@@ -30,9 +30,9 @@ from proxmoxsandbox._impl.async_proxmox import (
 # exec-status read is single-shot (the agent discards a finished process's
 # output once read), so get_agent_exec_status falls back to the on-disk results
 # if a retry finds the PID gone.
-# Exception: a 500 for a missing file / gone PID is surfaced immediately (it
-# will not change on retry); callers turn those into empty content / a disk
-# fallback.
+# Exception: a 500 for a missing file, an unreadable file (e.g. "Is a
+# directory"), or a gone PID is surfaced immediately (it will not change on
+# retry); callers turn those into empty content / a disk fallback / an error.
 _QGA_MAX_RETRIES = 5
 _QGA_RETRY_BASE_DELAY = 2.0  # seconds; doubled each attempt, capped below
 _QGA_RETRY_MAX_DELAY = 20.0  # seconds
@@ -72,6 +72,10 @@ class AgentCommands:
             if status_code == 500 and (
                 "no such file" in str(exc).casefold()
                 or "failed to open file" in str(exc).casefold()
+                # Guest-side read errno (e.g. "Is a directory", "Permission
+                # denied"): won't change on retry. Transient large-read
+                # failures come back as 596/597, not 500.
+                or "failed to read file" in str(exc).casefold()
                 # exec-status for a finished+already-read PID; not transient.
                 # get_agent_exec_status converts this into a disk fallback.
                 or _is_pid_gone(exc)

--- a/tests/proxmoxsandboxtest/test_qga_retry.py
+++ b/tests/proxmoxsandboxtest/test_qga_retry.py
@@ -51,6 +51,7 @@ PERMANENT_ERRORS = [
         "Agent error: failed to open file "
         "'/tmp/x.returncode': No such file or directory",
     ),
+    _http_error(500, "Agent error: failed to read file: Is a directory"),
     _PID_GONE,  # surfaced immediately; get_agent_exec_status turns it into a disk read
 ]
 


### PR DESCRIPTION
**TL;DR** A fatal `500 ... failed to read file: Is a directory` from the QEMU guest agent was being retried 5× with exponential backoff (~30s) before surfacing — the classifier only excluded a small allowlist of non-transient 500s. Now any `500 ... failed to read file` is treated as fatal and surfaced immediately.

<details><summary>Why this is safe and complete</summary>

`_is_transient_qga_error` returned `True` for every 500 except a few known messages (`no such file`, `failed to open file`, pid-gone). `failed to read file: Is a directory` didn't match, so it retried to exhaustion — wasting ~30s and slowing the unit tests — before raising an error that was never going to change.

Transient large-read failures come back from Proxmox as `596/597 Broken pipe` (handled by the `status >= 500` path), so a `500 ... failed to read file: <errno>` is always a guest-side error that won't change on retry.

This only touches the retry-classification layer. The existing contract translation in `read_file` (`Is a directory → IsADirectoryError`) is unchanged — it just fires immediately now instead of after the retries.

Not adding a `Permission denied → PermissionError` translation: the QGA runs as root, so a guest file read/write never hits `Permission denied` (root bypasses DAC). That's why `test_read_file_not_allowed` / `test_write_*_without_permissions` are already `known_failures` in the self_check test rather than implemented — the path is unreachable here.
</details>
