### PR TITLE
feat: enable extra headers in requests to Proxmox API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Enable extra custom headers in requests to Proxmox API.
 - Remove the unused single-instance fields (`host` etc.) from `ProxmoxSandboxEnvironmentConfig`; infrastructure is configured via `PROXMOX_CONFIG_FILE` or `PROXMOX_*` environment variables only. Passing these fields is now silently ignored (pydantic drops extra kwargs), and old `.eval` logs still deserialize.
 - Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
 - Opt logger into `INFO` level for consistency with Inspect core

--- a/README.md
+++ b/README.md
@@ -226,28 +226,7 @@ Instances with the same `pool_id` form a pool. Each eval sample acquires one ins
 
 ### Extra HTTP Headers
 
-`extra_headers` on an instance adds HTTP headers to every request sent to that instance's Proxmox API, including file uploads. Typical uses: credentials for a proxy or access gateway in front of the API (a bearer token, Cloudflare Access service token, or similar), an API key for a gateway that routes or rate-limits on one, or tracing headers for request attribution:
-
-```json
-{
-  "instances": [
-    {
-      "instance_id": "proxmox-1",
-      "pool_id": "ubuntu-ami-123",
-      "host": "proxmox.example.com",
-      "port": 443,
-      "user": "root",
-      "user_realm": "pam",
-      "password": "secret",
-      "node": "pve1",
-      "verify_tls": true,
-      "extra_headers": [
-        {"name": "Authorization", "value": "Bearer example-token"}
-      ]
-    }
-  ]
-}
-```
+`extra_headers` on an instance adds HTTP headers to every request sent to that instance's Proxmox API, including file uploads. See [`schema.py`](./src/proxmoxsandbox/schema.py) for details.
 
 Header values are treated as secrets and redacted from logs. The Proxmox authentication headers (`Cookie`, `CSRFPreventionToken`) cannot be overridden.
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,33 @@ export PROXMOX_CONFIG_FILE=/path/to/instances.json
 
 Instances with the same `pool_id` form a pool. Each eval sample acquires one instance from its pool, uses it exclusively, and releases it back when done. Concurrency is automatically limited to the total number of instances.
 
+### Proxmox Behind an Authenticating Reverse Proxy
+
+If a Proxmox instance sits behind a reverse proxy that requires its own authentication (for example a bearer token), configure `extra_headers` on that instance. The headers are sent with every request to the Proxmox API, including file uploads:
+
+```json
+{
+  "instances": [
+    {
+      "instance_id": "proxmox-1",
+      "pool_id": "ubuntu-ami-123",
+      "host": "proxmox.example.com",
+      "port": 443,
+      "user": "root",
+      "user_realm": "pam",
+      "password": "secret",
+      "node": "pve1",
+      "verify_tls": true,
+      "extra_headers": [
+        {"name": "Authorization", "value": "Bearer example-token"}
+      ]
+    }
+  ]
+}
+```
+
+Header values are treated as secrets and redacted from logs. The Proxmox authentication headers (`Cookie`, `CSRFPreventionToken`) cannot be overridden.
+
 ## Configuring
 
 Here is a full example sandbox configuration. 

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ export PROXMOX_CONFIG_FILE=/path/to/instances.json
 
 Instances with the same `pool_id` form a pool. Each eval sample acquires one instance from its pool, uses it exclusively, and releases it back when done. Concurrency is automatically limited to the total number of instances.
 
-### Proxmox Behind an Authenticating Reverse Proxy
+### Extra HTTP Headers
 
-If a Proxmox instance sits behind a reverse proxy that requires its own authentication (for example a bearer token), configure `extra_headers` on that instance. The headers are sent with every request to the Proxmox API, including file uploads:
+`extra_headers` on an instance adds HTTP headers to every request sent to that instance's Proxmox API, including file uploads. Typical uses: credentials for a proxy or access gateway in front of the API (a bearer token, Cloudflare Access service token, or similar), an API key for a gateway that routes or rate-limits on one, or tracing headers for request attribution:
 
 ```json
 {

--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -37,6 +37,7 @@ class AsyncProxmoxAPI:
     username: str
     password: str
     verify_tls: bool
+    extra_headers: Dict[str, str]
     ticket: Optional[str] = None
     ticket_date: Optional[float] = None
     csrf_token: Optional[str] = None
@@ -46,13 +47,32 @@ class AsyncProxmoxAPI:
     TICKET_LIFETIME_SECONDS = 7200
     TICKET_REFRESH_THRESHOLD = TICKET_LIFETIME_SECONDS - 600
 
+    # The Proxmox authentication headers; extra_headers may not shadow them.
+    RESERVED_HEADERS = frozenset({"cookie", "csrfpreventiontoken"})
+
     # note: host *includes* :port
-    def __init__(self, host: str, user: str, password: str, verify_tls: bool = True):
+    def __init__(
+        self,
+        host: str,
+        user: str,
+        password: str,
+        verify_tls: bool = True,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ):
         self.base_url = f"https://{host}"
         self.api_base_url = f"{self.base_url}/api2/json"
         self.username = user
         self.password = password
         self.verify_tls = verify_tls
+        self.extra_headers = dict(extra_headers or {})
+        reserved = [
+            name for name in self.extra_headers if name.lower() in self.RESERVED_HEADERS
+        ]
+        if reserved:
+            raise ValueError(
+                f"extra_headers may not include the Proxmox authentication "
+                f"headers: {', '.join(sorted(reserved))}"
+            )
 
     @classmethod
     def from_instance_config(cls, instance: ProxmoxInstanceConfig):
@@ -61,16 +81,29 @@ class AsyncProxmoxAPI:
             user=f"{instance.user}@{instance.user_realm}",
             password=instance.password.get_secret_value(),
             verify_tls=instance.verify_tls,
+            extra_headers={
+                header.name: header.value.get_secret_value()
+                for header in instance.extra_headers
+            },
         )
 
     def __hash__(self):
-        return hash((self.api_base_url, self.username, self.password, self.verify_tls))
+        return hash(
+            (
+                self.api_base_url,
+                self.username,
+                self.password,
+                self.verify_tls,
+                tuple(sorted(self.extra_headers.items())),
+            )
+        )
 
     async def _login(self, client: httpx.AsyncClient):
         """Get new authentication ticket and CSRF token."""
         with trace_action(self.logger, self.TRACE_NAME, "login"):
             response = await client.post(
                 f"{self.api_base_url}/access/ticket",
+                headers=self.extra_headers,
                 data={"username": self.username, "password": self.password},
             )
             response.raise_for_status()
@@ -160,7 +193,9 @@ class AsyncProxmoxAPI:
             return response.json()["data"]
 
     def _prepare_headers(self, method: str, content_type: str | None):
+        # Extra headers first, so the Proxmox auth headers below always win.
         headers = {
+            **self.extra_headers,
             "Cookie": f"PVEAuthCookie={self.ticket}",
         }
 
@@ -217,6 +252,7 @@ class AsyncProxmoxAPI:
             response = await client.get(
                 f"{self.api_base_url}{path}",
                 headers={
+                    **self.extra_headers,
                     "Cookie": f"PVEAuthCookie={self.ticket}",
                     # Opt out of pveproxy response compression: it truncates
                     # large incompressible bodies mid-transfer, surfacing as an
@@ -274,6 +310,14 @@ class AsyncProxmoxAPI:
         truncated = bool(data.get("truncated")) or len(raw) > count
         return raw[:count], truncated
 
+    def _curl_headers(self) -> List[str]:
+        """Request headers for the pycurl upload path."""
+        return [
+            *(f"{name}: {value}" for name, value in self.extra_headers.items()),
+            f"Cookie: PVEAuthCookie={self.ticket}",
+            f"CSRFPreventionToken: {self.csrf_token}",
+        ]
+
     async def upload_file_with_curl(
         self,
         node: str,
@@ -316,12 +360,7 @@ class AsyncProxmoxAPI:
                 curl.setopt(pycurl.SSL_VERIFYPEER, 0)
                 curl.setopt(pycurl.SSL_VERIFYHOST, 0)
 
-            # Set auth headers
-            headers = [
-                f"Cookie: PVEAuthCookie={self.ticket}",
-                f"CSRFPreventionToken: {self.csrf_token}",
-            ]
-            curl.setopt(pycurl.HTTPHEADER, headers)
+            curl.setopt(pycurl.HTTPHEADER, self._curl_headers())
 
             curl.setopt(
                 pycurl.HTTPPOST,

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -222,6 +222,22 @@ class VmConfig(BaseModel, frozen=True):
     cpu: Optional[str] = None
 
 
+class HttpHeader(BaseModel):
+    """
+    A single HTTP header.
+
+    Attributes:
+        name: The header name, e.g. "Authorization"
+        value: The header value. Modelled as a secret because extra headers
+            typically carry credentials (e.g. a bearer token for a reverse proxy).
+    """
+
+    model_config = ConfigDict(frozen=True, hide_input_in_errors=True)
+
+    name: str
+    value: SecretStr
+
+
 class ProxmoxInstanceConfig(BaseModel):
     """
     Configuration for a single Proxmox instance.
@@ -237,6 +253,10 @@ class ProxmoxInstanceConfig(BaseModel):
         password: The password for Proxmox authentication
         node: The name of the Proxmox node
         verify_tls: Whether to verify the Proxmox server's TLS certificate
+        extra_headers: Additional HTTP headers to send with every request to this
+            instance, e.g. for authenticating to a reverse proxy in front of the
+            Proxmox API. The Proxmox authentication headers (Cookie,
+            CSRFPreventionToken) cannot be overridden.
     """
 
     model_config = ConfigDict(frozen=True, hide_input_in_errors=True)
@@ -250,6 +270,7 @@ class ProxmoxInstanceConfig(BaseModel):
     password: SecretStr
     node: str
     verify_tls: bool
+    extra_headers: Tuple[HttpHeader, ...] = ()
 
 
 def _load_single_instance_from_env() -> ProxmoxInstanceConfig:

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -228,8 +228,8 @@ class HttpHeader(BaseModel):
 
     Attributes:
         name: The header name, e.g. "Authorization"
-        value: The header value. Modelled as a secret because extra headers
-            typically carry credentials (e.g. a bearer token for a reverse proxy).
+        value: The header value. Modelled as a secret because header values
+            often carry credentials (bearer tokens, API keys).
     """
 
     model_config = ConfigDict(frozen=True, hide_input_in_errors=True)
@@ -253,10 +253,11 @@ class ProxmoxInstanceConfig(BaseModel):
         password: The password for Proxmox authentication
         node: The name of the Proxmox node
         verify_tls: Whether to verify the Proxmox server's TLS certificate
-        extra_headers: Additional HTTP headers to send with every request to this
-            instance, e.g. for authenticating to a reverse proxy in front of the
-            Proxmox API. The Proxmox authentication headers (Cookie,
-            CSRFPreventionToken) cannot be overridden.
+        extra_headers: Additional HTTP headers to send with every request to
+            this instance (e.g. credentials for a proxy or gateway in front of
+            the Proxmox API, an API key, or tracing headers). The Proxmox
+            authentication headers (Cookie, CSRFPreventionToken) cannot be
+            overridden.
     """
 
     model_config = ConfigDict(frozen=True, hide_input_in_errors=True)

--- a/tests/proxmoxsandboxtest/test_extra_headers.py
+++ b/tests/proxmoxsandboxtest/test_extra_headers.py
@@ -1,0 +1,209 @@
+"""Tests for per-instance extra HTTP headers."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI
+from proxmoxsandbox.schema import (
+    HttpHeader,
+    ProxmoxInstanceConfig,
+    _load_instances_from_env_or_file,
+)
+
+HEADER_SENTINEL = "Bearer audit-token-sentinel-do-not-log"
+
+
+def _instance_config(**overrides) -> ProxmoxInstanceConfig:
+    values = dict(
+        instance_id="proxy-instance",
+        pool_id="proxy-pool",
+        host="proxmox.example.com",
+        port=443,
+        user="root",
+        user_realm="pam",
+        password="password-sentinel",
+        node="proxmox",
+        verify_tls=True,
+        extra_headers=(HttpHeader(name="Authorization", value=HEADER_SENTINEL),),
+    )
+    values.update(overrides)
+    return ProxmoxInstanceConfig(**values)
+
+
+def test_extra_headers_default_to_empty():
+    config = _instance_config(extra_headers=())
+    assert config.extra_headers == ()
+    api = AsyncProxmoxAPI.from_instance_config(config)
+    assert api.extra_headers == {}
+
+
+def test_extra_headers_reach_the_api_client():
+    api = AsyncProxmoxAPI.from_instance_config(_instance_config())
+    assert api.extra_headers == {"Authorization": HEADER_SENTINEL}
+
+
+def test_extra_header_values_are_redacted_in_config_representations():
+    config = _instance_config()
+
+    header = config.extra_headers[0]
+    assert isinstance(header.value, SecretStr)
+    assert header.value.get_secret_value() == HEADER_SENTINEL
+    assert HEADER_SENTINEL not in repr(config)
+    assert HEADER_SENTINEL not in str(config)
+    assert HEADER_SENTINEL not in config.model_dump_json()
+
+
+def test_instance_config_stays_hashable_with_extra_headers():
+    hash(_instance_config())
+
+
+def test_request_headers_include_extras_and_keep_proxmox_auth():
+    api = AsyncProxmoxAPI.from_instance_config(_instance_config())
+    api.ticket = "ticket-123"
+    api.csrf_token = "csrf-456"
+
+    headers = api._prepare_headers("POST", content_type=None)
+
+    assert headers["Authorization"] == HEADER_SENTINEL
+    assert headers["Cookie"] == "PVEAuthCookie=ticket-123"
+    assert headers["CSRFPreventionToken"] == "csrf-456"
+
+
+def test_curl_upload_headers_include_extras_and_keep_proxmox_auth():
+    api = AsyncProxmoxAPI.from_instance_config(_instance_config())
+    api.ticket = "ticket-123"
+    api.csrf_token = "csrf-456"
+
+    headers = api._curl_headers()
+
+    assert f"Authorization: {HEADER_SENTINEL}" in headers
+    assert "Cookie: PVEAuthCookie=ticket-123" in headers
+    assert "CSRFPreventionToken: csrf-456" in headers
+
+
+@pytest.mark.parametrize("name", ["Cookie", "cookie", "CSRFPreventionToken"])
+def test_reserved_proxmox_auth_headers_are_rejected(name):
+    with pytest.raises(ValueError, match="may not include"):
+        AsyncProxmoxAPI(
+            host="proxmox.example.com:443",
+            user="root@pam",
+            password="password",
+            extra_headers={name: "shadowed"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_login_sends_extra_headers():
+    api = AsyncProxmoxAPI.from_instance_config(_instance_config())
+    api.request = AsyncMock(  # type: ignore[method-assign]
+        return_value={"release": "9.2", "repoid": "abc", "version": "9.2.1"}
+    )
+    client = MagicMock()
+    response = MagicMock()
+    response.json.return_value = {
+        "data": {"ticket": "ticket-123", "CSRFPreventionToken": "csrf-456"}
+    }
+    client.post = AsyncMock(return_value=response)
+
+    await api._login(client)
+
+    assert client.post.call_args.kwargs["headers"] == {"Authorization": HEADER_SENTINEL}
+
+
+def test_extra_headers_participate_in_client_identity():
+    def api(token: str) -> AsyncProxmoxAPI:
+        return AsyncProxmoxAPI(
+            host="proxmox.example.com:443",
+            user="root@pam",
+            password="password",
+            extra_headers={"Authorization": token},
+        )
+
+    assert hash(api("Bearer one")) == hash(api("Bearer one"))
+    assert hash(api("Bearer one")) != hash(api("Bearer two"))
+
+
+def test_extra_headers_load_from_config_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "instances.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "instances": [
+                    {
+                        "instance_id": "test-1",
+                        "pool_id": "ubuntu-pool",
+                        "host": "proxmox.example.com",
+                        "port": 443,
+                        "user": "root",
+                        "user_realm": "pam",
+                        "password": "secret",
+                        "node": "pve1",
+                        "verify_tls": True,
+                        "extra_headers": [
+                            {"name": "Authorization", "value": HEADER_SENTINEL}
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("PROXMOX_CONFIG_FILE", str(config_path))
+
+    (instance,) = _load_instances_from_env_or_file()
+
+    (header,) = instance.extra_headers
+    assert header.name == "Authorization"
+    assert header.value.get_secret_value() == HEADER_SENTINEL
+
+
+def _mock_pve_transport(seen_auth_headers: dict[str, list[str]]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        seen_auth_headers.setdefault(path, []).append(
+            request.headers.get("Authorization", "")
+        )
+        if path.endswith("/access/ticket"):
+            return httpx.Response(
+                200,
+                json={"data": {"ticket": "t", "CSRFPreventionToken": "c"}},
+            )
+        if path.endswith("/version"):
+            return httpx.Response(
+                200,
+                json={"data": {"release": "9.2", "repoid": "abc", "version": "9.2.1"}},
+            )
+        if path.endswith("/agent/ping"):
+            return httpx.Response(200, json={"data": None})
+        if path.endswith("/agent/file-read"):
+            return httpx.Response(
+                200, json={"data": {"content": "aGVsbG8=", "truncated": False}}
+            )
+        return httpx.Response(404, json={"data": None})
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_extra_headers_sent_on_file_read_path(monkeypatch):
+    seen_auth_headers: dict[str, list[str]] = {}
+    transport = _mock_pve_transport(seen_auth_headers)
+    real_client = httpx.AsyncClient
+
+    def client_with_mock_transport(**kwargs):
+        kwargs.pop("verify", None)
+        return real_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_with_mock_transport)
+
+    api = AsyncProxmoxAPI.from_instance_config(_instance_config())
+    data, truncated = await api.read_file_capped("pve1", 100, "/tmp/file", count=1024)
+
+    assert data == b"hello"
+    assert truncated is False
+    for path, headers in seen_auth_headers.items():
+        assert headers == [HEADER_SENTINEL] * len(headers), path
+    assert any(path.endswith("/agent/file-read") for path in seen_auth_headers)


### PR DESCRIPTION
## Description

This PR enables the sandbox provider to pass extra headers in requests to the Proxmox PVE API. The motivating example is when the API is targeted via a reverse proxy which imposes its own auth header - this change allows the sandbox provider to pass such a header and successfully authenticate with the proxy.