### PR TITLE
Tests: consume inspect's portable self_check pytest suite

### DIFF
--- a/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
+++ b/tests/proxmoxsandboxtest/test_proxmox_sandbox_agent_commands.py
@@ -1,16 +1,12 @@
 import hashlib
 from pathlib import Path
-from typing import List
 
 import httpx
 import pytest
 import tenacity
 from inspect_ai.util import OutputLimitExceededError
-from inspect_ai.util._sandbox.self_check import self_check
 
 from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
-
-from .proxmox_sandbox_utils import setup_requests_logging
 
 pytestmark = pytest.mark.req_proxmox
 
@@ -243,38 +239,6 @@ async def test_write_file_large(
         assert exec_result.stdout.startswith(expected_md5)
 
 
-async def test_self_check(
-    proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
-) -> None:
-    if proxmox_sandbox_environment._is_windows():
-        pytest.skip("self_check uses Linux-specific paths and commands")
-
-    setup_requests_logging()
-
-    known_failures: List[str] = [
-        "test_read_file_not_allowed",  # user is root, so this doesn't work
-        "test_write_text_file_without_permissions",  # ditto
-        "test_write_binary_file_without_permissions",  # ditto
-        # Proxmox's QGA file-read API is hard-limited to 16 MiB; this self_check
-        # writes 50 MiB. read_file() caps at 16 MiB (a documented deviation from
-        # Inspect's 100 MiB spec, see read_file in _proxmox_sandbox_environment).
-        "test_read_and_write_large_file_binary",
-    ]
-
-    results = await check_results_of_self_check(
-        proxmox_sandbox_environment, known_failures
-    )
-
-    # 50 MiB can't round-trip (16 MiB cap) so it stays a known failure - but it
-    # must fail *gracefully* (OutputLimitExceededError), not a raw 597. The old
-    # outcome-blind exclusion is how the crash slipped through.
-    large_file_result = results["test_read_and_write_large_file_binary"]
-    assert "OutputLimitExceededError" in str(large_file_result), (
-        "Oversized read_file must fail with OutputLimitExceededError, got: "
-        f"{large_file_result!r}"
-    )
-
-
 async def test_exec_self_kill_degrades_gracefully(
     proxmox_sandbox_environment: ProxmoxSandboxEnvironment,
 ) -> None:
@@ -287,14 +251,3 @@ async def test_exec_self_kill_degrades_gracefully(
 
     after = await proxmox_sandbox_environment.exec(["echo", "alive"])
     assert after.success and after.stdout.strip() == "alive"
-
-
-async def check_results_of_self_check(sandbox_env, known_failures=[]):
-    self_check_results = await self_check(sandbox_env)
-    failures = []
-    for test_name, result in self_check_results.items():
-        if result is not True and test_name not in known_failures:
-            failures.append(f"Test {test_name} failed: {result}")
-    if failures:
-        assert False, "\n".join(failures)
-    return self_check_results

--- a/tests/proxmoxsandboxtest/test_sandbox_self_check.py
+++ b/tests/proxmoxsandboxtest/test_sandbox_self_check.py
@@ -1,0 +1,92 @@
+"""Runs inspect_ai's portable sandbox conformance suite against Proxmox.
+
+Linux only; self_check uses Linux-specific paths and commands.
+"""
+
+from typing import AsyncGenerator
+
+import pytest
+from inspect_ai.util import OutputLimitExceededError, SandboxEnvironment
+
+# Pull the portable check functions into this module so pytest collects them as
+# tests, each driven by the `sandbox_env` fixture below.
+from inspect_ai.util._sandbox.self_check import *  # noqa: F401, F403
+
+from proxmoxsandbox._impl.infra_commands import InfraCommands
+from proxmoxsandbox._proxmox_sandbox_environment import (
+    ProxmoxSandboxEnvironment,
+    ProxmoxSandboxEnvironmentConfig,
+)
+
+from .proxmox_sandbox_utils import setup_requests_logging
+
+pytestmark = pytest.mark.req_proxmox
+
+# Known failures, applied as strict xfails in the sandbox_env fixture (keyed on
+# the running check's function name).
+_XFAILS = {
+    "test_read_file_not_allowed": "user is root, so this doesn't work",
+    "test_write_text_file_without_permissions": "user is root",
+    "test_write_binary_file_without_permissions": "user is root",
+}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def reset_global_pool_state():
+    # Shadows conftest's function-scoped autouse fixture: sample_cleanup at
+    # module teardown needs the pool created by task_init, so we must not
+    # clear pool state between checks.
+    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
+    InfraCommands._instances.clear()
+    yield
+    ProxmoxSandboxEnvironment.proxmox_pool.clear_pools()
+    InfraCommands._instances.clear()
+
+
+@pytest.fixture(scope="module")
+async def proxmox_env() -> AsyncGenerator[ProxmoxSandboxEnvironment, None]:
+    setup_requests_logging()
+    task_name = "self_check"
+    config = ProxmoxSandboxEnvironmentConfig()
+    await ProxmoxSandboxEnvironment.task_init(task_name=task_name, config=None)
+    envs_dict = await ProxmoxSandboxEnvironment.sample_init(
+        task_name=task_name, config=config, metadata={}
+    )
+    default_env = envs_dict["default"]
+    assert isinstance(default_env, ProxmoxSandboxEnvironment)
+
+    yield default_env
+
+    await ProxmoxSandboxEnvironment.sample_cleanup(
+        task_name=task_name,
+        config=config,
+        environments=envs_dict,
+        interrupted=False,
+    )
+
+
+@pytest.fixture
+async def sandbox_env(
+    request: pytest.FixtureRequest, proxmox_env: ProxmoxSandboxEnvironment
+) -> ProxmoxSandboxEnvironment:
+    reason = _XFAILS.get(request.node.originalname)
+    if reason is not None:
+        request.node.add_marker(pytest.mark.xfail(reason=reason, strict=True))
+    return proxmox_env
+
+
+async def test_read_and_write_large_file_binary(
+    sandbox_env: SandboxEnvironment,
+) -> None:
+    # Shadows the portable check (same name wins at collection). Proxmox's QGA
+    # file-read API is hard-limited to 16 MiB; the portable check writes 50 MiB.
+    # read_file() caps at 16 MiB (a documented deviation from Inspect's 100 MiB
+    # spec, see read_file in _proxmox_sandbox_environment) — but it must fail
+    # *gracefully* (OutputLimitExceededError), not with a raw 597.
+    file_name = "test_read_and_write_large_file_binary.file"
+    long_bytes = b"\xc3" * (50 * 1024 * 1024)
+    await sandbox_env.write_file(file_name, long_bytes)
+    with pytest.raises(OutputLimitExceededError):
+        await sandbox_env.read_file(file_name, text=False)
+    res = await sandbox_env.exec(["rm", "-f", "--", file_name])
+    assert res.success

--- a/tests/proxmoxsandboxtest/test_sandbox_self_check.py
+++ b/tests/proxmoxsandboxtest/test_sandbox_self_check.py
@@ -75,7 +75,7 @@ async def sandbox_env(
     return proxmox_env
 
 
-async def test_read_and_write_large_file_binary(
+async def test_read_and_write_large_file_binary(  # type: ignore[no-redef]
     sandbox_env: SandboxEnvironment,
 ) -> None:
     # Shadows the portable check (same name wins at collection). Proxmox's QGA


### PR DESCRIPTION
Adapts the self_check test to the new sandbox conformance suite in inspect_ai, which replaces the `self_check()` runner with importable pytest checks driven by a `sandbox_env` fixture.

**Depends on UKGovernmentBEIS/inspect_ai#4265** 

- New `test_sandbox_self_check.py`: `from inspect_ai.util._sandbox.self_check import *` collects each check individually; a module-scoped env (one VM for the whole suite) plus a `sandbox_env` fixture that applies the `known_failures` as **strict** xfails. Linux only, as before.
- The old `test_self_check` + `check_results_of_self_check` are removed from `test_proxmox_sandbox_agent_commands.py`.
- The 16 MiB QGA read cap is handled by *shadowing* `test_read_and_write_large_file_binary` with a proxmox-specific version asserting the graceful `OutputLimitExceededError` failure — replacing the old outcome-blind exclusion plus follow-up assertion.
- The module shadows conftest's autouse `reset_global_pool_state` with a module-scoped one: `sample_cleanup` at module teardown needs the pool that `task_init` created.

## Verification

Against a fresh nitrovirt Proxmox instance: **41 passed, 3 xfailed** (7 min). The xfails match the prior `known_failures` exactly (root ignores permission bits ×3). Notably `test_exec_input_large` / `test_exec_large_command` — new checks that fail on the k8s and EC2 sandboxes — pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

