### PR TITLE
perf: reuse httpx AsyncClient across Proxmox API requests

### DIFF
--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -42,6 +42,8 @@ class AsyncProxmoxAPI:
     ticket_date: Optional[float] = None
     csrf_token: Optional[str] = None
     discovered_proxmox_version: Optional[ProxmoxVersionInfo] = None
+    _client: Optional[httpx.AsyncClient] = None
+    _client_loop: Optional[asyncio.AbstractEventLoop] = None
 
     # PVE tickets expire after 2 hours; refresh proactively with 10 min buffer
     TICKET_LIFETIME_SECONDS = 7200
@@ -98,6 +100,26 @@ class AsyncProxmoxAPI:
             )
         )
 
+    def _get_client(self) -> httpx.AsyncClient:
+        """One AsyncClient (and hence one connection pool) per event loop.
+
+        A pooled connection is bound to the loop that created it, so if the
+        loop changed (e.g. cli_cleanup's separate asyncio.run) we abandon the
+        old client rather than await its aclose from the wrong loop.
+        """
+        loop = asyncio.get_running_loop()
+        if (
+            self._client is None
+            or self._client.is_closed
+            or self._client_loop is not loop
+        ):
+            self._client = httpx.AsyncClient(
+                verify=self.verify_tls,
+                timeout=httpx.Timeout(connect=15, read=60, write=60, pool=60),
+            )
+            self._client_loop = loop
+        return self._client
+
     async def _login(self, client: httpx.AsyncClient):
         """Get new authentication ticket and CSRF token."""
         with trace_action(self.logger, self.TRACE_NAME, "login"):
@@ -141,17 +163,27 @@ class AsyncProxmoxAPI:
     ):
         if json is not None:
             content_type = "application/json"
-        async with httpx.AsyncClient(
-            verify=self.verify_tls,
-            timeout=httpx.Timeout(connect=15, read=60, write=60, pool=60),
-        ) as client:
-            # Get a fresh ticket if we don't have one or it's approaching expiry
-            if not self.ticket or self._ticket_near_expiry():
-                await self._login(client)
+        client = self._get_client()
+        # Get a fresh ticket if we don't have one or it's approaching expiry
+        if not self.ticket or self._ticket_near_expiry():
+            await self._login(client)
 
-            if self.csrf_token is None:
-                raise ValueError("CSRF token was not set by login")
+        if self.csrf_token is None:
+            raise ValueError("CSRF token was not set by login")
 
+        headers = self._prepare_headers(method, content_type)
+
+        response = await client.request(
+            method,
+            f"{self.api_base_url}{path}",
+            headers=headers,
+            json=json,
+            content=body_content,
+        )
+        # If we get a 401, our ticket might have expired (2 hour lifetime)
+        # Try to login once and retry the request
+        if response.status_code == 401:
+            await self._login(client)
             headers = self._prepare_headers(method, content_type)
 
             response = await client.request(
@@ -161,36 +193,23 @@ class AsyncProxmoxAPI:
                 json=json,
                 content=body_content,
             )
-            # If we get a 401, our ticket might have expired (2 hour lifetime)
-            # Try to login once and retry the request
-            if response.status_code == 401:
-                await self._login(client)
-                headers = self._prepare_headers(method, content_type)
 
-                response = await client.request(
-                    method,
-                    f"{self.api_base_url}{path}",
-                    headers=headers,
-                    json=json,
-                    content=body_content,
-                )
-
-            if response.is_error and raise_errors:
-                # We are deliberately not using response.raise_for_status here as it
-                # does not include response.text in the raised error
-                message = (
-                    f"HTTP response error: {response.status_code} "
-                    + f"{response.reason_phrase}"
-                )
-                if response.text:
-                    message += f": {response.text}"
-                raise httpx.HTTPStatusError(
-                    message, request=response.request, response=response
-                )
-            else:
-                if response.is_error:
-                    return response.json()
-            return response.json()["data"]
+        if response.is_error and raise_errors:
+            # We are deliberately not using response.raise_for_status here as it
+            # does not include response.text in the raised error
+            message = (
+                f"HTTP response error: {response.status_code} "
+                + f"{response.reason_phrase}"
+            )
+            if response.text:
+                message += f": {response.text}"
+            raise httpx.HTTPStatusError(
+                message, request=response.request, response=response
+            )
+        else:
+            if response.is_error:
+                return response.json()
+        return response.json()["data"]
 
     def _prepare_headers(self, method: str, content_type: str | None):
         # Extra headers first, so the Proxmox auth headers below always win.
@@ -241,43 +260,39 @@ class AsyncProxmoxAPI:
         https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/agent/file-read
         """
         path = f"/nodes/{node}/qemu/{vm_id}/agent/file-read"
-        async with httpx.AsyncClient(
-            verify=self.verify_tls,
-            timeout=httpx.Timeout(connect=15, read=60, write=60, pool=60),
-        ) as client:
-            # ping first: it logs in if needed, so the version is discovered
-            # before we decide which file-read variant to use.
-            await self._ping_qemu_agent(node, vm_id)
-            modern = self.release_at_least(9, 2)
-            response = await client.get(
-                f"{self.api_base_url}{path}",
-                headers={
-                    **self.extra_headers,
-                    "Cookie": f"PVEAuthCookie={self.ticket}",
-                    # Opt out of pveproxy response compression: it truncates
-                    # large incompressible bodies mid-transfer, surfacing as an
-                    # upstream "597 Broken pipe".
-                    "Accept-Encoding": "identity",
-                },
-                params=(
-                    {"file": filepath, "count": count, "decode": 0}
-                    if modern
-                    else {"file": filepath}
-                ),
+        client = self._get_client()
+        # ping first: it logs in if needed, so the version is discovered
+        # before we decide which file-read variant to use.
+        await self._ping_qemu_agent(node, vm_id)
+        modern = self.release_at_least(9, 2)
+        response = await client.get(
+            f"{self.api_base_url}{path}",
+            headers={
+                **self.extra_headers,
+                "Cookie": f"PVEAuthCookie={self.ticket}",
+                # Opt out of pveproxy response compression: it truncates
+                # large incompressible bodies mid-transfer, surfacing as an
+                # upstream "597 Broken pipe".
+                "Accept-Encoding": "identity",
+            },
+            params=(
+                {"file": filepath, "count": count, "decode": 0}
+                if modern
+                else {"file": filepath}
+            ),
+        )
+        if response.is_error:
+            # Mirror request()'s error so callers can still match the agent's
+            # message text (e.g. "No such file", "Is a directory").
+            message = (
+                f"HTTP response error: {response.status_code} {response.reason_phrase}"
             )
-            if response.is_error:
-                # Mirror request()'s error so callers can still match the agent's
-                # message text (e.g. "No such file", "Is a directory").
-                message = (
-                    f"HTTP response error: {response.status_code} "
-                    f"{response.reason_phrase}"
-                )
-                if response.text:
-                    message += f": {response.text}"
-                raise httpx.HTTPStatusError(
-                    message, request=response.request, response=response
-                )
-            data = response.json()["data"]
+            if response.text:
+                message += f": {response.text}"
+            raise httpx.HTTPStatusError(
+                message, request=response.request, response=response
+            )
+        data = response.json()["data"]
         content: str = data.get("content") or ""
         if not modern:
             return self._decode_legacy_file_read(content, data, count)

--- a/src/proxmoxsandbox/_impl/async_proxmox.py
+++ b/src/proxmoxsandbox/_impl/async_proxmox.py
@@ -116,9 +116,33 @@ class AsyncProxmoxAPI:
             self._client = httpx.AsyncClient(
                 verify=self.verify_tls,
                 timeout=httpx.Timeout(connect=15, read=60, write=60, pool=60),
+                # pveproxy closes idle keep-alive connections after ~5s; expire
+                # them client-side first or a request written just as the server
+                # closes surfaces as RemoteProtocolError. max_connections=None
+                # keeps the old one-client-per-request concurrency semantics
+                # (no PoolTimeout under heavy QGA polling).
+                limits=httpx.Limits(
+                    max_connections=None,
+                    max_keepalive_connections=20,
+                    keepalive_expiry=4.0,
+                ),
             )
             self._client_loop = loop
         return self._client
+
+    async def aclose(self) -> None:
+        """Close the pooled client; the next request lazily creates a new one.
+
+        If the client was created on a different event loop, its connections
+        belong to that loop and can't be closed from here — drop the reference
+        and let GC reap the sockets.
+        """
+        client, client_loop = self._client, self._client_loop
+        self._client = None
+        self._client_loop = None
+        if client is not None and not client.is_closed:
+            if client_loop is asyncio.get_running_loop():
+                await client.aclose()
 
     async def _login(self, client: httpx.AsyncClient):
         """Get new authentication ticket and CSRF token."""

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -641,6 +641,14 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 "[blue]inspect sandbox cleanup proxmox[/blue]\n"
             )
 
+        # The InfraCommands registry outlives the task; drop the pooled HTTP
+        # connections (a later task lazily reconnects).
+        for target, infra_commands in InfraCommands._instances.items():
+            try:
+                await infra_commands.async_proxmox.aclose()
+            except Exception as e:
+                cls.logger.warning(f"closing API client failed for {target}: {e}")
+
     @classmethod
     @override
     async def cli_cleanup(cls, id: str | None) -> None:
@@ -653,7 +661,10 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                     instance.node,
                     ProxmoxSandboxEnvironmentConfig().image_storage,
                 )
-                await infra_commands.cleanup_no_id()
+                try:
+                    await infra_commands.cleanup_no_id()
+                finally:
+                    await async_proxmox_api.aclose()
         else:
             print("\n[red]Cleanup by ID not implemented[/red]\n")
 

--- a/tests/proxmoxsandboxtest/test_async_proxmox_client.py
+++ b/tests/proxmoxsandboxtest/test_async_proxmox_client.py
@@ -1,0 +1,86 @@
+"""Client reuse semantics of AsyncProxmoxAPI._get_client / aclose.
+
+No network involved: only client identity and lifecycle are asserted.
+"""
+
+import asyncio
+
+from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI
+
+
+def make_api() -> AsyncProxmoxAPI:
+    return AsyncProxmoxAPI(
+        host="proxmox.invalid:8006",
+        user="root@pam",
+        password="unused",
+        verify_tls=False,
+    )
+
+
+def test_client_reused_within_loop() -> None:
+    api = make_api()
+
+    async def main():
+        first = api._get_client()
+        second = api._get_client()
+        assert first is second
+        await api.aclose()
+
+    asyncio.run(main())
+
+
+def test_client_recreated_on_new_loop() -> None:
+    api = make_api()
+
+    async def get():
+        return api._get_client()
+
+    first = asyncio.run(get())
+    second = asyncio.run(get())
+    assert first is not second
+
+    async def close():
+        await api.aclose()
+
+    asyncio.run(close())
+
+
+def test_aclose_recreates_client() -> None:
+    api = make_api()
+
+    async def main():
+        first = api._get_client()
+        await api.aclose()
+        assert first.is_closed
+        second = api._get_client()
+        assert second is not first
+        assert not second.is_closed
+        await api.aclose()
+
+    asyncio.run(main())
+
+
+def test_aclose_from_other_loop_drops_without_closing() -> None:
+    api = make_api()
+
+    async def get():
+        return api._get_client()
+
+    first = asyncio.run(get())
+
+    async def close():
+        await api.aclose()
+
+    # Created on a dead loop: aclose must not await into it, just drop.
+    asyncio.run(close())
+    assert not first.is_closed
+    assert api._client is None
+
+
+def test_aclose_without_client_is_noop() -> None:
+    api = make_api()
+
+    async def close():
+        await api.aclose()
+
+    asyncio.run(close())

--- a/tests/proxmoxsandboxtest/test_cli_cleanup.py
+++ b/tests/proxmoxsandboxtest/test_cli_cleanup.py
@@ -83,51 +83,50 @@ async def test_cli_cleanup_all_instances(multi_instance_config_file):
             ) as mock_proxmox_api,
             patch.object(InfraCommands, "build", side_effect=create_mock_infra),
         ):
+            mock_proxmox_api.from_instance_config.return_value.aclose = AsyncMock()
             await ProxmoxSandboxEnvironment.cli_cleanup(id=None)
 
-            mock_proxmox_api.from_instance_config.assert_has_calls(
-                [
-                    call(
-                        ProxmoxInstanceConfig(
-                            instance_id="server-1",
-                            pool_id="pool-a",
-                            host="10.0.1.10",
-                            port=8006,
-                            user="root",
-                            user_realm="pam",
-                            password="test",
-                            node="pve1",
-                            verify_tls=False,
-                        )
-                    ),
-                    call(
-                        ProxmoxInstanceConfig(
-                            instance_id="server-2",
-                            pool_id="pool-a",
-                            host="10.0.1.11",
-                            port=8006,
-                            user="root",
-                            user_realm="pam",
-                            password="test",
-                            node="pve2",
-                            verify_tls=False,
-                        )
-                    ),
-                    call(
-                        ProxmoxInstanceConfig(
-                            instance_id="server-3",
-                            pool_id="pool-b",
-                            host="10.0.1.20",
-                            port=8006,
-                            user="root",
-                            user_realm="pam",
-                            password="test",
-                            node="pve3",
-                            verify_tls=False,
-                        )
-                    ),
-                ]
-            )
+            assert mock_proxmox_api.from_instance_config.call_args_list == [
+                call(
+                    ProxmoxInstanceConfig(
+                        instance_id="server-1",
+                        pool_id="pool-a",
+                        host="10.0.1.10",
+                        port=8006,
+                        user="root",
+                        user_realm="pam",
+                        password="test",
+                        node="pve1",
+                        verify_tls=False,
+                    )
+                ),
+                call(
+                    ProxmoxInstanceConfig(
+                        instance_id="server-2",
+                        pool_id="pool-a",
+                        host="10.0.1.11",
+                        port=8006,
+                        user="root",
+                        user_realm="pam",
+                        password="test",
+                        node="pve2",
+                        verify_tls=False,
+                    )
+                ),
+                call(
+                    ProxmoxInstanceConfig(
+                        instance_id="server-3",
+                        pool_id="pool-b",
+                        host="10.0.1.20",
+                        port=8006,
+                        user="root",
+                        user_realm="pam",
+                        password="test",
+                        node="pve3",
+                        verify_tls=False,
+                    )
+                ),
+            ]
             assert mock_proxmox_api.from_instance_config.call_count == 3
 
             # Verify InfraCommands.build was called for each instance
@@ -237,9 +236,12 @@ async def test_cli_cleanup_handles_cleanup_error():
             return mock_infra
 
         with (
-            patch("proxmoxsandbox._proxmox_sandbox_environment.AsyncProxmoxAPI"),
+            patch(
+                "proxmoxsandbox._proxmox_sandbox_environment.AsyncProxmoxAPI"
+            ) as mock_proxmox_api,
             patch.object(InfraCommands, "build", side_effect=create_failing_infra),
         ):
+            mock_proxmox_api.from_instance_config.return_value.aclose = AsyncMock()
             # Should raise the exception from the first cleanup
             with pytest.raises(Exception, match="Cleanup failed on first instance"):
                 await ProxmoxSandboxEnvironment.cli_cleanup(id=None)
@@ -297,9 +299,12 @@ async def test_cli_cleanup_pools_created_correctly():
             return mock_infra
 
         with (
-            patch("proxmoxsandbox._proxmox_sandbox_environment.AsyncProxmoxAPI"),
+            patch(
+                "proxmoxsandbox._proxmox_sandbox_environment.AsyncProxmoxAPI"
+            ) as mock_proxmox_api,
             patch.object(InfraCommands, "build", side_effect=create_mock_infra),
         ):
+            mock_proxmox_api.from_instance_config.return_value.aclose = AsyncMock()
             # Pools should not exist before cleanup
             assert len(ProxmoxSandboxEnvironment.proxmox_pool._instance_pools) == 0
 


### PR DESCRIPTION
**TL;DR:** Reuse one `httpx.AsyncClient` per `AsyncProxmoxAPI` instance (per event loop) instead of opening a fresh client — and hence a fresh TCP+TLS handshake — for every API request. Per-request latency drops ~3x (8.9ms → 3.0ms mean), but a full eval is unchanged: API time is dominated by server-side QGA/task work, not connection setup. On these numbers alone this isn't worth merging; it's filed for review because the win grows with RTT to the Proxmox host and it removes per-request TLS churn in pveproxy under high sample concurrency.

The client is closed in `task_cleanup`/`cli_cleanup` and lazily recreated on next use; `keepalive_expiry` is set to 4s because pveproxy closes idle keep-alive connections at ~5s, and expiring client-side first avoids a request racing the server's close (which would surface as `RemoteProtocolError` on the non-QGA paths that don't retry transport errors). `max_connections=None` keeps the old unbounded-concurrency semantics rather than inheriting httpx's 100-connection pool cap.

<details><summary>Measurements</summary>

Measured against a real PVE 9.2 host, sub-millisecond RTT (TCP connect median 0.5ms).

Micro-benchmark, 100 sequential `GET /version`:

|  | fresh client per request (main) | reused client |
|---|---|---|
| mean / median / p95 | 8.9 / 8.3 / 13.2 ms | 3.0 / 2.8 / 4.5 ms |

End-to-end eval (1 sample, 25 `sandbox().exec` + `write_file` + `read_file`, ~240 API calls), 3 runs each: baseline 107.1–108.2s wall, reused 106.8–110.6s — no difference. Both spend ~57s inside `request()`, i.e. ~237ms per call of mostly server-side work; the ~6ms x 240 ≈ 1.4s saved is lost in noise.

The test host is adjacent. A fresh TLS handshake costs 2+ extra round trips per request, so against a remote host (e.g. 20ms RTT) the same eval shape would save ~10s.

pveproxy keep-alive behaviour, probed empirically: idle connections closed after ~5s, ~100 requests max per connection. httpx detected both and reconnected cleanly (idle gaps of 1–30s and a 300-request burst, zero errors) even before the `keepalive_expiry` guard was added.

</details>
