### PR TITLE
feat: add a network egress lockdown bootstrap script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
 - Opt logger into `INFO` level for consistency with Inspect core
 - Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
-- Optional marker-file-gated egress lockdown for sandbox guests, installed inert by the bundled provisioning scripts (no behaviour change unless `/etc/inspect-proxmox-egress-lockdown` is created); when active it drops guest traffic forwarded via all default-route interfaces, reasserts the rules every minute via a systemd timer, fails closed (blanket forward drop + Proxmox API halt on failure), and stops the SDN `dnsmasq` instances from recursing upstream — backstopped by a firewall rule dropping upstream `dnsmasq` traffic — closing the DNS-tunnel channel
+- Optional egress lockdown for sandbox guests (when using the bundled provisioning scripts): drops forwarded guest traffic and stops the SDN `dnsmasq` instances recursing upstream. Installed inert, so nothing changes until `/etc/inspect-proxmox-egress-lockdown` is created; see the README
 - Fix: guest file / command-output reads work again on Proxmox < 9.2.
 - Fix: reading a large or binary guest file / command output no longer crashes with HTTP 597 "Broken pipe" (on Proxmox >= 9.2).
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
 - Opt logger into `INFO` level for consistency with Inspect core
 - Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
-- Optional marker-file-gated egress lockdown for sandbox guests, installed inert by the bundled provisioning scripts (no behaviour change unless `/etc/inspect-proxmox-egress-lockdown` is created)
+- Optional marker-file-gated egress lockdown for sandbox guests, installed inert by the bundled provisioning scripts (no behaviour change unless `/etc/inspect-proxmox-egress-lockdown` is created); when active it drops forwarded guest traffic and stops the SDN `dnsmasq` instances from recursing upstream, closing the DNS-tunnel channel
 - Fix: guest file / command-output reads work again on Proxmox < 9.2.
 - Fix: reading a large or binary guest file / command output no longer crashes with HTTP 597 "Broken pipe" (on Proxmox >= 9.2).
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
 - Opt logger into `INFO` level for consistency with Inspect core
 - Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
+- Optional marker-file-gated egress lockdown for sandbox guests, installed inert by the bundled provisioning scripts (no behaviour change unless `/etc/inspect-proxmox-egress-lockdown` is created)
 - Fix: guest file / command-output reads work again on Proxmox < 9.2.
 - Fix: reading a large or binary guest file / command output no longer crashes with HTTP 597 "Broken pipe" (on Proxmox >= 9.2).
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
 - Opt logger into `INFO` level for consistency with Inspect core
 - Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
-- Optional marker-file-gated egress lockdown for sandbox guests, installed inert by the bundled provisioning scripts (no behaviour change unless `/etc/inspect-proxmox-egress-lockdown` is created); when active it drops forwarded guest traffic and stops the SDN `dnsmasq` instances from recursing upstream, closing the DNS-tunnel channel
+- Optional marker-file-gated egress lockdown for sandbox guests, installed inert by the bundled provisioning scripts (no behaviour change unless `/etc/inspect-proxmox-egress-lockdown` is created); when active it drops guest traffic forwarded via all default-route interfaces, reasserts the rules every minute via a systemd timer, fails closed (blanket forward drop + Proxmox API halt on failure), and stops the SDN `dnsmasq` instances from recursing upstream — backstopped by a firewall rule dropping upstream `dnsmasq` traffic — closing the DNS-tunnel channel
 - Fix: guest file / command-output reads work again on Proxmox < 9.2.
 - Fix: reading a large or binary guest file / command output no longer crashes with HTTP 597 "Broken pipe" (on Proxmox >= 9.2).
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,21 @@ export PROXMOX_WINDOWS_TEMPLATE_TAG=<your-tag>
 
 With this set, tests in `test_proxmox_sandbox_agent_commands.py` will run for both Linux and Windows.
 
+### Egress lockdown test
+
+`test_egress_lockdown_e2e.py` is skipped unless `PROXMOX_EGRESS_LOCKDOWN_ENABLED`
+is set, because it needs the host's egress lockdown active — and a locked-down
+host fails other integration tests that expect guests to have egress. To run it:
+
+```bash
+ssh root@<proxmox-host> 'touch /etc/inspect-proxmox-egress-lockdown && systemctl start inspect-proxmox-egress-lockdown.service'
+PROXMOX_EGRESS_LOCKDOWN_ENABLED=1 uv run pytest tests/proxmoxsandboxtest/test_egress_lockdown_e2e.py
+ssh root@<proxmox-host> 'rm /etc/inspect-proxmox-egress-lockdown && systemctl start inspect-proxmox-egress-lockdown.service'
+```
+
+Remember the last step: leaving the marker in place breaks the rest of the
+integration suite.
+
 ### Debug logging
 
 To see debug-level log output while running tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,13 @@ With this set, tests in `test_proxmox_sandbox_agent_commands.py` will run for bo
 
 `test_egress_lockdown_e2e.py` is skipped unless `PROXMOX_EGRESS_LOCKDOWN_ENABLED`
 is set, because it needs the host's egress lockdown active — and a locked-down
-host fails other integration tests that expect guests to have egress. To run it:
+host fails other integration tests that expect guests to have egress.
+
+The built-in VM template must already exist on the host before locking down:
+baking it boots the source image and installs packages (including
+`qemu-guest-agent`) from inside the guest, which needs guest egress. Any test
+that creates a default sandbox (e.g. `test_host_isolation_e2e.py`) bakes it on
+first use. Then:
 
 ```bash
 ssh root@<proxmox-host> 'touch /etc/inspect-proxmox-egress-lockdown && systemctl start inspect-proxmox-egress-lockdown.service'

--- a/README.md
+++ b/README.md
@@ -98,6 +98,47 @@ These work under either firewall backend (`pve-firewall` or the nftables
 `proxmox-firewall`); the latter won't touch these chains. On `iptables-legacy`
 hosts they won't show in `nft list ruleset` — use `iptables -t raw -S` / `-S FORWARD`.
 
+### Optional egress lockdown
+
+The provisioning scripts also install — but never activate — an egress lockdown
+for sandbox guests. When active, all traffic forwarded between guests and the
+host's default-route interface is dropped: total north–south isolation, not an
+internet-only filter. Unaffected: guest↔guest traffic across vnets (it never
+crosses the management NIC), DHCP and DNS service from the host (names still
+*resolve*, because the host forwards DNS queries upstream itself — connections
+to the resolved addresses then fail), and the host's own egress (package
+installs, cloud agents, SSH).
+
+The lockdown is gated on a marker file that provisioning never creates, so
+hosts are unrestricted by default. To restrict a running host:
+
+```bash
+touch /etc/inspect-proxmox-egress-lockdown
+systemctl restart inspect-proxmox-egress-lockdown.service
+```
+
+To open it up again:
+
+```bash
+rm /etc/inspect-proxmox-egress-lockdown
+systemctl restart inspect-proxmox-egress-lockdown.service
+```
+
+The drop rules live in the mangle table's `FORWARD` chain, which is evaluated
+before every filter-table rule, so activating the lockdown also cuts off guest
+connections that are already established (e.g. a download started beforehand)
+without a conntrack flush. Rules are comment-tagged
+`inspect-proxmox-egress-lockdown`, and each service run converges the rule set:
+rules that shouldn't exist (marker removed, or a stale interface name after
+moving to different hardware) are deleted. Neither firewall backend touches the
+mangle table, so there are no coexistence conflicts.
+
+The lockdown is IPv4-only — forwarded guest IPv6 is already dropped wholesale
+by the isolation rules above. It also only affects *routed* traffic: a guest
+NIC hand-bridged directly onto the management bridge travels at layer 2 and
+never traverses `FORWARD`. Everything this library provisions is routed, and
+therefore covered.
+
 ### Single Proxmox Instance
 
 Set the following environment variables (e.g. in a [`.env`](https://dotenvx.com/docs/env-file) file):

--- a/README.md
+++ b/README.md
@@ -100,16 +100,14 @@ hosts they won't show in `nft list ruleset` — use `iptables -t raw -S` / `-S F
 
 ### Optional egress lockdown
 
-The provisioning scripts also install — but never activate — an egress lockdown
+The provisioning scripts also install but don't activate an egress lockdown
 for sandbox guests. When active, all traffic forwarded between guests and the
-host's default-route interface is dropped: total north–south isolation, not an
-internet-only filter. Unaffected: guest↔guest traffic across vnets (it never
-crosses the management NIC), DHCP and DNS service from the host (names still
-*resolve*, because the host forwards DNS queries upstream itself — connections
-to the resolved addresses then fail), and the host's own egress (package
-installs, cloud agents, SSH).
+host's default-route interface is dropped. This serves to lock down most common
+attempts at network access from guest VMs. Some outbound network connections
+are still possible via `dnsmasq`, where the host proxies requests
+for DNS resolution.
 
-The lockdown is gated on a marker file that provisioning never creates, so
+The lockdown is gated on a marker file that provisioning doesn't create, so
 hosts are unrestricted by default. To restrict a running host:
 
 ```bash
@@ -126,18 +124,9 @@ systemctl restart inspect-proxmox-egress-lockdown.service
 
 The drop rules live in the mangle table's `FORWARD` chain, which is evaluated
 before every filter-table rule, so activating the lockdown also cuts off guest
-connections that are already established (e.g. a download started beforehand)
-without a conntrack flush. Rules are comment-tagged
-`inspect-proxmox-egress-lockdown`, and each service run converges the rule set:
-rules that shouldn't exist (marker removed, or a stale interface name after
-moving to different hardware) are deleted. Neither firewall backend touches the
+connections that are already established (e.g. a download started beforehand).
+Neither firewall backend touches the
 mangle table, so there are no coexistence conflicts.
-
-The lockdown is IPv4-only — forwarded guest IPv6 is already dropped wholesale
-by the isolation rules above. It also only affects *routed* traffic: a guest
-NIC hand-bridged directly onto the management bridge travels at layer 2 and
-never traverses `FORWARD`. Everything this library provisions is routed, and
-therefore covered.
 
 ### Single Proxmox Instance
 

--- a/README.md
+++ b/README.md
@@ -101,28 +101,47 @@ hosts they won't show in `nft list ruleset` — use `iptables -t raw -S` / `-S F
 ### Optional egress lockdown
 
 The provisioning scripts also install but don't activate an egress lockdown
-for sandbox guests. When active, all traffic forwarded between guests and the
-host's default-route interface is dropped, and the per-zone SDN `dnsmasq`
-instances are stopped from recursing to any upstream resolver. Together these
-close both direct egress and the DNS-resolution channel a guest could otherwise
-tunnel through (names no longer resolve beyond the internal vnets). Unaffected:
-guest↔guest traffic across vnets (it never crosses the management NIC) and the
-host's own egress and DNS (package installs, cloud agents, SSH).
+for sandbox guests. When active, all traffic forwarded between guests and
+every interface carrying a default route is dropped, and the per-zone SDN
+`dnsmasq` instances are stopped from recursing to any upstream resolver.
+Together these close both direct egress and the DNS-resolution channel a guest
+could otherwise tunnel through (names no longer resolve beyond the internal
+vnets). Unaffected: guest↔guest traffic across vnets (it never crosses the
+management NIC) and the host's own egress and DNS (package installs, cloud
+agents, SSH).
 
 The lockdown is gated on a marker file that provisioning doesn't create, so
 hosts are unrestricted by default. To restrict a running host:
 
 ```bash
 touch /etc/inspect-proxmox-egress-lockdown
-systemctl restart inspect-proxmox-egress-lockdown.service
+systemctl start inspect-proxmox-egress-lockdown.service
 ```
 
 To open it up again:
 
 ```bash
 rm /etc/inspect-proxmox-egress-lockdown
-systemctl restart inspect-proxmox-egress-lockdown.service
+systemctl start inspect-proxmox-egress-lockdown.service
 ```
+
+A systemd timer re-runs the lockdown every minute. Each run re-inserts the
+drop rules at the top of their chains and garbage-collects rules from earlier
+runs, so rules that another process removed or reordered (e.g. a firewall
+reload) are repaired within a minute, and removing the marker converges to a
+fully clean state without waiting for a reboot.
+
+The lockdown fails closed. If no default-route interface can be found, the
+script applies a blanket drop on all forwarded traffic — which also cuts
+guest↔guest traffic — and fails the unit. Any unit failure triggers a
+fail-deadly halt: `pveproxy` and `pvedaemon` are stopped and runtime-masked,
+taking the Proxmox API (and this library's ability to run samples on the host)
+down rather than risking guests with open egress. SSH is unaffected, so an
+operator can investigate with
+`journalctl -u inspect-proxmox-egress-lockdown.service` and recover with
+`systemctl unmask --runtime pveproxy.service pvedaemon.service && systemctl
+start pveproxy.service pvedaemon.service`; a reboot also clears the runtime
+mask.
 
 The drop rules live in the mangle table's `FORWARD` chain, which is evaluated
 before every filter-table rule, so activating the lockdown also cuts off guest
@@ -134,7 +153,16 @@ The DNS side works by blanking the upstream resolver file (`/run/dnsmasq/resolv.
 the SDN `dnsmasq` instances forward through and reloading them, so they keep
 answering internal names but refuse everything else. The previous upstream is
 backed up and restored when the marker is removed, so opening the host back up
-also restores guest DNS.
+also restores guest DNS. As a firewall backstop, host-originated `dnsmasq`
+traffic out of the default-route interfaces is also dropped, so upstream
+recursion stays blocked even if something rewrites the resolver file (it lives
+on tmpfs and is recreated at boot) before the timer re-blanks it.
+
+The lockdown is only a strong control for the SDN topology this library
+generates: it covers traffic forwarded between guest vnets and the host's
+default-route interfaces. Pre-existing bridges wired straight to other NICs,
+template VMs with extra network devices left attached, interfaces without a
+default route, and tunnels originating on the host itself are out of scope.
 
 ### Single Proxmox Instance
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ vnets). Unaffected: guest↔guest traffic across vnets (it never crosses the
 management NIC) and the host's own egress and DNS (package installs, cloud
 agents, SSH).
 
+Guests must not need egress to boot: the built-in VM template bake (first use
+of a `built_in` image on a host) installs packages from inside the guest, so
+it must happen before the lockdown is applied. Sandbox VMs cloned from an
+already-baked template boot fine.
+
 The lockdown is gated on a marker file that provisioning doesn't create, so
 hosts are unrestricted by default. To restrict a running host:
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,12 @@ hosts they won't show in `nft list ruleset` — use `iptables -t raw -S` / `-S F
 
 The provisioning scripts also install but don't activate an egress lockdown
 for sandbox guests. When active, all traffic forwarded between guests and the
-host's default-route interface is dropped. This serves to lock down most common
-attempts at network access from guest VMs. Some outbound network connections
-are still possible via `dnsmasq`, where the host proxies requests
-for DNS resolution.
+host's default-route interface is dropped, and the per-zone SDN `dnsmasq`
+instances are stopped from recursing to any upstream resolver. Together these
+close both direct egress and the DNS-resolution channel a guest could otherwise
+tunnel through (names no longer resolve beyond the internal vnets). Unaffected:
+guest↔guest traffic across vnets (it never crosses the management NIC) and the
+host's own egress and DNS (package installs, cloud agents, SSH).
 
 The lockdown is gated on a marker file that provisioning doesn't create, so
 hosts are unrestricted by default. To restrict a running host:
@@ -125,8 +127,14 @@ systemctl restart inspect-proxmox-egress-lockdown.service
 The drop rules live in the mangle table's `FORWARD` chain, which is evaluated
 before every filter-table rule, so activating the lockdown also cuts off guest
 connections that are already established (e.g. a download started beforehand).
-Neither firewall backend touches the
-mangle table, so there are no coexistence conflicts.
+Neither firewall backend touches the mangle table, so there are no coexistence
+conflicts.
+
+The DNS side works by blanking the upstream resolver file (`/run/dnsmasq/resolv.conf`)
+the SDN `dnsmasq` instances forward through and reloading them, so they keep
+answering internal names but refuse everything else. The previous upstream is
+backed up and restored when the marker is removed, so opening the host back up
+also restores guest DNS.
 
 ### Single Proxmox Instance
 

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -414,8 +414,7 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 BLOCK_METADATA_UNIT
 
-# NOTE: keep in sync with the on-first-boot heredoc in
-# scripts/virtualized_proxmox/build_proxmox_auto.sh.
+# NOTE: keep in sync with scripts/virtualized_proxmox/build_proxmox_auto.sh.
 cat > /usr/local/bin/inspect-proxmox-egress-lockdown.sh << 'EGRESS_LOCKDOWN'
 #!/bin/bash
 set -euo pipefail

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -422,7 +422,7 @@ set -euo pipefail
 
 MARKER=/etc/inspect-proxmox-egress-lockdown
 COMMENT=inspect-proxmox-egress-lockdown
-MGMT_NIC=$(ip route show default | awk '{print $5}' | head -1)
+RUN_ID="$$.$(date +%s)"
 
 RESOLV=/run/dnsmasq/resolv.conf
 RESOLV_BACKUP=/run/dnsmasq/resolv.conf.inspect-egress-backup
@@ -431,31 +431,42 @@ reload_dnsmasq() {
     pkill -HUP dnsmasq 2>/dev/null || true
 }
 
-if [ -f "$MARKER" ]; then
-    [ -z "$MGMT_NIC" ] && { echo "ERROR: could not determine management NIC from default route" >&2; exit 1; }
-    iptables -w -t mangle -C FORWARD -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
-        || iptables -w -t mangle -I FORWARD 1 -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
-    iptables -w -t mangle -C FORWARD -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
-        || iptables -w -t mangle -I FORWARD 1 -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
+gc_stale_rules() {
+    iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rule; do
+        case "$rule" in
+            *"$COMMENT $RUN_ID"*) continue ;;
+        esac
+        echo "${rule#-A }" | xargs iptables -w -t mangle -D || true
+    done
+}
 
+blank_resolv() {
     mkdir -p /run/dnsmasq
     if [ -f "$RESOLV" ] && [ ! -f "$RESOLV_BACKUP" ] && ! grep -q "$COMMENT" "$RESOLV"; then
         cp -a "$RESOLV" "$RESOLV_BACKUP"
     fi
     printf '# %s: upstream DNS recursion disabled while marker present\n' "$COMMENT" > "$RESOLV"
     reload_dnsmasq
-fi
+}
 
-iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rule; do
-    if [ -f "$MARKER" ]; then
-        case "$rule" in
-            *" -i $MGMT_NIC "*|*" -o $MGMT_NIC "*) continue ;;
-        esac
+if [ -f "$MARKER" ]; then
+    MGMT_NICS=$(ip route show default | awk '{for (i = 1; i < NF; i++) if ($i == "dev") print $(i + 1)}' | sort -u)
+    if [ -z "$MGMT_NICS" ]; then
+        iptables -w -t mangle -I FORWARD 1 -m comment --comment "$COMMENT $RUN_ID" -j DROP
+        gc_stale_rules
+        blank_resolv
+        echo "ERROR: no default-route NIC found; blanket FORWARD drop applied, failing unit" >&2
+        exit 1
     fi
-    echo "${rule#-A }" | xargs iptables -w -t mangle -D
-done
-
-if [ ! -f "$MARKER" ]; then
+    for NIC in $MGMT_NICS; do
+        iptables -w -t mangle -I FORWARD 1 -o "$NIC" -m comment --comment "$COMMENT $RUN_ID" -j DROP
+        iptables -w -t mangle -I FORWARD 1 -i "$NIC" -m comment --comment "$COMMENT $RUN_ID" -j DROP
+        iptables -w -t mangle -I OUTPUT 1 -o "$NIC" -m owner --uid-owner dnsmasq -m comment --comment "$COMMENT $RUN_ID" -j DROP
+    done
+    gc_stale_rules
+    blank_resolv
+else
+    gc_stale_rules
     if [ -f "$RESOLV_BACKUP" ]; then
         mv -f "$RESOLV_BACKUP" "$RESOLV"
         reload_dnsmasq
@@ -472,15 +483,37 @@ cat > /etc/systemd/system/inspect-proxmox-egress-lockdown.service << 'EGRESS_LOC
 Description=Optional egress lockdown for sandbox guests (gated on /etc/inspect-proxmox-egress-lockdown)
 After=network-online.target pve-firewall.service proxmox-firewall.service
 Wants=network-online.target
+OnFailure=inspect-proxmox-egress-lockdown-halt.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/inspect-proxmox-egress-lockdown.sh
-RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target
 EGRESS_LOCKDOWN_UNIT
+
+cat > /etc/systemd/system/inspect-proxmox-egress-lockdown.timer << 'EGRESS_LOCKDOWN_TIMER'
+[Unit]
+Description=Reassert egress lockdown every minute
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+AccuracySec=15s
+
+[Install]
+WantedBy=timers.target
+EGRESS_LOCKDOWN_TIMER
+
+cat > /etc/systemd/system/inspect-proxmox-egress-lockdown-halt.service << 'EGRESS_LOCKDOWN_HALT_UNIT'
+[Unit]
+Description=Stop the Proxmox API because egress lockdown failed (fail deadly)
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo "egress lockdown failed: stopping and masking pveproxy/pvedaemon; see journalctl -u inspect-proxmox-egress-lockdown.service" >&2; systemctl mask --runtime pveproxy.service pvedaemon.service; systemctl stop pveproxy.service pvedaemon.service'
+EGRESS_LOCKDOWN_HALT_UNIT
 
 # Host isolation. See root README.
 # Re-applied every boot (no marker): the node name changes per launch, so any
@@ -537,6 +570,7 @@ systemctl enable proxmox-ami-fixup-password.service
 systemctl enable proxmox-ami-fixup-firewall.service
 systemctl enable inspect-proxmox-block-cloud-metadata.service
 systemctl enable inspect-proxmox-egress-lockdown.service
+systemctl enable inspect-proxmox-egress-lockdown.timer
 
 # ===== CloudWatch OTLP metrics collector =====
 # Ship pvestatd's metrics to the CloudWatch OTLP endpoint via a localhost CloudWatch

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -424,12 +424,26 @@ MARKER=/etc/inspect-proxmox-egress-lockdown
 COMMENT=inspect-proxmox-egress-lockdown
 MGMT_NIC=$(ip route show default | awk '{print $5}' | head -1)
 
+RESOLV=/run/dnsmasq/resolv.conf
+RESOLV_BACKUP=/run/dnsmasq/resolv.conf.inspect-egress-backup
+
+reload_dnsmasq() {
+    pkill -HUP dnsmasq 2>/dev/null || true
+}
+
 if [ -f "$MARKER" ]; then
     [ -z "$MGMT_NIC" ] && { echo "ERROR: could not determine management NIC from default route" >&2; exit 1; }
     iptables -w -t mangle -C FORWARD -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
         || iptables -w -t mangle -I FORWARD 1 -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
     iptables -w -t mangle -C FORWARD -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
         || iptables -w -t mangle -I FORWARD 1 -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
+
+    mkdir -p /run/dnsmasq
+    if [ -f "$RESOLV" ] && [ ! -f "$RESOLV_BACKUP" ] && ! grep -q "$COMMENT" "$RESOLV"; then
+        cp -a "$RESOLV" "$RESOLV_BACKUP"
+    fi
+    printf '# %s: upstream DNS recursion disabled while marker present\n' "$COMMENT" > "$RESOLV"
+    reload_dnsmasq
 fi
 
 iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rule; do
@@ -440,6 +454,16 @@ iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rul
     fi
     echo "${rule#-A }" | xargs iptables -w -t mangle -D
 done
+
+if [ ! -f "$MARKER" ]; then
+    if [ -f "$RESOLV_BACKUP" ]; then
+        mv -f "$RESOLV_BACKUP" "$RESOLV"
+        reload_dnsmasq
+    elif [ -f "$RESOLV" ] && grep -q "$COMMENT" "$RESOLV"; then
+        rm -f "$RESOLV"
+        reload_dnsmasq
+    fi
+fi
 EGRESS_LOCKDOWN
 chmod +x /usr/local/bin/inspect-proxmox-egress-lockdown.sh
 

--- a/src/proxmoxsandbox/scripts/ec2/userdata.sh
+++ b/src/proxmoxsandbox/scripts/ec2/userdata.sh
@@ -414,6 +414,50 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 BLOCK_METADATA_UNIT
 
+# NOTE: keep in sync with the on-first-boot heredoc in
+# scripts/virtualized_proxmox/build_proxmox_auto.sh.
+cat > /usr/local/bin/inspect-proxmox-egress-lockdown.sh << 'EGRESS_LOCKDOWN'
+#!/bin/bash
+set -euo pipefail
+
+MARKER=/etc/inspect-proxmox-egress-lockdown
+COMMENT=inspect-proxmox-egress-lockdown
+MGMT_NIC=$(ip route show default | awk '{print $5}' | head -1)
+
+if [ -f "$MARKER" ]; then
+    [ -z "$MGMT_NIC" ] && { echo "ERROR: could not determine management NIC from default route" >&2; exit 1; }
+    iptables -w -t mangle -C FORWARD -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
+        || iptables -w -t mangle -I FORWARD 1 -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
+    iptables -w -t mangle -C FORWARD -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
+        || iptables -w -t mangle -I FORWARD 1 -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
+fi
+
+iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rule; do
+    if [ -f "$MARKER" ]; then
+        case "$rule" in
+            *" -i $MGMT_NIC "*|*" -o $MGMT_NIC "*) continue ;;
+        esac
+    fi
+    echo "${rule#-A }" | xargs iptables -w -t mangle -D
+done
+EGRESS_LOCKDOWN
+chmod +x /usr/local/bin/inspect-proxmox-egress-lockdown.sh
+
+cat > /etc/systemd/system/inspect-proxmox-egress-lockdown.service << 'EGRESS_LOCKDOWN_UNIT'
+[Unit]
+Description=Optional egress lockdown for sandbox guests (gated on /etc/inspect-proxmox-egress-lockdown)
+After=network-online.target pve-firewall.service proxmox-firewall.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/inspect-proxmox-egress-lockdown.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EGRESS_LOCKDOWN_UNIT
+
 # Host isolation. See root README.
 # Re-applied every boot (no marker): the node name changes per launch, so any
 # node-scoped rules baked into the AMI are orphaned under the old node name, and
@@ -468,6 +512,7 @@ systemctl enable proxmox-ami-fixup-nat.service
 systemctl enable proxmox-ami-fixup-password.service
 systemctl enable proxmox-ami-fixup-firewall.service
 systemctl enable inspect-proxmox-block-cloud-metadata.service
+systemctl enable inspect-proxmox-egress-lockdown.service
 
 # ===== CloudWatch OTLP metrics collector =====
 # Ship pvestatd's metrics to the CloudWatch OTLP endpoint via a localhost CloudWatch

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -306,8 +306,52 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 BLOCK_METADATA_UNIT
 
+# NOTE: keep in sync with scripts/ec2/userdata.sh.
+cat > /usr/local/bin/inspect-proxmox-egress-lockdown.sh << 'EGRESS_LOCKDOWN'
+#!/bin/bash
+set -euo pipefail
+
+MARKER=/etc/inspect-proxmox-egress-lockdown
+COMMENT=inspect-proxmox-egress-lockdown
+MGMT_NIC=$(ip route show default | awk '{print $5}' | head -1)
+
+if [ -f "$MARKER" ]; then
+    [ -z "$MGMT_NIC" ] && { echo "ERROR: could not determine management NIC from default route" >&2; exit 1; }
+    iptables -w -t mangle -C FORWARD -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
+        || iptables -w -t mangle -I FORWARD 1 -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
+    iptables -w -t mangle -C FORWARD -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
+        || iptables -w -t mangle -I FORWARD 1 -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
+fi
+
+iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rule; do
+    if [ -f "$MARKER" ]; then
+        case "$rule" in
+            *" -i $MGMT_NIC "*|*" -o $MGMT_NIC "*) continue ;;
+        esac
+    fi
+    echo "${rule#-A }" | xargs iptables -w -t mangle -D
+done
+EGRESS_LOCKDOWN
+chmod +x /usr/local/bin/inspect-proxmox-egress-lockdown.sh
+
+cat > /etc/systemd/system/inspect-proxmox-egress-lockdown.service << 'EGRESS_LOCKDOWN_UNIT'
+[Unit]
+Description=Optional egress lockdown for sandbox guests (gated on /etc/inspect-proxmox-egress-lockdown)
+After=network-online.target pve-firewall.service proxmox-firewall.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/inspect-proxmox-egress-lockdown.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EGRESS_LOCKDOWN_UNIT
+
 systemctl daemon-reload
 systemctl enable inspect-proxmox-block-cloud-metadata.service
+systemctl enable inspect-proxmox-egress-lockdown.service
 
 touch /var/local/inspect-proxmox-on-first-boot.done
 

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -313,7 +313,7 @@ set -euo pipefail
 
 MARKER=/etc/inspect-proxmox-egress-lockdown
 COMMENT=inspect-proxmox-egress-lockdown
-MGMT_NIC=$(ip route show default | awk '{print $5}' | head -1)
+RUN_ID="$$.$(date +%s)"
 
 RESOLV=/run/dnsmasq/resolv.conf
 RESOLV_BACKUP=/run/dnsmasq/resolv.conf.inspect-egress-backup
@@ -322,31 +322,42 @@ reload_dnsmasq() {
     pkill -HUP dnsmasq 2>/dev/null || true
 }
 
-if [ -f "$MARKER" ]; then
-    [ -z "$MGMT_NIC" ] && { echo "ERROR: could not determine management NIC from default route" >&2; exit 1; }
-    iptables -w -t mangle -C FORWARD -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
-        || iptables -w -t mangle -I FORWARD 1 -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
-    iptables -w -t mangle -C FORWARD -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
-        || iptables -w -t mangle -I FORWARD 1 -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
+gc_stale_rules() {
+    iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rule; do
+        case "$rule" in
+            *"$COMMENT $RUN_ID"*) continue ;;
+        esac
+        echo "${rule#-A }" | xargs iptables -w -t mangle -D || true
+    done
+}
 
+blank_resolv() {
     mkdir -p /run/dnsmasq
     if [ -f "$RESOLV" ] && [ ! -f "$RESOLV_BACKUP" ] && ! grep -q "$COMMENT" "$RESOLV"; then
         cp -a "$RESOLV" "$RESOLV_BACKUP"
     fi
     printf '# %s: upstream DNS recursion disabled while marker present\n' "$COMMENT" > "$RESOLV"
     reload_dnsmasq
-fi
+}
 
-iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rule; do
-    if [ -f "$MARKER" ]; then
-        case "$rule" in
-            *" -i $MGMT_NIC "*|*" -o $MGMT_NIC "*) continue ;;
-        esac
+if [ -f "$MARKER" ]; then
+    MGMT_NICS=$(ip route show default | awk '{for (i = 1; i < NF; i++) if ($i == "dev") print $(i + 1)}' | sort -u)
+    if [ -z "$MGMT_NICS" ]; then
+        iptables -w -t mangle -I FORWARD 1 -m comment --comment "$COMMENT $RUN_ID" -j DROP
+        gc_stale_rules
+        blank_resolv
+        echo "ERROR: no default-route NIC found; blanket FORWARD drop applied, failing unit" >&2
+        exit 1
     fi
-    echo "${rule#-A }" | xargs iptables -w -t mangle -D
-done
-
-if [ ! -f "$MARKER" ]; then
+    for NIC in $MGMT_NICS; do
+        iptables -w -t mangle -I FORWARD 1 -o "$NIC" -m comment --comment "$COMMENT $RUN_ID" -j DROP
+        iptables -w -t mangle -I FORWARD 1 -i "$NIC" -m comment --comment "$COMMENT $RUN_ID" -j DROP
+        iptables -w -t mangle -I OUTPUT 1 -o "$NIC" -m owner --uid-owner dnsmasq -m comment --comment "$COMMENT $RUN_ID" -j DROP
+    done
+    gc_stale_rules
+    blank_resolv
+else
+    gc_stale_rules
     if [ -f "$RESOLV_BACKUP" ]; then
         mv -f "$RESOLV_BACKUP" "$RESOLV"
         reload_dnsmasq
@@ -363,19 +374,42 @@ cat > /etc/systemd/system/inspect-proxmox-egress-lockdown.service << 'EGRESS_LOC
 Description=Optional egress lockdown for sandbox guests (gated on /etc/inspect-proxmox-egress-lockdown)
 After=network-online.target pve-firewall.service proxmox-firewall.service
 Wants=network-online.target
+OnFailure=inspect-proxmox-egress-lockdown-halt.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/inspect-proxmox-egress-lockdown.sh
-RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target
 EGRESS_LOCKDOWN_UNIT
 
+cat > /etc/systemd/system/inspect-proxmox-egress-lockdown.timer << 'EGRESS_LOCKDOWN_TIMER'
+[Unit]
+Description=Reassert egress lockdown every minute
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+AccuracySec=15s
+
+[Install]
+WantedBy=timers.target
+EGRESS_LOCKDOWN_TIMER
+
+cat > /etc/systemd/system/inspect-proxmox-egress-lockdown-halt.service << 'EGRESS_LOCKDOWN_HALT_UNIT'
+[Unit]
+Description=Stop the Proxmox API because egress lockdown failed (fail deadly)
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo "egress lockdown failed: stopping and masking pveproxy/pvedaemon; see journalctl -u inspect-proxmox-egress-lockdown.service" >&2; systemctl mask --runtime pveproxy.service pvedaemon.service; systemctl stop pveproxy.service pvedaemon.service'
+EGRESS_LOCKDOWN_HALT_UNIT
+
 systemctl daemon-reload
 systemctl enable inspect-proxmox-block-cloud-metadata.service
 systemctl enable inspect-proxmox-egress-lockdown.service
+systemctl enable inspect-proxmox-egress-lockdown.timer
 
 touch /var/local/inspect-proxmox-on-first-boot.done
 

--- a/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
+++ b/src/proxmoxsandbox/scripts/virtualized_proxmox/build_proxmox_auto.sh
@@ -315,12 +315,26 @@ MARKER=/etc/inspect-proxmox-egress-lockdown
 COMMENT=inspect-proxmox-egress-lockdown
 MGMT_NIC=$(ip route show default | awk '{print $5}' | head -1)
 
+RESOLV=/run/dnsmasq/resolv.conf
+RESOLV_BACKUP=/run/dnsmasq/resolv.conf.inspect-egress-backup
+
+reload_dnsmasq() {
+    pkill -HUP dnsmasq 2>/dev/null || true
+}
+
 if [ -f "$MARKER" ]; then
     [ -z "$MGMT_NIC" ] && { echo "ERROR: could not determine management NIC from default route" >&2; exit 1; }
     iptables -w -t mangle -C FORWARD -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
         || iptables -w -t mangle -I FORWARD 1 -o "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
     iptables -w -t mangle -C FORWARD -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP 2>/dev/null \
         || iptables -w -t mangle -I FORWARD 1 -i "$MGMT_NIC" -m comment --comment "$COMMENT" -j DROP
+
+    mkdir -p /run/dnsmasq
+    if [ -f "$RESOLV" ] && [ ! -f "$RESOLV_BACKUP" ] && ! grep -q "$COMMENT" "$RESOLV"; then
+        cp -a "$RESOLV" "$RESOLV_BACKUP"
+    fi
+    printf '# %s: upstream DNS recursion disabled while marker present\n' "$COMMENT" > "$RESOLV"
+    reload_dnsmasq
 fi
 
 iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rule; do
@@ -331,6 +345,16 @@ iptables-save -t mangle | { grep -F -- "$COMMENT" || true; } | while read -r rul
     fi
     echo "${rule#-A }" | xargs iptables -w -t mangle -D
 done
+
+if [ ! -f "$MARKER" ]; then
+    if [ -f "$RESOLV_BACKUP" ]; then
+        mv -f "$RESOLV_BACKUP" "$RESOLV"
+        reload_dnsmasq
+    elif [ -f "$RESOLV" ] && grep -q "$COMMENT" "$RESOLV"; then
+        rm -f "$RESOLV"
+        reload_dnsmasq
+    fi
+fi
 EGRESS_LOCKDOWN
 chmod +x /usr/local/bin/inspect-proxmox-egress-lockdown.sh
 

--- a/tests/proxmoxsandboxtest/test_egress_lockdown_e2e.py
+++ b/tests/proxmoxsandboxtest/test_egress_lockdown_e2e.py
@@ -1,0 +1,184 @@
+"""End-to-end check that the optional egress lockdown holds from inside a guest.
+
+Skipped unless `PROXMOX_EGRESS_LOCKDOWN_ENABLED` is set: it needs the host's
+lockdown marker in place and the service started, and a locked-down host fails
+the rest of the integration suite (which expects guests to have egress). See
+CONTRIBUTING.md for the setup and teardown sequence, including why the built-in
+VM template has to be baked before locking the host down.
+
+What lockdown does and does not take away, from the guest's point of view: the
+mangle FORWARD drops only see packets crossing a default-route NIC, so anything
+host-bound still works — the guest keeps its DHCP lease and can still query the
+SDN resolver. Blanking dnsmasq's resolv.conf plus the uid-owner OUTPUT drop
+removes that resolver's upstream, so it answers but cannot recurse.
+"""
+
+import os
+import re
+
+import pytest
+
+from proxmoxsandbox._proxmox_sandbox_environment import (
+    ProxmoxSandboxEnvironment,
+    ProxmoxSandboxEnvironmentConfig,
+)
+
+from .proxmox_sandbox_utils import setup_sandbox
+
+pytestmark = [
+    pytest.mark.req_proxmox,
+    pytest.mark.skipif(
+        os.getenv("PROXMOX_EGRESS_LOCKDOWN_ENABLED") is None,
+        reason=(
+            "requires a Proxmox host with egress lockdown active; see CONTRIBUTING.md"
+        ),
+    ),
+]
+
+EXTERNAL_IP = "1.1.1.1"
+EXTERNAL_NAME = "example.com"
+
+NOT_LOCKED_DOWN_HINT = (
+    "Is /etc/inspect-proxmox-egress-lockdown present, and was "
+    "inspect-proxmox-egress-lockdown.service started after creating it?"
+)
+
+DNS_PROBE_SCRIPT = """
+import socket
+import struct
+import sys
+
+server, name = sys.argv[1], sys.argv[2]
+
+question = b"".join(
+    bytes([len(label)]) + label.encode() for label in name.split(".")
+) + bytes(1)
+query = struct.pack("!HHHHHH", 0x2A2A, 0x0100, 1, 0, 0, 0) + question
+query += struct.pack("!HH", 1, 1)
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.settimeout(5)
+sock.sendto(query, (server, 53))
+try:
+    reply = sock.recv(4096)
+except socket.timeout:
+    print("NO_REPLY")
+    sys.exit(0)
+
+flags, _, answer_count = struct.unpack("!HHH", reply[2:8])
+print(f"rcode={flags & 0xF} answers={answer_count}")
+"""
+
+
+async def _dns_probe(
+    env: ProxmoxSandboxEnvironment, server: str, name: str
+) -> tuple[int, int] | None:
+    """Query `server` for `name` from inside the guest; None if nothing replied."""
+    result = await env.exec(
+        ["python3", "-c", DNS_PROBE_SCRIPT, server, name],
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"DNS probe did not run in the guest: {result.stderr!r}"
+    )
+
+    output = result.stdout.strip()
+    if output == "NO_REPLY":
+        return None
+
+    match = re.fullmatch(r"rcode=(\d+) answers=(\d+)", output)
+    assert match, f"unexpected DNS probe output: {output!r}"
+    return int(match.group(1)), int(match.group(2))
+
+
+async def test_locked_down_host_denies_guest_egress_but_keeps_sdn_services() -> None:
+    """A guest on a locked-down host has no egress, but DHCP and SDN DNS work."""
+    task_name = "test_egress_lockdown_e2e"
+    config = ProxmoxSandboxEnvironmentConfig()
+
+    _, envs_dict = await setup_sandbox(task_name, config)
+    try:
+        env = envs_dict["default"]
+        assert isinstance(env, ProxmoxSandboxEnvironment)
+
+        address_res = await env.exec(
+            ["sh", "-c", "ip -4 -o addr show scope global | awk '{print $4}'"],
+            timeout=10,
+        )
+        assert address_res.returncode == 0
+        assert address_res.stdout.split(), (
+            "sandbox VM has no global IPv4 address, so DHCP from the SDN "
+            "dnsmasq stopped working under lockdown"
+        )
+
+        gateway_res = await env.exec(
+            ["sh", "-c", "ip route show default | awk '{print $3}'"],
+            timeout=10,
+        )
+        assert gateway_res.returncode == 0
+        gateway = gateway_res.stdout.strip()
+        assert gateway, (
+            "no default gateway inside the sandbox VM, so its DHCP lease "
+            "carried no route under lockdown"
+        )
+
+        http_res = await env.exec(
+            [
+                "curl",
+                "--silent",
+                "--max-time",
+                "5",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                f"http://{EXTERNAL_IP}",
+            ],
+            timeout=15,
+        )
+        assert http_res.stdout.strip() == "000", (
+            f"external address {EXTERNAL_IP}:80 reachable from sandbox VM "
+            f"(curl returned http_code={http_res.stdout.strip()!r}). "
+            f"{NOT_LOCKED_DOWN_HINT}"
+        )
+
+        tcp_res = await env.exec(
+            [
+                "sh",
+                "-c",
+                f'timeout 5 bash -c "</dev/tcp/{EXTERNAL_IP}/443" '
+                "&& echo open || echo blocked",
+            ],
+            timeout=15,
+        )
+        assert tcp_res.stdout.strip() == "blocked", (
+            f"external address {EXTERNAL_IP}:443 reachable from sandbox VM: "
+            f"{tcp_res.stdout!r}. {NOT_LOCKED_DOWN_HINT}"
+        )
+
+        getent_res = await env.exec(["getent", "hosts", EXTERNAL_NAME], timeout=30)
+        assert getent_res.returncode != 0, (
+            f"{EXTERNAL_NAME} resolved from sandbox VM via the guest's normal "
+            f"resolver path: {getent_res.stdout!r}. {NOT_LOCKED_DOWN_HINT}"
+        )
+
+        external_probe = await _dns_probe(env, gateway, EXTERNAL_NAME)
+        assert external_probe is not None, (
+            f"SDN resolver on {gateway} stopped answering under lockdown; "
+            "guests should keep internal DNS because their queries are "
+            "host-bound rather than forwarded"
+        )
+        rcode, answer_count = external_probe
+        assert not (rcode == 0 and answer_count > 0), (
+            f"SDN resolver on {gateway} still recursed upstream for "
+            f"{EXTERNAL_NAME} (rcode={rcode}, answers={answer_count}). "
+            f"{NOT_LOCKED_DOWN_HINT}"
+        )
+
+    finally:
+        await ProxmoxSandboxEnvironment.sample_cleanup(
+            task_name=task_name,
+            config=config,
+            environments=envs_dict,
+            interrupted=False,
+        )

--- a/tests/proxmoxsandboxtest/test_egress_lockdown_e2e.py
+++ b/tests/proxmoxsandboxtest/test_egress_lockdown_e2e.py
@@ -1,16 +1,12 @@
 """End-to-end check that the optional egress lockdown holds from inside a guest.
 
-Skipped unless `PROXMOX_EGRESS_LOCKDOWN_ENABLED` is set: it needs the host's
-lockdown marker in place and the service started, and a locked-down host fails
-the rest of the integration suite (which expects guests to have egress). See
-CONTRIBUTING.md for the setup and teardown sequence, including why the built-in
-VM template has to be baked before locking the host down.
+Skipped unless `PROXMOX_EGRESS_LOCKDOWN_ENABLED` is set: it needs a host with
+the lockdown active, which fails the rest of the integration suite. See
+CONTRIBUTING.md for the setup and teardown sequence.
 
-What lockdown does and does not take away, from the guest's point of view: the
-mangle FORWARD drops only see packets crossing a default-route NIC, so anything
-host-bound still works — the guest keeps its DHCP lease and can still query the
-SDN resolver. Blanking dnsmasq's resolv.conf plus the uid-owner OUTPUT drop
-removes that resolver's upstream, so it answers but cannot recurse.
+Only forwarded traffic is dropped, so host-bound traffic — the guest's DHCP
+lease, queries to the SDN resolver — keeps working. That resolver loses its
+upstream, so it answers but cannot recurse.
 """
 
 import os
@@ -38,10 +34,7 @@ pytestmark = [
 EXTERNAL_IP = "1.1.1.1"
 EXTERNAL_NAME = "example.com"
 
-NOT_LOCKED_DOWN_HINT = (
-    "Is /etc/inspect-proxmox-egress-lockdown present, and was "
-    "inspect-proxmox-egress-lockdown.service started after creating it?"
-)
+NOT_LOCKED_DOWN_HINT = "Is the host actually locked down? See CONTRIBUTING.md."
 
 DNS_PROBE_SCRIPT = """
 import socket
@@ -73,7 +66,7 @@ print(f"rcode={flags & 0xF} answers={answer_count}")
 async def _dns_probe(
     env: ProxmoxSandboxEnvironment, server: str, name: str
 ) -> tuple[int, int] | None:
-    """Query `server` for `name` from inside the guest; None if nothing replied."""
+    """Query `server` for `name` from the guest; None if nothing replied."""
     result = await env.exec(
         ["python3", "-c", DNS_PROBE_SCRIPT, server, name],
         timeout=30,
@@ -106,10 +99,7 @@ async def test_locked_down_host_denies_guest_egress_but_keeps_sdn_services() -> 
             timeout=10,
         )
         assert address_res.returncode == 0
-        assert address_res.stdout.split(), (
-            "sandbox VM has no global IPv4 address, so DHCP from the SDN "
-            "dnsmasq stopped working under lockdown"
-        )
+        assert address_res.stdout.split(), "no global IPv4 address, so DHCP broke"
 
         gateway_res = await env.exec(
             ["sh", "-c", "ip route show default | awk '{print $3}'"],
@@ -117,10 +107,7 @@ async def test_locked_down_host_denies_guest_egress_but_keeps_sdn_services() -> 
         )
         assert gateway_res.returncode == 0
         gateway = gateway_res.stdout.strip()
-        assert gateway, (
-            "no default gateway inside the sandbox VM, so its DHCP lease "
-            "carried no route under lockdown"
-        )
+        assert gateway, "no default gateway, so the DHCP lease carried no route"
 
         http_res = await env.exec(
             [
@@ -137,9 +124,8 @@ async def test_locked_down_host_denies_guest_egress_but_keeps_sdn_services() -> 
             timeout=15,
         )
         assert http_res.stdout.strip() == "000", (
-            f"external address {EXTERNAL_IP}:80 reachable from sandbox VM "
-            f"(curl returned http_code={http_res.stdout.strip()!r}). "
-            f"{NOT_LOCKED_DOWN_HINT}"
+            f"{EXTERNAL_IP}:80 reachable "
+            f"(http_code={http_res.stdout.strip()!r}). {NOT_LOCKED_DOWN_HINT}"
         )
 
         tcp_res = await env.exec(
@@ -152,27 +138,22 @@ async def test_locked_down_host_denies_guest_egress_but_keeps_sdn_services() -> 
             timeout=15,
         )
         assert tcp_res.stdout.strip() == "blocked", (
-            f"external address {EXTERNAL_IP}:443 reachable from sandbox VM: "
-            f"{tcp_res.stdout!r}. {NOT_LOCKED_DOWN_HINT}"
+            f"{EXTERNAL_IP}:443 reachable. {NOT_LOCKED_DOWN_HINT}"
         )
 
         getent_res = await env.exec(["getent", "hosts", EXTERNAL_NAME], timeout=30)
         assert getent_res.returncode != 0, (
-            f"{EXTERNAL_NAME} resolved from sandbox VM via the guest's normal "
-            f"resolver path: {getent_res.stdout!r}. {NOT_LOCKED_DOWN_HINT}"
+            f"{EXTERNAL_NAME} resolved: {getent_res.stdout!r}. {NOT_LOCKED_DOWN_HINT}"
         )
 
         external_probe = await _dns_probe(env, gateway, EXTERNAL_NAME)
         assert external_probe is not None, (
-            f"SDN resolver on {gateway} stopped answering under lockdown; "
-            "guests should keep internal DNS because their queries are "
-            "host-bound rather than forwarded"
+            f"SDN resolver on {gateway} stopped answering guests entirely"
         )
         rcode, answer_count = external_probe
         assert not (rcode == 0 and answer_count > 0), (
-            f"SDN resolver on {gateway} still recursed upstream for "
-            f"{EXTERNAL_NAME} (rcode={rcode}, answers={answer_count}). "
-            f"{NOT_LOCKED_DOWN_HINT}"
+            f"SDN resolver on {gateway} recursed upstream for {EXTERNAL_NAME} "
+            f"(rcode={rcode}, answers={answer_count}). {NOT_LOCKED_DOWN_HINT}"
         )
 
     finally:

--- a/tests/proxmoxsandboxtest/test_provisioning_security.py
+++ b/tests/proxmoxsandboxtest/test_provisioning_security.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -51,3 +52,69 @@ def test_provisioners_contain_expected_iptables_rules(provisioner: Path) -> None
     # The single-cloud denylist is gone.
     assert "169.254.169.254/32" not in script
     assert "fd00:ec2::254" not in script
+
+
+def _extract_heredoc(script: str, delimiter: str) -> str:
+    match = re.search(
+        rf"<< '{delimiter}'\n(.*?\n){delimiter}\n", script, flags=re.DOTALL
+    )
+    assert match, f"heredoc {delimiter} not found"
+    return match.group(1)
+
+
+@pytest.mark.parametrize(
+    "delimiter",
+    [
+        "EGRESS_LOCKDOWN",
+        "EGRESS_LOCKDOWN_UNIT",
+        "EGRESS_LOCKDOWN_TIMER",
+        "EGRESS_LOCKDOWN_HALT_UNIT",
+    ],
+)
+def test_egress_lockdown_heredocs_identical(delimiter: str) -> None:
+    userdata = (EC2_SCRIPTS / "userdata.sh").read_text()
+    virtualized = VIRTUALIZED_SCRIPT.read_text()
+
+    assert _extract_heredoc(userdata, delimiter) == _extract_heredoc(
+        virtualized, delimiter
+    )
+
+
+@pytest.mark.parametrize(
+    "provisioner",
+    [
+        EC2_SCRIPTS / "userdata.sh",
+        VIRTUALIZED_SCRIPT,
+    ],
+)
+def test_provisioners_contain_egress_lockdown(provisioner: Path) -> None:
+    script = provisioner.read_text()
+
+    assert "cat > /usr/local/bin/inspect-proxmox-egress-lockdown.sh" in script
+    assert "ExecStart=/usr/local/bin/inspect-proxmox-egress-lockdown.sh" in script
+    assert "systemctl enable inspect-proxmox-egress-lockdown.service" in script
+    assert "systemctl enable inspect-proxmox-egress-lockdown.timer" in script
+    assert "OnFailure=inspect-proxmox-egress-lockdown-halt.service" in script
+    assert "systemctl mask --runtime pveproxy.service pvedaemon.service" in script
+    assert "systemctl stop pveproxy.service pvedaemon.service" in script
+    assert (
+        'iptables -w -t mangle -I FORWARD 1 -o "$NIC" '
+        '-m comment --comment "$COMMENT $RUN_ID" -j DROP'
+    ) in script
+    assert (
+        'iptables -w -t mangle -I FORWARD 1 -i "$NIC" '
+        '-m comment --comment "$COMMENT $RUN_ID" -j DROP'
+    ) in script
+    assert (
+        'iptables -w -t mangle -I OUTPUT 1 -o "$NIC" -m owner --uid-owner dnsmasq '
+        '-m comment --comment "$COMMENT $RUN_ID" -j DROP'
+    ) in script
+    assert (
+        "iptables -w -t mangle -I FORWARD 1 "
+        '-m comment --comment "$COMMENT $RUN_ID" -j DROP'
+    ) in script
+    assert "OnUnitActiveSec=1min" in script
+    lockdown = _extract_heredoc(script, "EGRESS_LOCKDOWN")
+    assert "could not determine management NIC" not in lockdown
+    assert "ERROR: no default-route NIC found" in lockdown
+    assert "RemainAfterExit" not in _extract_heredoc(script, "EGRESS_LOCKDOWN_UNIT")


### PR DESCRIPTION
## Description

Adds a new bootstrap script for preventing guest VM network access via requests forward by the host. This bootstrap script does not run by default, but can be configured to do so.

## Limitations

This approach does not prevent the host from making outbound network calls. Since the host runs a `dnsmasq` proxy, outbound traffic from the agent is technically still possible, via DNS resolution.