### PR TITLE
Fix file read on < 9.2 (count param is not available)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Fix: reading a large or binary guest file / command output no longer crashes with HTTP 597 "Broken pipe".
+- Fix: guest file / command-output reads work again on Proxmox < 9.2.
+- Fix: reading a large or binary guest file / command output no longer crashes with HTTP 597 "Broken pipe" (on Proxmox >= 9.2).
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process (e.g. `pkill -f`); it returns a failed `ExecResult` (`128+signal`, or `137` when the signal is unavailable) instead of raising a misleading `TimeoutError`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ poetry add git+ssh://git@github.com/UKGovernmentBEIS/inspect_proxmox_sandbox.git
 
 This plugin assumes you already have one or more Proxmox instances set up, and that you have admin access to them.
 
+Proxmox 9 or later is required; 9.2 or later is recommended for improvements in read_file.
+
 Your Proxmox instance(s) must allow additional storage types in `local` from the default.
 You can run this on your Proxmox node to configure them:
 

--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -76,6 +76,16 @@ class AsyncProxmoxAPI:
             raise ValueError("Need to be logged in")
         return self.discovered_proxmox_version
 
+    def release_at_least(self, required_major: int, required_minor: int = 0) -> bool:
+        """True if the pve-manager release is >= the given major.minor."""
+        release_string = self.get_discovered_proxmox_version().release
+        # Parse version string (e.g., "9.2.1" or "9.0")
+        match = re.match(r"(\d+)\.(\d+)", release_string)
+        if not match:
+            raise ValueError(f"Could not parse Proxmox version: {release_string}")
+        major, minor = int(match.group(1)), int(match.group(2))
+        return (major, minor) >= (required_major, required_minor)
+
     async def request(
         self,
         method: str,
@@ -169,14 +179,19 @@ class AsyncProxmoxAPI:
     # one pass.
     _B64_SEGMENT = re.compile(rb"[A-Za-z0-9+/]+={0,2}")
 
+    _warned_legacy_file_read: bool = False
+
     async def read_file_capped(
         self, node: str, vm_id: int, filepath: str, count: int
     ) -> Tuple[bytes, bool]:
         """Read up to `count` bytes of a guest file; return (data, truncated).
 
-        Uses agent file-read decode=0 (base64), not the default decode=1:
-        decode=1 returns Latin-1-mangled UTF-8 that inflates binary ~2-6x, and
-        large responses then fail with an upstream "597 Broken pipe". API:
+        On PVE >= 9.2, uses agent file-read decode=0 (base64) with a bounded
+        `count`, not the default decode=1: decode=1 returns Latin-1-mangled UTF-8
+        that inflates binary ~2-6x, and large responses then fail with an upstream
+        "597 Broken pipe". The count/offset/decode options were added in
+        qemu-server 9.1.5 (shipped in PVE 9.2); older versions reject them, so we
+        fall back to a plain decode=1 read there (see _decode_legacy_file_read). API:
         https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/agent/file-read
         """
         path = f"/nodes/{node}/qemu/{vm_id}/agent/file-read"
@@ -184,7 +199,10 @@ class AsyncProxmoxAPI:
             verify=self.verify_tls,
             timeout=httpx.Timeout(connect=15, read=60, write=60, pool=60),
         ) as client:
+            # ping first: it logs in if needed, so the version is discovered
+            # before we decide which file-read variant to use.
             await self._ping_qemu_agent(node, vm_id)
+            modern = self.release_at_least(9, 2)
             response = await client.get(
                 f"{self.api_base_url}{path}",
                 headers={
@@ -194,7 +212,11 @@ class AsyncProxmoxAPI:
                     # upstream "597 Broken pipe".
                     "Accept-Encoding": "identity",
                 },
-                params={"file": filepath, "count": count, "decode": 0},
+                params=(
+                    {"file": filepath, "count": count, "decode": 0}
+                    if modern
+                    else {"file": filepath}
+                ),
             )
             if response.is_error:
                 # Mirror request()'s error so callers can still match the agent's
@@ -210,11 +232,36 @@ class AsyncProxmoxAPI:
                 )
             data = response.json()["data"]
         content: str = data.get("content") or ""
+        if not modern:
+            return self._decode_legacy_file_read(content, data, count)
         raw = b"".join(
             base64.b64decode(seg)
             for seg in self._B64_SEGMENT.findall(content.encode("ascii"))
         )
         return raw, bool(data.get("truncated"))
+
+    def _decode_legacy_file_read(
+        self, content: str, data: dict, count: int
+    ) -> Tuple[bytes, bool]:
+        """decode=1 fallback for PVE < 9.2 (no count/decode params).
+
+        Under decode=1 each raw file byte arrives as a Latin-1 codepoint serialised
+        into UTF-8 JSON, so encoding back to iso-8859-1 recovers the bytes. PVE caps
+        the read at 16 MiB itself; we additionally honour `count` client-side.
+        """
+        if not self._warned_legacy_file_read:
+            self._warned_legacy_file_read = True
+            self.logger.warning(
+                "Proxmox %s is < 9.2: using the legacy guest file-read path. "
+                "Large or binary read_file/exec-output reads are less efficient "
+                "and may fail on very large files; the decode fix from "
+                "qemu-server 9.1.5 is unavailable. Upgrade to PVE >= 9.2 for the "
+                "full fix.",
+                self.get_discovered_proxmox_version().release,
+            )
+        raw = content.encode("iso-8859-1")
+        truncated = bool(data.get("truncated")) or len(raw) > count
+        return raw[:count], truncated
 
     async def upload_file_with_curl(
         self,

--- a/src/proxmoxsandbox/_impl/built_in_vm.py
+++ b/src/proxmoxsandbox/_impl/built_in_vm.py
@@ -1,6 +1,5 @@
 import abc
 import os
-import re
 import subprocess
 import tempfile
 from io import BytesIO
@@ -90,19 +89,8 @@ class BuiltInVM(abc.ABC):
         Raises:
             ValueError: If the Proxmox version is below the required version
         """
-        release_string = self.async_proxmox.get_discovered_proxmox_version().release
-
-        # Parse version string (e.g., "8.2.2" or "9.0")
-        match = re.match(r"(\d+)\.(\d+)", release_string)
-        if not match:
-            raise ValueError(f"Could not parse Proxmox version: {release_string}")
-
-        major = int(match.group(1))
-        minor = int(match.group(2))
-
-        if major < required_major or (
-            major == required_major and minor < required_minor
-        ):
+        if not self.async_proxmox.release_at_least(required_major, required_minor):
+            release_string = self.async_proxmox.get_discovered_proxmox_version().release
             raise ValueError(
                 f"Proxmox version {release_string} does not meet minimum requirement "
                 f"{required_major}.{required_minor}"

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -43,11 +43,9 @@ from proxmoxsandbox.schema import (
 # for derivation); 30 KiB leaves a little headroom for env/cwd/etc. overhead.
 _INLINE_STDIN_LIMIT = 30 * 1024
 
-# 40KB chunks to be safe, to take base64 encoding into account
-# note this 40KB limit was based on the Proxmox <=8.3 limit of
-# 60Kb, but this was increased in Proxmox 8.4, so could
-# potentially be increased here. Would need to check the
-# version number to ensure backward compatibility.
+# Chunk raw writes so the base64-encoded content stays under PVE's 61440-char
+# file-write `content` cap (see the exec-stdin note in exec()): 40 KiB raw is
+# ~54 KiB base64, comfortably under.
 _WRITE_CHUNK_SIZE = 40 * 1024
 
 _IN_GUEST_KILL_GRACE = 5

--- a/tests/proxmoxsandboxtest/test_version_guard.py
+++ b/tests/proxmoxsandboxtest/test_version_guard.py
@@ -1,0 +1,59 @@
+"""Unit tests for the PVE version guard on guest file-read.
+
+These don't need a live Proxmox: they exercise version parsing and the
+decode=1 legacy fallback decoding directly.
+"""
+
+import pytest
+
+from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI, ProxmoxVersionInfo
+
+
+def _api(release: str) -> AsyncProxmoxAPI:
+    api = AsyncProxmoxAPI("localhost:8006", "root@pam", "secret", verify_tls=False)
+    api.discovered_proxmox_version = ProxmoxVersionInfo(
+        release=release, repoid="deadbeef", version=release
+    )
+    return api
+
+
+@pytest.mark.parametrize(
+    "release, expected",
+    [
+        ("9.2.0", True),
+        ("9.2", True),
+        ("10.0.1", True),
+        ("9.2.1.aisi1", True),
+        # qemu-server 9.1.5 has the feature, but we gate on the pve-manager release
+        ("9.1.5", False),
+        ("9.1", False),
+        ("9.0", False),
+        ("8.4.1", False),
+    ],
+)
+def test_release_at_least_9_2(release: str, expected: bool) -> None:
+    assert _api(release).release_at_least(9, 2) is expected
+
+
+def test_decode_legacy_recovers_latin1_bytes() -> None:
+    # decode=1 returns each raw byte as a Latin-1 codepoint; "é" (0xE9) round-trips.
+    raw, truncated = _api("9.1.5")._decode_legacy_file_read(
+        content="café", data={"truncated": False}, count=1024
+    )
+    assert raw == "café".encode("utf-8")[:3] + b"\xe9"  # 'caf' + 0xe9
+    assert truncated is False
+
+
+def test_decode_legacy_honours_count_cap() -> None:
+    raw, truncated = _api("9.1.5")._decode_legacy_file_read(
+        content="abcdef", data={"truncated": False}, count=3
+    )
+    assert raw == b"abc"
+    assert truncated is True
+
+
+def test_decode_legacy_propagates_server_truncation() -> None:
+    _, truncated = _api("9.1.5")._decode_legacy_file_read(
+        content="abc", data={"truncated": True}, count=1024
+    )
+    assert truncated is True


### PR DESCRIPTION
Fix for

```
HTTPStatusError('HTTP response error: 400 Parameter
                             verification failed.: {"data":null,"message":"Parameter
                             verification failed.\\n","errors":{"decode":"property is not
                             defined in schema and the schema does not allow additional
                             properties","count":"property is not defined in schema and the
                             schema does not allow additional properties"}}')). Sample will
                             be retried.
```