### PR TITLE
Move image_storage to instance config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Anchor the ephemeral SDN zone regex so automatic cleanup is less likely to delete unrelated pre-existing zones
 - Enable extra custom headers in requests to Proxmox API.
+- Move the `image_storage` field from `ProxmoxSandboxEnvironmentConfig` to `ProxmoxInstanceConfig`.
 - Remove the unused single-instance fields (`host` etc.) from `ProxmoxSandboxEnvironmentConfig`; infrastructure is configured via `PROXMOX_CONFIG_FILE` or `PROXMOX_*` environment variables only. Passing these fields is now silently ignored (pydantic drops extra kwargs), and old `.eval` logs still deserialize.
 - Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
 - Opt logger into `INFO` level for consistency with Inspect core

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ export PROXMOX_CONFIG_FILE=/path/to/instances.json
       "user_realm": "pam",
       "password": "secret",
       "node": "pve1",
+      "image_storage": "local-lvm",
       "verify_tls": false
     },
     {
@@ -216,6 +217,7 @@ export PROXMOX_CONFIG_FILE=/path/to/instances.json
       "user_realm": "pam",
       "password": "secret",
       "node": "pve2",
+      "image_storage": "local-lvm",
       "verify_tls": false
     }
   ]
@@ -246,10 +248,6 @@ At least one VM in the configuration must be a sandbox.
 sandbox=SandboxEnvironmentSpec(
     "proxmox",
     ProxmoxSandboxEnvironmentConfig(
-        # Storage pool for VM disk images. Defaults to PROXMOX_IMAGE_STORAGE env var
-        # or "local-lvm" if not set.
-        image_storage="local-lvm",
-
         # When using PROXMOX_CONFIG_FILE with multiple instances, set this to select
         # which pool to use (must match a pool_id in the config file).
         # Not needed for single-instance setups.

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -352,7 +352,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 infra_commands = InfraCommands.get_instance(target)
             except LookupError:
                 infra_commands = InfraCommands.build(
-                    async_proxmox_api, instance.node, config.image_storage
+                    async_proxmox_api, instance.node, instance.image_storage
                 )
                 InfraCommands.set_instance(target, infra_commands)
 
@@ -651,7 +651,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
                 infra_commands = InfraCommands.build(
                     async_proxmox_api,
                     instance.node,
-                    ProxmoxSandboxEnvironmentConfig().image_storage,
+                    instance.image_storage,
                 )
                 await infra_commands.cleanup_no_id()
         else:

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -258,6 +258,9 @@ class ProxmoxInstanceConfig(BaseModel):
         password: The password for Proxmox authentication
         node: The name of the Proxmox node
         verify_tls: Whether to verify the Proxmox server's TLS certificate
+        image_storage: The Proxmox storage pool for VM disk images (e.g.
+            "local-lvm"). Defaults to the PROXMOX_IMAGE_STORAGE environment variable,
+            or "local-lvm" if not set.
         extra_headers: Additional HTTP headers to send with every request to
             this instance (e.g. credentials for a proxy or gateway in front of
             the Proxmox API, an API key, or tracing headers). The Proxmox
@@ -276,6 +279,9 @@ class ProxmoxInstanceConfig(BaseModel):
     password: SecretStr
     node: str
     verify_tls: bool
+    image_storage: str = Field(
+        default_factory=lambda: getenv("PROXMOX_IMAGE_STORAGE", "local-lvm")
+    )
     extra_headers: Tuple[HttpHeader, ...] = ()
 
 
@@ -296,6 +302,7 @@ def _load_single_instance_from_env() -> ProxmoxInstanceConfig:
         password=getenv("PROXMOX_PASSWORD", "password"),
         node=getenv("PROXMOX_NODE", "proxmox"),
         verify_tls=getenv("PROXMOX_VERIFY_TLS", "1") == "1",
+        image_storage=getenv("PROXMOX_IMAGE_STORAGE", "local-lvm"),
     )
 
 
@@ -333,10 +340,6 @@ class ProxmoxSandboxEnvironmentConfig(BaseModel):
     Attributes:
         instance_pool_id: Which pool to use for this sample (must match a pool_id in
             PROXMOX_CONFIG_FILE or defaults to "default" for single-instance mode)
-        image_storage: The Proxmox storage pool for VM disk images (e.g.
-            "local-lvm"). Defaults to the PROXMOX_IMAGE_STORAGE environment variable,
-            or "local-lvm" if not set, which is the default if you installed Proxmox
-            normally.
         sdn_config: Software-defined networking configuration
         vms_config: Configurations for virtual machines
     """
@@ -350,8 +353,4 @@ class ProxmoxSandboxEnvironmentConfig(BaseModel):
     sdn_config: SdnConfigType = "auto"
     vms_config: Tuple[VmConfig, ...] = (
         VmConfig(vm_source_config=VmSourceConfig(built_in="ubuntu24.04")),
-    )
-
-    image_storage: str = Field(
-        default_factory=lambda: getenv("PROXMOX_IMAGE_STORAGE", "local-lvm")
     )

--- a/tests/proxmoxsandboxtest/conftest.py
+++ b/tests/proxmoxsandboxtest/conftest.py
@@ -75,7 +75,6 @@ async def async_proxmox_api(
 @pytest.fixture
 async def infra_commands(
     async_proxmox_api: AsyncProxmoxAPI,
-    sandbox_env_config: ProxmoxSandboxEnvironmentConfig,
     instance_config: ProxmoxInstanceConfig,
 ) -> InfraCommands:
     target = ProxmoxTarget(
@@ -84,7 +83,7 @@ async def infra_commands(
         node=instance_config.node,
     )
     instance = InfraCommands.build(
-        async_proxmox_api, instance_config.node, sandbox_env_config.image_storage
+        async_proxmox_api, instance_config.node, instance_config.image_storage
     )
     InfraCommands.set_instance(target, instance)
     return instance

--- a/tests/proxmoxsandboxtest/test_config_loading.py
+++ b/tests/proxmoxsandboxtest/test_config_loading.py
@@ -28,6 +28,7 @@ def test_load_instances_from_file():
                 "password": "secret",
                 "node": "pve1",
                 "verify_tls": False,
+                "image_storage": "fast-storage",
             },
             {
                 "instance_id": "test-2",
@@ -70,6 +71,7 @@ def test_load_instances_from_file():
         assert instances[0].password.get_secret_value() == "secret"
         assert instances[0].node == "pve1"
         assert instances[0].verify_tls is False
+        assert instances[0].image_storage == "fast-storage"
 
         assert instances[1].instance_id == "test-2"
         assert instances[1].pool_id == "kali-pool"
@@ -106,6 +108,7 @@ def test_load_instances_from_env_vars():
         os.environ["PROXMOX_PASSWORD"] = "test123"
         os.environ["PROXMOX_NODE"] = "node1"
         os.environ["PROXMOX_VERIFY_TLS"] = "0"
+        os.environ["PROXMOX_IMAGE_STORAGE"] = "env-storage"
 
         instances = _load_instances_from_env_or_file()
 
@@ -119,6 +122,7 @@ def test_load_instances_from_env_vars():
         assert instances[0].password.get_secret_value() == "test123"
         assert instances[0].node == "node1"
         assert instances[0].verify_tls is False
+        assert instances[0].image_storage == "env-storage"
 
     finally:
         # Restore original environment
@@ -257,6 +261,7 @@ def test_sandbox_config_defaults():
     assert config.sdn_config == "auto"
     assert len(config.vms_config) == 1
     assert config.vms_config[0].vm_source_config.built_in == "ubuntu24.04"
+    assert not hasattr(config, "image_storage")
 
 
 def test_sandbox_config_explicit_pool_id():

--- a/tests/proxmoxsandboxtest/test_config_loading.py
+++ b/tests/proxmoxsandboxtest/test_config_loading.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError
 
 from proxmoxsandbox.schema import (
     ProxmoxInstanceConfig,
-    ProxmoxSandboxEnvironmentConfig,
     _load_instances_from_env_or_file,
 )
 
@@ -250,25 +249,6 @@ def test_missing_required_fields_in_instance():
         os.unlink(temp_path)
         os.environ.clear()
         os.environ.update(old_env)
-
-
-def test_sandbox_config_defaults():
-    """Test ProxmoxSandboxEnvironmentConfig default values."""
-    config = ProxmoxSandboxEnvironmentConfig()
-
-    # Check defaults
-    assert config.instance_pool_id == "default"
-    assert config.sdn_config == "auto"
-    assert len(config.vms_config) == 1
-    assert config.vms_config[0].vm_source_config.built_in == "ubuntu24.04"
-    assert not hasattr(config, "image_storage")
-
-
-def test_sandbox_config_explicit_pool_id():
-    """Test ProxmoxSandboxEnvironmentConfig with explicit pool_id."""
-    config = ProxmoxSandboxEnvironmentConfig(instance_pool_id="custom-pool")
-
-    assert config.instance_pool_id == "custom-pool"
 
 
 def test_default_concurrency_with_config_file():


### PR DESCRIPTION
The way I see it, ProxmoxSandboxEnvironmentConfig is "what does the eval want the proxmox instance to configure so that it can run". The eval doesn't care what image storage the instance is using. Meanwhile, ProxmoxInstanceConfig is something your provisioning layer fills in with "these are the details of the instances I provisioned, that you'll need in order to use them properly", and image_storage is such a thing just like host and port are.

Benefits:
- evals no longer have to specify this thing they don't care about
- instance provisioning *can* set this and obviate the need to use PROXMOX_IMAGE_STORAGE in some cases
- fix a bug where if two evals ran on the same host / port / node, only the image_storage specified by the first would be used to create the infra_commands that both would use (I doubt this came up much).

I haven't thought too hard about migration / compatibility. The situation is a bit worse than it was in #103 because this field was actually useful at its old location. An alternative could be to keep this on `ProxmoxSandboxEnvironmentConfig` for now in some kind of deprecated way, and then somehow fall back to that if it's not specified on the instance, but that sounds somewhat fiddly so I'd be a bit inclined to simply eat the breakage. People who are typechecking their code should notice it that way.

## Testing

- [x] CI.
- [x] Manually running req_proxmox tests

```
======================= 203 passed, 5 skipped, 16 warnings in 1959.00s (0:32:39) =======================
```