### PR TITLE
bump _QGA_MAX_RETRIES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix: reading a large or binary guest file / command output no longer crashes with HTTP 597 "Broken pipe" (on Proxmox >= 9.2).
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process
+- Fix: "500 QEMU guest agent is not running" is retried for much longer (~45s -> 8m25s)
 
 ## 0.11.0 - 2026-06-01
 

--- a/src/proxmoxsandbox/_impl/agent_commands.py
+++ b/src/proxmoxsandbox/_impl/agent_commands.py
@@ -33,7 +33,7 @@ from proxmoxsandbox._impl.async_proxmox import (
 # Exception: a 500 for a missing file / gone PID is surfaced immediately (it
 # will not change on retry); callers turn those into empty content / a disk
 # fallback.
-_QGA_MAX_RETRIES = 5
+_QGA_MAX_RETRIES = 25
 _QGA_RETRY_BASE_DELAY = 2.0  # seconds; doubled each attempt, capped below
 _QGA_RETRY_MAX_DELAY = 20.0  # seconds
 


### PR DESCRIPTION
We've seen quite a bit of "500 QEMU guest agent is not running" failures. Crucially, sometimes these recover by themselves, sometimes they exhaust their retries and die. In the modern era of the typical sample taking hours to days, retrying for less than 60 seconds before giving up on the sample seems not tenacious enough to me.

Since each attempt waits for 3 seconds (as far as I know we don't control this) and the retry waits double from 2 up to a max of 20, 5 attempts is approximately 3 + 2 + 3 + 4 + 3 + 8 + 3 + 16 + 3 = 45 seconds, and 25 attempts is that plus 20 more attempts * (20 + 3) per attempt = 505 seconds, or 8m25s.

You can imagine doing more sophisticated things here as well, but let's get this out the door and see how it is in practice.

I have not tested this. It's very simple and testing it "properly" would mean deliberately inducing a failure, which might be annoying to do.