### PR TITLE
feat: support attaching to existing sandbox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 
 [project.entry-points."inspect_ai"]
 "proxmox-sandbox" = "proxmoxsandbox._proxmox_sandbox_environment"
+"proxmox-existing-sandbox" = "proxmoxsandbox._existing_proxmox_sandbox_environment"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/proxmoxsandbox/_existing_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_existing_proxmox_sandbox_environment.py
@@ -1,0 +1,149 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, cast, get_args
+
+from inspect_ai.util import (
+    SandboxEnvironment,
+    SandboxEnvironmentConfigType,
+    sandboxenv,
+)
+from pydantic import BaseModel
+from typing_extensions import override
+
+from proxmoxsandbox._impl.agent_commands import AgentCommands
+from proxmoxsandbox._impl.async_proxmox import AsyncProxmoxAPI
+from proxmoxsandbox._impl.infra_commands import InfraCommands, ProxmoxTarget
+from proxmoxsandbox._proxmox_sandbox_environment import ProxmoxSandboxEnvironment
+from proxmoxsandbox.schema import (
+    ExistingProxmoxSandboxEnvironmentConfig,
+    OsType,
+)
+
+
+@sandboxenv(name="proxmox-existing")
+class ExistingProxmoxSandboxEnvironment(ProxmoxSandboxEnvironment):
+    """A non-owning Inspect sandbox attached to an existing Proxmox VM."""
+
+    @classmethod
+    @override
+    async def sample_init(
+        cls,
+        task_name: str,
+        config: SandboxEnvironmentConfigType | None,
+        metadata: dict[str, str],
+    ) -> dict[str, SandboxEnvironment]:
+        if isinstance(config, str):
+            config_path = Path(config)
+            try:
+                config = cls.config_deserialize(
+                    json.loads(config_path.read_text(encoding="utf-8"))
+                )
+            except (OSError, json.JSONDecodeError) as ex:
+                raise ValueError(
+                    f"Unable to load proxmox-existing config from {config_path}: {ex}"
+                ) from ex
+        if not isinstance(config, ExistingProxmoxSandboxEnvironmentConfig):
+            raise ValueError(
+                "config must be an ExistingProxmoxSandboxEnvironmentConfig"
+            )
+
+        pool_id = config.instance_pool_id
+        instance = await cls.proxmox_pool.acquire_instance(pool_id)
+
+        try:
+            async_proxmox_api = AsyncProxmoxAPI.from_instance_config(instance)
+            target = ProxmoxTarget(
+                host=instance.host, port=instance.port, node=instance.node
+            )
+            try:
+                infra_commands = InfraCommands.get_instance(target)
+            except LookupError:
+                infra_commands = InfraCommands.build(
+                    async_proxmox_api, instance.node, instance.image_storage
+                )
+                InfraCommands.set_instance(target, infra_commands)
+
+            vm_config = await infra_commands.qemu_commands.read_vm(config.vm_id)
+            vm_status = await infra_commands.async_proxmox.request(
+                "GET", f"/nodes/{instance.node}/qemu/{config.vm_id}/status/current"
+            )
+            if vm_status.get("status") != "running":
+                raise ValueError(
+                    f"Existing VM {config.vm_id} is not running "
+                    f"(status={vm_status.get('status')!r})"
+                )
+
+            # The inherited sandbox operations all use QGA. await_vm performs a
+            # bounded, retrying agent ping now that the status check has established
+            # that this provider must not start the VM itself.
+            await infra_commands.qemu_commands.await_vm(
+                vm_id=config.vm_id, is_sandbox=True
+            )
+
+            os_type_value = vm_config.get("ostype", "l26")
+            os_type = (
+                cast(OsType, os_type_value)
+                if os_type_value in get_args(OsType)
+                else None
+            )
+            environment = cls(
+                infra_commands=infra_commands,
+                agent_commands=AgentCommands(
+                    async_proxmox=infra_commands.async_proxmox,
+                    node=instance.node,
+                ),
+                ipam_mappings=(),
+                vm_id=config.vm_id,
+                all_vm_ids=(),
+                sdn_zone_id=None,
+                instance=instance,
+                pool_id=pool_id,
+                os_type=os_type,
+            )
+            cls.logger.info(
+                f"Attached non-owning sandbox to existing VM {config.vm_id} on "
+                f"instance {instance.instance_id}"
+            )
+            return {"default": environment}
+        except BaseException:
+            await cls.proxmox_pool.release_instance(pool_id, instance)
+            raise
+
+    @classmethod
+    @override
+    async def sample_cleanup(
+        cls,
+        task_name: str,
+        config: SandboxEnvironmentConfigType | None,
+        environments: Dict[str, SandboxEnvironment],
+        interrupted: bool,
+    ) -> None:
+        for environment in environments.values():
+            if isinstance(environment, ExistingProxmoxSandboxEnvironment):
+                if environment.instance is not None and environment.pool_id is not None:
+                    await cls.proxmox_pool.release_instance(
+                        environment.pool_id, environment.instance
+                    )
+                break
+
+    @classmethod
+    @override
+    async def task_cleanup(
+        cls,
+        task_name: str,
+        config: SandboxEnvironmentConfigType | None,
+        cleanup: bool,
+    ) -> None:
+        # This provider owns no infrastructure. In particular, do not sweep the
+        # shared InfraCommands registry: it may contain the attached range.
+        return None
+
+    @classmethod
+    @override
+    async def cli_cleanup(cls, id: str | None) -> None:
+        print("proxmox-existing owns no resources; nothing to clean up.")
+
+    @classmethod
+    @override
+    def config_deserialize(cls, config: dict[str, Any]) -> BaseModel:
+        return ExistingProxmoxSandboxEnvironmentConfig(**config)

--- a/src/proxmoxsandbox/schema.py
+++ b/src/proxmoxsandbox/schema.py
@@ -354,3 +354,20 @@ class ProxmoxSandboxEnvironmentConfig(BaseModel):
     vms_config: Tuple[VmConfig, ...] = (
         VmConfig(vm_source_config=VmSourceConfig(built_in="ubuntu24.04")),
     )
+
+
+class ExistingProxmoxSandboxEnvironmentConfig(BaseModel):
+    """Configuration for attaching Inspect to an existing Proxmox VM.
+
+    The existing-VM provider does not own the VM or any of its networking and
+    will never provision or clean up Proxmox resources.
+
+    Attributes:
+        instance_pool_id: Pool containing the Proxmox host for the existing VM.
+        vm_id: ID of the running VM that should be exposed as the default sandbox.
+    """
+
+    model_config = ConfigDict(frozen=True, hide_input_in_errors=True)
+
+    instance_pool_id: str = "default"
+    vm_id: int = Field(gt=0)

--- a/tests/proxmoxsandboxtest/test_existing_environment.py
+++ b/tests/proxmoxsandboxtest/test_existing_environment.py
@@ -1,0 +1,159 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from proxmoxsandbox._existing_proxmox_sandbox_environment import (
+    ExistingProxmoxSandboxEnvironment,
+)
+from proxmoxsandbox._impl.infra_commands import InfraCommands
+from proxmoxsandbox.schema import (
+    ExistingProxmoxSandboxEnvironmentConfig,
+    ProxmoxInstanceConfig,
+)
+
+
+class FakePool:
+    instance = ProxmoxInstanceConfig(
+        instance_id="existing-host",
+        pool_id="default",
+        host="proxmox.example",
+        port=8006,
+        user="root",
+        user_realm="pam",
+        password="secret",
+        node="pve",
+        verify_tls=False,
+    )
+    acquire_instance = AsyncMock(return_value=instance)
+    release_instance = AsyncMock()
+
+    @classmethod
+    async def initialize(cls) -> None:
+        return None
+
+    @classmethod
+    def default_concurrency(cls) -> int:
+        return 1
+
+
+@pytest.fixture
+def fake_pool(monkeypatch):
+    FakePool.acquire_instance.reset_mock()
+    FakePool.release_instance.reset_mock()
+    monkeypatch.setattr(ExistingProxmoxSandboxEnvironment, "proxmox_pool", FakePool)
+    return FakePool
+
+
+def test_existing_config_requires_positive_vm_id():
+    with pytest.raises(ValidationError):
+        ExistingProxmoxSandboxEnvironmentConfig(vm_id=0)
+
+
+@pytest.mark.asyncio
+async def test_sample_init_loads_json_config_path(fake_pool, tmp_path):
+    config_path = tmp_path / "existing.json"
+    config_path.write_text(json.dumps({"vm_id": 117}), encoding="utf-8")
+
+    infra = MagicMock()
+    infra.async_proxmox = AsyncMock()
+    infra.async_proxmox.request = AsyncMock(return_value={"status": "running"})
+    infra.qemu_commands = MagicMock()
+    infra.qemu_commands.read_vm = AsyncMock(return_value={"ostype": "l26"})
+    infra.qemu_commands.await_vm = AsyncMock()
+    infra.task_wrapper = MagicMock()
+
+    with (
+        patch.object(InfraCommands, "get_instance", side_effect=LookupError),
+        patch.object(InfraCommands, "build", return_value=infra),
+        patch.object(InfraCommands, "set_instance"),
+    ):
+        environments = await ExistingProxmoxSandboxEnvironment.sample_init(
+            "test", str(config_path), {}
+        )
+
+    assert environments["default"].vm_id == 117
+
+
+@pytest.mark.asyncio
+async def test_attaches_without_registering_or_provisioning(fake_pool):
+    infra = MagicMock()
+    infra.async_proxmox = AsyncMock()
+    infra.async_proxmox.request = AsyncMock(return_value={"status": "running"})
+    infra.qemu_commands = MagicMock()
+    infra.qemu_commands.read_vm = AsyncMock(return_value={"ostype": "l26"})
+    infra.qemu_commands.await_vm = AsyncMock()
+    infra.qemu_commands.register_vm = MagicMock()
+    infra.create_sdn_and_vms = AsyncMock()
+    infra.cleanup_no_id = AsyncMock()
+    infra.task_wrapper = MagicMock()
+
+    with (
+        patch.object(InfraCommands, "get_instance", side_effect=LookupError),
+        patch.object(InfraCommands, "build", return_value=infra),
+        patch.object(InfraCommands, "set_instance"),
+    ):
+        environments = await ExistingProxmoxSandboxEnvironment.sample_init(
+            "test", ExistingProxmoxSandboxEnvironmentConfig(vm_id=117), {}
+        )
+
+    environment = environments["default"]
+    assert isinstance(environment, ExistingProxmoxSandboxEnvironment)
+    assert environment.vm_id == 117
+    assert environment.all_vm_ids == ()
+    assert environment.sdn_zone_id is None
+    infra.qemu_commands.read_vm.assert_awaited_once_with(117)
+    infra.qemu_commands.await_vm.assert_awaited_once_with(
+        vm_id=117, is_sandbox=True
+    )
+    infra.qemu_commands.register_vm.assert_not_called()
+    infra.create_sdn_and_vms.assert_not_awaited()
+    infra.cleanup_no_id.assert_not_awaited()
+
+    await ExistingProxmoxSandboxEnvironment.sample_cleanup(
+        "test",
+        ExistingProxmoxSandboxEnvironmentConfig(vm_id=117),
+        environments,
+        interrupted=False,
+    )
+    fake_pool.release_instance.assert_awaited_once_with(
+        "default", fake_pool.instance
+    )
+
+
+@pytest.mark.asyncio
+async def test_stopped_vm_releases_instance_without_cleanup(fake_pool):
+    infra = MagicMock()
+    infra.async_proxmox = AsyncMock()
+    infra.async_proxmox.request = AsyncMock(return_value={"status": "stopped"})
+    infra.qemu_commands = MagicMock()
+    infra.qemu_commands.read_vm = AsyncMock(return_value={"ostype": "l26"})
+    infra.qemu_commands.await_vm = AsyncMock()
+    infra.cleanup_no_id = AsyncMock()
+
+    with (
+        patch.object(InfraCommands, "get_instance", side_effect=LookupError),
+        patch.object(InfraCommands, "build", return_value=infra),
+        patch.object(InfraCommands, "set_instance"),
+    ):
+        with pytest.raises(ValueError, match="VM 117 is not running"):
+            await ExistingProxmoxSandboxEnvironment.sample_init(
+                "test", ExistingProxmoxSandboxEnvironmentConfig(vm_id=117), {}
+            )
+
+    fake_pool.release_instance.assert_awaited_once_with(
+        "default", fake_pool.instance
+    )
+    infra.qemu_commands.await_vm.assert_not_awaited()
+    infra.cleanup_no_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_cleanup_is_non_owning():
+    with patch.object(InfraCommands, "_instances", {MagicMock(): MagicMock()}):
+        await ExistingProxmoxSandboxEnvironment.task_cleanup(
+            "test", ExistingProxmoxSandboxEnvironmentConfig(vm_id=117), True
+        )
+        for infra in InfraCommands._instances.values():
+            infra.task_cleanup.assert_not_called()


### PR DESCRIPTION
This is only a PoC - I suspect this code is not production ready (in particular I have concerns that the "existing sandbox overrides the spinning up sandbox" structure is fragile compared to having them both inherit from an abstract base class)  - but I want it to be committed onto a branch as it is regardless a useful intermediate step that I'll be reusing.

See CASTCE-5953 for context