### PR TITLE
Don't wait for each VM to boot before creating the next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process
 - Fix: "500 QEMU guest agent is not running" is retried for much longer (~45s -> 8m25s)
-- Don't wait for a VM to reach "running" before starting the next one (just wait for all of them together at the end)
+- Don't wait for a VM to reach "running" before starting the next one (just wait for all of them together at the end). Set `await_before_next_vm=True` on a `VmConfig` if later VMs depend on it having booted first
 
 ## 0.11.0 - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Security: redact Proxmox passwords in configuration representations and validation error messages, and omit credentials from cleanup logs
 - Fix: `exec()` no longer aborts the sample when a command kills its own command-runner wrapper process
 - Fix: "500 QEMU guest agent is not running" is retried for much longer (~45s -> 8m25s)
+- Don't wait for a VM to reach "running" before starting the next one (just wait for all of them together at the end)
 
 ## 0.11.0 - 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ sandbox=SandboxEnvironmentSpec(
                 nic_controller="virtio", # optional, default will be VirtIO. Can also use "e1000" for older VM images.
                 cpu="host", # optional, default "host". The qemu CPU model (e.g. "host", "qemu64", "x86-64-v2"). Older guest kernels (notably FreeBSD/pfSense) can panic on nested virtualization with "host"; use "qemu64" for those.
                 firewall=True, # optional, default is False. Enables the Proxmox firewall on all NICs for VM isolation.
+                await_before_next_vm=False, # optional, default is False, i.e. all VMs boot concurrently. Set to True if the VMs listed after this one need it to have booted first (e.g. it is their router or DHCP server).
                 # If you have more than one VNet, assign the VM to the VNet via nics.
                 # You can assign more than one, to give the VM more than one network interface.
                 # If you leave this blank, your VM will be assigned to the first VNet.

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ sandbox=SandboxEnvironmentSpec(
                 nic_controller="virtio", # optional, default will be VirtIO. Can also use "e1000" for older VM images.
                 cpu="host", # optional, default "host". The qemu CPU model (e.g. "host", "qemu64", "x86-64-v2"). Older guest kernels (notably FreeBSD/pfSense) can panic on nested virtualization with "host"; use "qemu64" for those.
                 firewall=True, # optional, default is False. Enables the Proxmox firewall on all NICs for VM isolation.
-                await_before_next_vm=False, # optional, default is False, i.e. all VMs boot concurrently. Set to True if the VMs listed after this one need it to have booted first (e.g. it is their router or DHCP server).
+                await_before_next_vm=False, # optional, default is False, i.e. all VMs boot concurrently. Set to True if the VMs listed after this one need it to have booted first.
                 # If you have more than one VNet, assign the VM to the VNet via nics.
                 # You can assign more than one, to give the VM more than one network interface.
                 # If you leave this blank, your VM will be assigned to the first VNet.

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -166,7 +166,7 @@ class InfraCommands(abc.ABC):
                     sdn_vnet_aliases=vnet_aliases,
                     vm_config=vm_config,
                     built_in_vm_ids=known_builtins,
-                    wait_until_ready=False,
+                    wait_until_ready=vm_config.await_before_next_vm,
                 )
                 self.qemu_commands.register_vm(vm_id)
                 vm_configs_with_ids.append((vm_id, vm_config))

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -176,7 +176,7 @@ class InfraCommands(abc.ABC):
         for vm_id, vm_config in vm_configs_with_ids:
             self.logger.info(f"Waiting for VM {vm_config.name} (ID={vm_id})")
             await self.qemu_commands.await_vm(vm_id, vm_config.is_sandbox)
-            self.logger.info(f"VM {vm_config.name} is ready")
+            self.logger.info(f"VM {vm_config.name} (ID={vm_id}) is ready")
 
         return tuple(vm_configs_with_ids), sdn_zone_id, tuple(ipam_mappings)
 

--- a/src/proxmoxsandbox/_impl/infra_commands.py
+++ b/src/proxmoxsandbox/_impl/infra_commands.py
@@ -166,6 +166,7 @@ class InfraCommands(abc.ABC):
                     sdn_vnet_aliases=vnet_aliases,
                     vm_config=vm_config,
                     built_in_vm_ids=known_builtins,
+                    wait_until_ready=False,
                 )
                 self.qemu_commands.register_vm(vm_id)
                 vm_configs_with_ids.append((vm_id, vm_config))

--- a/src/proxmoxsandbox/_impl/qemu_commands.py
+++ b/src/proxmoxsandbox/_impl/qemu_commands.py
@@ -179,18 +179,24 @@ class QemuCommands(abc.ABC):
     async def find_next_available_vm_id(self) -> int:
         return await self.async_proxmox.request("GET", "/cluster/nextid")
 
-    async def start_and_await(
+    async def start(
         self,
         vm_id: int,
-        is_sandbox: bool,
     ) -> None:
-        async def start() -> None:
+        async def do_start() -> None:
             await self.async_proxmox.request(
                 "POST",
                 f"/nodes/{self.node}/qemu/{vm_id}/status/start",
             )
 
-        await self.task_wrapper.do_action_and_wait_for_tasks(start)
+        await self.task_wrapper.do_action_and_wait_for_tasks(do_start)
+
+    async def start_and_await(
+        self,
+        vm_id: int,
+        is_sandbox: bool,
+    ) -> None:
+        await self.start(vm_id=vm_id)
 
         await self.await_vm(
             vm_id=vm_id,
@@ -289,6 +295,7 @@ class QemuCommands(abc.ABC):
         sdn_vnet_aliases: VnetAliases,
         vm_config: VmConfig,
         built_in_vm_ids: Dict[str, int],
+        wait_until_ready: bool,
     ) -> int:
         if (
             vm_config.os_type != "l26"
@@ -421,6 +428,7 @@ class QemuCommands(abc.ABC):
             vm_id_to_clone=vm_id_to_clone,
             sdn_vnet_aliases=sdn_vnet_aliases,
             preserve_tags=preserve_tags,
+            wait_until_ready=wait_until_ready,
         )
 
         if new_vm_id is None:
@@ -545,6 +553,7 @@ class QemuCommands(abc.ABC):
         vm_id_to_clone: int,
         sdn_vnet_aliases: VnetAliases,
         preserve_tags: bool,
+        wait_until_ready: bool,
     ) -> int:
         new_vm_id = await self.find_next_available_vm_id()
 
@@ -579,7 +588,12 @@ class QemuCommands(abc.ABC):
 
         await self.task_wrapper.do_action_and_wait_for_tasks(other_updates)
 
-        await self.start_and_await(vm_id=new_vm_id, is_sandbox=vm_config.is_sandbox)
+        await self.start(vm_id=new_vm_id)
+        if wait_until_ready:
+            await self.await_vm(
+                vm_id=new_vm_id,
+                is_sandbox=vm_config.is_sandbox,
+            )
         return new_vm_id
 
     def other_config_json(

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -197,6 +197,10 @@ class VmConfig(BaseModel, frozen=True):
         cpu: The qemu CPU model (e.g. "host", "qemu64", "x86-64-v2"). If unset,
             defaults to "host". Older guest kernels (notably FreeBSD/pfSense) can
             panic on nested virtualization with "host"; use "qemu64" for those.
+        await_before_next_vm: if True, wait for this VM to finish booting (and, when
+            is_sandbox, to answer a guest-agent ping) before creating the next VM in
+            vms_config. Defaults to False, so VMs boot concurrently. Set this on a VM
+            that later ones depend on at boot time, e.g. a router or DHCP server.
 
     Note on nics configuration:
     - If set, the VM will be connected to these VNets (one interface per VNet)
@@ -220,6 +224,7 @@ class VmConfig(BaseModel, frozen=True):
     firewall: bool = False
     os_type: Optional[OsType] = "l26"
     cpu: Optional[str] = None
+    await_before_next_vm: bool = False
 
 
 class HttpHeader(BaseModel):

--- a/tests/proxmoxsandboxtest/test_qemu_commands.py
+++ b/tests/proxmoxsandboxtest/test_qemu_commands.py
@@ -37,7 +37,7 @@ async def test_simple_vm_non_sandbox(
             uefi_boot=False,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
-        wait_until_ready=True,
+        wait_until_ready=False,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -67,7 +67,7 @@ async def test_none_nic_from_template_tag(
             nics=None,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
-        wait_until_ready=True,
+        wait_until_ready=False,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -95,7 +95,7 @@ async def test_empty_nic_from_template_tag(
             nics=(),
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
-        wait_until_ready=True,
+        wait_until_ready=False,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -120,7 +120,7 @@ async def test_none_nic_from_built_in(
             nics=None,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
-        wait_until_ready=True,
+        wait_until_ready=False,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -160,7 +160,7 @@ async def test_existing_alias_from_built_in(
             ),
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
-        wait_until_ready=True,
+        wait_until_ready=False,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -201,7 +201,7 @@ async def test_multiple_nic(
             nics=(VmNicConfig(vnet_alias="vnetB"), VmNicConfig(vnet_alias="vnetA")),
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
-        wait_until_ready=True,
+        wait_until_ready=False,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -232,7 +232,7 @@ async def test_empty_nic_from_built_in(
             nics=(),
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
-        wait_until_ready=True,
+        wait_until_ready=False,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -260,7 +260,7 @@ async def test_disk_controller_match_from_built_in(
             is_sandbox=False,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
-        wait_until_ready=True,
+        wait_until_ready=False,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -287,7 +287,7 @@ async def test_disk_controller_mismatch_from_built_in_raises(
                 disk_controller="ide",
             ),
             built_in_vm_ids=await built_in_vm.known_builtins(),
-            wait_until_ready=True,
+            wait_until_ready=False,
         )
 
 
@@ -307,7 +307,7 @@ async def test_disk_controller_mismatch_from_template_tag_raises(
                 disk_controller="ide",
             ),
             built_in_vm_ids=await built_in_vm.known_builtins(),
-            wait_until_ready=True,
+            wait_until_ready=False,
         )
 
 
@@ -326,6 +326,8 @@ async def test_from_ova_local(qemu_commands: QemuCommands):
             is_sandbox=True,
         ),
         built_in_vm_ids={},
+        # ping_qemu_agent below is a single call with no retry, so the guest
+        # agent must already be up by the time this returns
         wait_until_ready=True,
     )
 
@@ -353,6 +355,8 @@ async def test_from_ova_uefi_sandbox(qemu_commands: QemuCommands):
             is_sandbox=True,
         ),
         built_in_vm_ids={},
+        # ping_qemu_agent below is a single call with no retry, so the guest
+        # agent must already be up by the time this returns
         wait_until_ready=True,
     )
 
@@ -378,6 +382,8 @@ async def test_uefi(
             uefi_boot=True,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        # ping_qemu_agent below is a single call with no retry, so the guest
+        # agent must already be up by the time this returns
         wait_until_ready=True,
     )
 

--- a/tests/proxmoxsandboxtest/test_qemu_commands.py
+++ b/tests/proxmoxsandboxtest/test_qemu_commands.py
@@ -37,6 +37,7 @@ async def test_simple_vm_non_sandbox(
             uefi_boot=False,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        wait_until_ready=True,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -66,6 +67,7 @@ async def test_none_nic_from_template_tag(
             nics=None,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        wait_until_ready=True,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -93,6 +95,7 @@ async def test_empty_nic_from_template_tag(
             nics=(),
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        wait_until_ready=True,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -117,6 +120,7 @@ async def test_none_nic_from_built_in(
             nics=None,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        wait_until_ready=True,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -156,6 +160,7 @@ async def test_existing_alias_from_built_in(
             ),
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        wait_until_ready=True,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -196,6 +201,7 @@ async def test_multiple_nic(
             nics=(VmNicConfig(vnet_alias="vnetB"), VmNicConfig(vnet_alias="vnetA")),
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        wait_until_ready=True,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -226,6 +232,7 @@ async def test_empty_nic_from_built_in(
             nics=(),
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        wait_until_ready=True,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -253,6 +260,7 @@ async def test_disk_controller_match_from_built_in(
             is_sandbox=False,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        wait_until_ready=True,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)
@@ -279,6 +287,7 @@ async def test_disk_controller_mismatch_from_built_in_raises(
                 disk_controller="ide",
             ),
             built_in_vm_ids=await built_in_vm.known_builtins(),
+            wait_until_ready=True,
         )
 
 
@@ -298,6 +307,7 @@ async def test_disk_controller_mismatch_from_template_tag_raises(
                 disk_controller="ide",
             ),
             built_in_vm_ids=await built_in_vm.known_builtins(),
+            wait_until_ready=True,
         )
 
 
@@ -316,6 +326,7 @@ async def test_from_ova_local(qemu_commands: QemuCommands):
             is_sandbox=True,
         ),
         built_in_vm_ids={},
+        wait_until_ready=True,
     )
 
     await qemu_commands.ping_qemu_agent(new_vm_id)
@@ -342,6 +353,7 @@ async def test_from_ova_uefi_sandbox(qemu_commands: QemuCommands):
             is_sandbox=True,
         ),
         built_in_vm_ids={},
+        wait_until_ready=True,
     )
 
     await qemu_commands.ping_qemu_agent(new_vm_id)
@@ -366,6 +378,7 @@ async def test_uefi(
             uefi_boot=True,
         ),
         built_in_vm_ids=await built_in_vm.known_builtins(),
+        wait_until_ready=True,
     )
 
     new_vm = await qemu_commands.read_vm(new_vm_id)


### PR DESCRIPTION
create_sdn_and_vms already awaits every VM once they have all been created, so awaiting inside clone_vm_and_start as well just serialised the boots. Now each VM's boot overlaps with the next VM's clone and config.

Creation itself stays sequential: /cluster/nextid is read-then-use and TaskWrapper waits for all new cluster tasks, so concurrent creates would need additional care.

This implementation deliberately chosen to be minimal and safe. I think VM destruction should also get this treatment, but I've chosen not to stick my nose in that at this time.

Seemed OK to make a breaking API change since we're already making some for the next release anyway. (Although actually now that I think of it, I haven't checked if any of the changed things are exported in a non-underscore-prefixed module.)

# Testing

- Existing tests all pass, including the `req_proxmox` tests, except I haven't managed to run the no-internet test yet.
- On a range I'm working on, this took startup from ~15 minutes to ~5 minutes, and it all seemed to start up okay.