### PR TITLE
Fix `sandbox_service()` on this provider: clamp reads to PVE's 16 MiB `agent/file-read` cap

### DIFF
--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -62,8 +62,8 @@ _IN_GUEST_KILL_GRACE = 5
 # PVE rejects an agent/file-read with `count` above this ("value must have a
 # maximum value of 16777216"), so every read count must be clamped to it —
 # including ones derived from Inspect limits, which callers can raise above it.
-# override_max_exec_output_size() does exactly that when the sandbox service
-# reads a bridge request, which used to 400 every poll and stall the bridge.
+# sandbox_service() raises MAX_EXEC_OUTPUT_SIZE to 150 MiB for every request
+# read (override_max_exec_output_size), which used to 400 on each poll.
 _PVE_AGENT_FILE_READ_MAX = 16 * 1024**2
 _PVE_AGENT_FILE_READ_MAX_STR = "16 MiB"
 

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -64,8 +64,8 @@ _IN_GUEST_KILL_GRACE = 5
 # including ones derived from Inspect limits, which callers can raise above it.
 # sandbox_service() raises MAX_EXEC_OUTPUT_SIZE to 150 MiB for every request
 # read (override_max_exec_output_size), which used to 400 on each poll.
-_PVE_AGENT_FILE_READ_MAX = 16 * 1024**2
-_PVE_AGENT_FILE_READ_MAX_STR = "16 MiB"
+_PVE_FILE_READ_MAX = 16 * 1024**2
+_PVE_FILE_READ_MAX_STR = "16 MiB"
 
 
 def _split_chunks(
@@ -892,7 +892,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             filepath=f"{tmp_start}script.returncode",
             count=min(
                 SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
-                _PVE_AGENT_FILE_READ_MAX,
+                _PVE_FILE_READ_MAX,
             ),
         )
         returncode_string_stripped = raw.decode("utf-8", errors="replace").strip()
@@ -904,7 +904,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         # decode=0 gives raw bytes; decode UTF-8 errors="replace" (output is
         # arbitrary bytes). Oversized output is flagged via `truncated`.
         limit = SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE
-        cap = min(limit, _PVE_AGENT_FILE_READ_MAX)
+        cap = min(limit, _PVE_FILE_READ_MAX)
         raw, truncated = await self.agent_commands.read_file_capped_or_blank(
             vm_id=self.vm_id,
             filepath=filepath,
@@ -914,8 +914,8 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         if truncated:
             raise OutputLimitExceededError(
                 SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE_STR
-                if limit <= _PVE_AGENT_FILE_READ_MAX
-                else _PVE_AGENT_FILE_READ_MAX_STR,
+                if limit <= _PVE_FILE_READ_MAX
+                else _PVE_FILE_READ_MAX_STR,
                 text,
             )
         return text
@@ -1180,7 +1180,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             raise ValueError("VM ID is not set")
         # PVE caps agent file-read at 16 MiB; cap at the (test-overridable)
         # Inspect limit, never above that.
-        cap = min(SandboxEnvironmentLimits.MAX_READ_FILE_SIZE, _PVE_AGENT_FILE_READ_MAX)
+        cap = min(SandboxEnvironmentLimits.MAX_READ_FILE_SIZE, _PVE_FILE_READ_MAX)
         try:
             data_bytes, truncated = await self.agent_commands.read_file_capped(
                 vm_id=self.vm_id,
@@ -1205,9 +1205,8 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             # File exceeds the cap; report the active limit (16 MiB or a test override).
             limit_str = (
                 SandboxEnvironmentLimits.MAX_READ_FILE_SIZE_STR
-                if SandboxEnvironmentLimits.MAX_READ_FILE_SIZE
-                <= _PVE_AGENT_FILE_READ_MAX
-                else _PVE_AGENT_FILE_READ_MAX_STR
+                if SandboxEnvironmentLimits.MAX_READ_FILE_SIZE <= _PVE_FILE_READ_MAX
+                else _PVE_FILE_READ_MAX_STR
             )
             raise OutputLimitExceededError(limit_str, None)
         if text:

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -59,6 +59,14 @@ _WRITE_CHUNK_SIZE = 40 * 1024
 
 _IN_GUEST_KILL_GRACE = 5
 
+# PVE rejects an agent/file-read with `count` above this ("value must have a
+# maximum value of 16777216"), so every read count must be clamped to it —
+# including ones derived from Inspect limits, which callers can raise above it.
+# override_max_exec_output_size() does exactly that when the sandbox service
+# reads a bridge request, which used to 400 every poll and stall the bridge.
+_PVE_AGENT_FILE_READ_MAX = 16 * 1024**2
+_PVE_AGENT_FILE_READ_MAX_STR = "16 MiB"
+
 
 def _split_chunks(
     data: bytes, size: int = _WRITE_CHUNK_SIZE
@@ -882,7 +890,10 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         raw, _truncated = await self.agent_commands.read_file_capped_or_blank(
             vm_id=self.vm_id,
             filepath=f"{tmp_start}script.returncode",
-            count=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+            count=min(
+                SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+                _PVE_AGENT_FILE_READ_MAX,
+            ),
         )
         returncode_string_stripped = raw.decode("utf-8", errors="replace").strip()
         if len(returncode_string_stripped) == 0:
@@ -892,15 +903,20 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     async def _read_exec_output(self, filepath: str) -> str:
         # decode=0 gives raw bytes; decode UTF-8 errors="replace" (output is
         # arbitrary bytes). Oversized output is flagged via `truncated`.
+        limit = SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE
+        cap = min(limit, _PVE_AGENT_FILE_READ_MAX)
         raw, truncated = await self.agent_commands.read_file_capped_or_blank(
             vm_id=self.vm_id,
             filepath=filepath,
-            count=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+            count=cap,
         )
         text = raw.decode("utf-8", errors="replace")
         if truncated:
             raise OutputLimitExceededError(
-                SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE_STR, text
+                SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE_STR
+                if limit <= _PVE_AGENT_FILE_READ_MAX
+                else _PVE_AGENT_FILE_READ_MAX_STR,
+                text,
             )
         return text
 
@@ -1164,7 +1180,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             raise ValueError("VM ID is not set")
         # PVE caps agent file-read at 16 MiB; cap at the (test-overridable)
         # Inspect limit, never above that.
-        cap = min(SandboxEnvironmentLimits.MAX_READ_FILE_SIZE, 16777216)
+        cap = min(SandboxEnvironmentLimits.MAX_READ_FILE_SIZE, _PVE_AGENT_FILE_READ_MAX)
         try:
             data_bytes, truncated = await self.agent_commands.read_file_capped(
                 vm_id=self.vm_id,
@@ -1189,8 +1205,9 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
             # File exceeds the cap; report the active limit (16 MiB or a test override).
             limit_str = (
                 SandboxEnvironmentLimits.MAX_READ_FILE_SIZE_STR
-                if SandboxEnvironmentLimits.MAX_READ_FILE_SIZE <= 16777216
-                else "16 MiB"
+                if SandboxEnvironmentLimits.MAX_READ_FILE_SIZE
+                <= _PVE_AGENT_FILE_READ_MAX
+                else _PVE_AGENT_FILE_READ_MAX_STR
             )
             raise OutputLimitExceededError(limit_str, None)
         if text:

--- a/tests/proxmoxsandboxtest/test_exec_output_read_cap.py
+++ b/tests/proxmoxsandboxtest/test_exec_output_read_cap.py
@@ -1,0 +1,91 @@
+"""Exec-output reads stay under PVE's agent/file-read cap.
+
+Inspect's sandbox service wraps its request read in
+`override_max_exec_output_size(SERVICE_REQUEST_READ_OUTPUT_LIMIT)` — 150 MiB,
+nearly 10x PVE's 16 MiB cap on `count`. Passing that straight through makes PVE
+400 every poll, which stalls the service (and so `sandbox_agent_bridge`) with no
+useful error. These tests drive the read helpers with mocked QGA collaborators.
+"""
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from inspect_ai.util import OutputLimitExceededError, SandboxEnvironmentLimits
+from inspect_ai.util._sandbox.limits import override_max_exec_output_size
+from inspect_ai.util._sandbox.service import SERVICE_REQUEST_READ_OUTPUT_LIMIT
+
+from proxmoxsandbox import _proxmox_sandbox_environment as mod
+from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
+
+
+def _make_sandbox(*, truncated: bool = False) -> ProxmoxSandboxEnvironment:
+    agent_commands = MagicMock()
+    agent_commands.read_file_capped_or_blank = AsyncMock(return_value=(b"0", truncated))
+    return ProxmoxSandboxEnvironment(
+        infra_commands=MagicMock(),
+        agent_commands=agent_commands,
+        ipam_mappings=(),
+        vm_id=100,
+        all_vm_ids=(100,),
+        sdn_zone_id=None,
+        instance=None,
+        pool_id=None,
+        os_type="l26",
+    )
+
+
+def _count(env: ProxmoxSandboxEnvironment) -> int:
+    read = cast(AsyncMock, env.agent_commands.read_file_capped_or_blank)
+    assert read.await_args is not None, "the read helper was never awaited"
+    return int(read.await_args.kwargs["count"])
+
+
+# The service's override is the real trigger; the default limit is included so
+# the clamp can't be "fixed" by hardcoding 16 MiB and losing a lower limit.
+@pytest.mark.parametrize(
+    "override",
+    [None, SERVICE_REQUEST_READ_OUTPUT_LIMIT, mod._PVE_AGENT_FILE_READ_MAX + 1],
+    ids=["default", "service-request-limit", "one-over-cap"],
+)
+async def test_exec_output_read_count_never_exceeds_pve_cap(
+    override: int | None,
+) -> None:
+    env = _make_sandbox()
+    if override is None:
+        await env._read_exec_output("/tmp/out")
+    else:
+        with override_max_exec_output_size(override):
+            await env._read_exec_output("/tmp/out")
+
+    assert _count(env) <= mod._PVE_AGENT_FILE_READ_MAX
+
+
+async def test_return_code_read_count_never_exceeds_pve_cap() -> None:
+    env = _make_sandbox()
+    with override_max_exec_output_size(SERVICE_REQUEST_READ_OUTPUT_LIMIT):
+        await env._read_return_code("/tmp/")
+
+    assert _count(env) <= mod._PVE_AGENT_FILE_READ_MAX
+
+
+async def test_low_limit_is_still_honoured() -> None:
+    """The clamp is a ceiling, not a floor — a limit under the cap wins."""
+    env = _make_sandbox()
+    with override_max_exec_output_size(1024):
+        await env._read_exec_output("/tmp/out")
+
+    assert _count(env) == 1024
+
+
+async def test_truncation_reports_whichever_limit_bit() -> None:
+    env = _make_sandbox(truncated=True)
+
+    with override_max_exec_output_size(SERVICE_REQUEST_READ_OUTPUT_LIMIT):
+        with pytest.raises(OutputLimitExceededError) as over_cap:
+            await env._read_exec_output("/tmp/out")
+    assert mod._PVE_AGENT_FILE_READ_MAX_STR in str(over_cap.value)
+
+    with pytest.raises(OutputLimitExceededError) as under_cap:
+        await env._read_exec_output("/tmp/out")
+    assert SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE_STR in str(under_cap.value)

--- a/tests/proxmoxsandboxtest/test_exec_output_read_cap.py
+++ b/tests/proxmoxsandboxtest/test_exec_output_read_cap.py
@@ -1,10 +1,10 @@
 """Exec-output reads stay under PVE's agent/file-read cap.
 
-Inspect's sandbox service wraps its request read in
+`sandbox_service()` wraps every request read in
 `override_max_exec_output_size(SERVICE_REQUEST_READ_OUTPUT_LIMIT)` — 150 MiB,
 nearly 10x PVE's 16 MiB cap on `count`. Passing that straight through makes PVE
-400 every poll, which stalls the service (and so `sandbox_agent_bridge`) with no
-useful error. These tests drive the read helpers with mocked QGA collaborators.
+400 on each poll, so no request is ever read, whatever its size. These tests
+drive the read helpers with mocked QGA collaborators.
 """
 
 from typing import cast
@@ -41,7 +41,7 @@ def _count(env: ProxmoxSandboxEnvironment) -> int:
     return int(read.await_args.kwargs["count"])
 
 
-# The service's override is the real trigger; the default limit is included so
+# The service's override is the trigger; the default limit is included so
 # the clamp can't be "fixed" by hardcoding 16 MiB and losing a lower limit.
 @pytest.mark.parametrize(
     "override",

--- a/tests/proxmoxsandboxtest/test_exec_output_read_cap.py
+++ b/tests/proxmoxsandboxtest/test_exec_output_read_cap.py
@@ -45,7 +45,7 @@ def _count(env: ProxmoxSandboxEnvironment) -> int:
 # the clamp can't be "fixed" by hardcoding 16 MiB and losing a lower limit.
 @pytest.mark.parametrize(
     "override",
-    [None, SERVICE_REQUEST_READ_OUTPUT_LIMIT, mod._PVE_AGENT_FILE_READ_MAX + 1],
+    [None, SERVICE_REQUEST_READ_OUTPUT_LIMIT, mod._PVE_FILE_READ_MAX + 1],
     ids=["default", "service-request-limit", "one-over-cap"],
 )
 async def test_exec_output_read_count_never_exceeds_pve_cap(
@@ -58,7 +58,7 @@ async def test_exec_output_read_count_never_exceeds_pve_cap(
         with override_max_exec_output_size(override):
             await env._read_exec_output("/tmp/out")
 
-    assert _count(env) <= mod._PVE_AGENT_FILE_READ_MAX
+    assert _count(env) <= mod._PVE_FILE_READ_MAX
 
 
 async def test_return_code_read_count_never_exceeds_pve_cap() -> None:
@@ -66,7 +66,7 @@ async def test_return_code_read_count_never_exceeds_pve_cap() -> None:
     with override_max_exec_output_size(SERVICE_REQUEST_READ_OUTPUT_LIMIT):
         await env._read_return_code("/tmp/")
 
-    assert _count(env) <= mod._PVE_AGENT_FILE_READ_MAX
+    assert _count(env) <= mod._PVE_FILE_READ_MAX
 
 
 async def test_low_limit_is_still_honoured() -> None:
@@ -84,7 +84,7 @@ async def test_truncation_reports_whichever_limit_bit() -> None:
     with override_max_exec_output_size(SERVICE_REQUEST_READ_OUTPUT_LIMIT):
         with pytest.raises(OutputLimitExceededError) as over_cap:
             await env._read_exec_output("/tmp/out")
-    assert mod._PVE_AGENT_FILE_READ_MAX_STR in str(over_cap.value)
+    assert mod._PVE_FILE_READ_MAX_STR in str(over_cap.value)
 
     with pytest.raises(OutputLimitExceededError) as under_cap:
         await env._read_exec_output("/tmp/out")


### PR DESCRIPTION
`sandbox_service()` has never worked on this provider, for any request size. It wraps
every request read in `override_max_exec_output_size(SERVICE_REQUEST_READ_OUTPUT_LIMIT)`
— 150 MiB — and PVE rejects an `agent/file-read` whose `count` exceeds 16 MiB, so every
poll 400s and no request is ever read. This clamps every read count to the PVE cap.

<details><summary>Mechanism and A/B verification</summary>

`SERVICE_REQUEST_READ_OUTPUT_LIMIT` (`inspect_ai/util/_sandbox/service.py:50`) is
`150 * 1024**2`. Its only caller is `_handle_request` at the same file's line 310, which
applies it unconditionally to each request read — the override is not conditional on
payload size, so a 40-byte request fails exactly like a 40 MiB one.

The failure is also silent-ish by construction. `_handle_request` only recovers from
`OutputLimitExceededError` (via `_discard_unreadable_request`, which at least unblocks the
client with an error). PVE's 400 isn't that, so the handler just raises, the request file
stays in the queue, and it is retried on every poll for as long as the sample lives.

Verified A/B on a bare `sandbox_service` — one `echo` method, guest calls it once through
the generated client, no bridge, no agent, no model calls, `inspect_ai` 0.3.239:

| | result |
|---|---|
| patched (this PR) | `GUEST_STDOUT=echo:ping`, method invoked, 1m25s |
| unpatched `main` | service starts, then 36 × `warning: Error handling sandbox service request: HTTP response error: 400 Parameter verification failed … value must have a maximum value of 16777216`; guest client never gets a response; sample dies `RuntimeError('Command timed out')` |

Same script, same host, only the provider file differs. So this is not specific to any one
consumer of `sandbox_service()` — `sandbox_agent_bridge` was just where I first hit it.

Unit-level, the regression test fails on 3 of 6 cases without the clamp
(`assert 157286400 <= 16777216`). The clamp is a ceiling only — a limit *below* 16 MiB
still wins, which `test_low_limit_is_still_honoured` pins down, since any read count
derived from an Inspect limit needs clamping without losing a lower caller-set limit.

Footgun for later: `read_file` has its own reason to respect the same cap, so the two
`16777216` literals there now share the constant. If PVE ever raises the limit, it's one
place.

</details>
