### PR TITLE
Fix: don't accidentally suppress debug/trace output from the package logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Enable extra custom headers in requests to Proxmox API.
 - Remove the unused single-instance fields (`host` etc.) from `ProxmoxSandboxEnvironmentConfig`; infrastructure is configured via `PROXMOX_CONFIG_FILE` or `PROXMOX_*` environment variables only. Passing these fields is now silently ignored (pydantic drops extra kwargs), and old `.eval` logs still deserialize.
 - Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
-- Opt logger into `INFO` level for consistency with Inspect core, without suppressing `debug`/`trace` output when a lower `--log-level` is set
+- Opt logger into `INFO` level for consistency with Inspect core, also supporting `debug`/`trace` output when a lower `--log-level` is set
 - Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
 - Optional egress lockdown for sandbox guests (when using the bundled provisioning scripts): drops forwarded guest traffic and stops the SDN `dnsmasq` instances recursing upstream. Installed inert, so nothing changes until `/etc/inspect-proxmox-egress-lockdown` is created; see the README
 - Fix: guest file / command-output reads work again on Proxmox < 9.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Enable extra custom headers in requests to Proxmox API.
 - Remove the unused single-instance fields (`host` etc.) from `ProxmoxSandboxEnvironmentConfig`; infrastructure is configured via `PROXMOX_CONFIG_FILE` or `PROXMOX_*` environment variables only. Passing these fields is now silently ignored (pydantic drops extra kwargs), and old `.eval` logs still deserialize.
 - Log the acquired pool instance (`host`/`port`/`node`) at `INFO`
-- Opt logger into `INFO` level for consistency with Inspect core
+- Opt logger into `INFO` level for consistency with Inspect core, without suppressing `debug`/`trace` output when a lower `--log-level` is set
 - Prevent VMs from accessing cloud instance metadata credentials, disable IPv6 for sandbox guests (when using the bundled provisioning scripts)
 - Optional egress lockdown for sandbox guests (when using the bundled provisioning scripts): drops forwarded guest traffic and stops the SDN `dnsmasq` instances recursing upstream. Installed inert, so nothing changes until `/etc/inspect-proxmox-egress-lockdown` is created; see the README
 - Fix: guest file / command-output reads work again on Proxmox < 9.2.

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -37,15 +37,6 @@ from proxmoxsandbox.schema import (
     ProxmoxSandboxEnvironmentConfig,
 )
 
-# Inspect only lowers its own package loggers below the root WARNING default, so a
-# third-party provider's INFO never reaches the .eval transcript. As an Inspect
-# extension we opt our own logger in; a user can still silence it with
-# --log-level-transcript warning (that gate is downstream of this level).
-# Guarded on NOTSET so we never clobber a level a host application set before
-# this module was imported (e.g. someone who wants proxmoxsandbox at DEBUG).
-if getLogger("proxmoxsandbox").level == NOTSET:
-    getLogger("proxmoxsandbox").setLevel(INFO)
-
 # Above this many raw stdin bytes, exec() writes stdin to a file and redirects
 # from it instead of inlining base64 into the shell script — see exec() below.
 # Empirically ~34 KiB raw stdin saturates the script-write API limit (see exec
@@ -297,10 +288,31 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
         return cls.proxmox_pool.default_concurrency()
 
     @classmethod
+    def _init_package_log_level(cls) -> None:
+        """Set the package logger to INFO, or to the root's level if that is lower.
+
+        Inspect configures only its own package loggers, so `proxmoxsandbox`
+        would otherwise inherit the root level and lose its INFO records from
+        the .eval transcript. INFO is the floor; `--log-level debug/trace`
+        lowers the root below it and wins.
+
+        Runs from the lifecycle entry points because it must happen after
+        Inspect's `init_logger`. Extensions are imported earlier, during
+        `platform_init()`, while the root logger is still at its default.
+        Skipped when a level is already set, so a host application's choice
+        stands.
+        """
+        if getLogger("proxmoxsandbox").level == NOTSET:
+            getLogger("proxmoxsandbox").setLevel(
+                min(INFO, getLogger().getEffectiveLevel())
+            )
+
+    @classmethod
     @override
     async def task_init(
         cls, task_name: str, config: SandboxEnvironmentConfigType | None
     ) -> None:
+        cls._init_package_log_level()
         # Pool creation only depends on infrastructure config (PROXMOX_CONFIG_FILE),
         # not on eval-specific config. Config may be None when the task delegates
         # per-sample config to sample_init.
@@ -644,6 +656,7 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
     @classmethod
     @override
     async def cli_cleanup(cls, id: str | None) -> None:
+        cls._init_package_log_level()
         if id is None:
             await cls.create_proxmox_instance_pools()
             for instance in cls.proxmox_pool.all_instances():

--- a/src/proxmoxsandbox/_proxmox_sandbox_environment.py
+++ b/src/proxmoxsandbox/_proxmox_sandbox_environment.py
@@ -289,18 +289,11 @@ class ProxmoxSandboxEnvironment(SandboxEnvironment):
 
     @classmethod
     def _init_package_log_level(cls) -> None:
-        """Set the package logger to INFO, or to the root's level if that is lower.
+        """Set the package logger to INFO, or the root's level if lower.
 
-        Inspect configures only its own package loggers, so `proxmoxsandbox`
-        would otherwise inherit the root level and lose its INFO records from
-        the .eval transcript. INFO is the floor; `--log-level debug/trace`
-        lowers the root below it and wins.
-
-        Runs from the lifecycle entry points because it must happen after
-        Inspect's `init_logger`. Extensions are imported earlier, during
-        `platform_init()`, while the root logger is still at its default.
-        Skipped when a level is already set, so a host application's choice
-        stands.
+        Must run after Inspect's `init_logger`; extensions are imported
+        earlier, during `platform_init()`, when the root is still at its
+        default.
         """
         if getLogger("proxmoxsandbox").level == NOTSET:
             getLogger("proxmoxsandbox").setLevel(

--- a/tests/proxmoxsandboxtest/test_host_attribution.py
+++ b/tests/proxmoxsandboxtest/test_host_attribution.py
@@ -20,19 +20,36 @@ from proxmoxsandbox.schema import ProxmoxSandboxEnvironmentConfig
 LOGGER_NAME = "proxmoxsandbox._proxmox_sandbox_environment"
 
 
-def test_provider_logger_opted_into_info():
-    """The provider lowers its own logger to INFO so its lines reach the .eval.
+# Sentinel env default: TEST-NET-3, provably not a real pool instance.
+ENV_SENTINEL_HOST = "203.0.113.255"
 
-    Inspect leaves third-party package loggers at the root WARNING default, so
-    without this the attribution line would never be created under a default
-    `inspect eval`. Users can still suppress via --log-level-transcript warning.
-    """
-    assert logging.getLogger("proxmoxsandbox").level == logging.INFO
+
+@pytest.fixture
+def reset_log_levels():
+    """Isolate logger levels, so these tests don't leak into the rest of the file."""
+    pkg, root = logging.getLogger("proxmoxsandbox"), logging.getLogger()
+    saved_pkg, saved_root = pkg.level, root.level
+    pkg.setLevel(logging.NOTSET)
+    yield
+    pkg.setLevel(saved_pkg)
+    root.setLevel(saved_root)
+
+
+@pytest.mark.asyncio
+async def test_provider_logger_opted_into_info(reset_log_levels):
+    """With root at its WARNING default, task_init enables the logger for INFO."""
+    os.environ["PROXMOX_HOST"] = ENV_SENTINEL_HOST
+    await ProxmoxSandboxEnvironment.task_init("test_task", None)
     assert logging.getLogger(LOGGER_NAME).isEnabledFor(logging.INFO)
 
 
-# Sentinel env default: TEST-NET-3, provably not a real pool instance.
-ENV_SENTINEL_HOST = "203.0.113.255"
+@pytest.mark.asyncio
+async def test_lower_root_level_is_not_overridden(reset_log_levels):
+    """With root set below INFO, task_init enables the logger for that level."""
+    os.environ["PROXMOX_HOST"] = ENV_SENTINEL_HOST
+    logging.getLogger().setLevel(logging.DEBUG)
+    await ProxmoxSandboxEnvironment.task_init("test_task", None)
+    assert logging.getLogger(LOGGER_NAME).isEnabledFor(logging.DEBUG)
 
 
 def _make_mock_infra():

--- a/tests/proxmoxsandboxtest/test_host_attribution.py
+++ b/tests/proxmoxsandboxtest/test_host_attribution.py
@@ -45,11 +45,11 @@ async def test_provider_logger_opted_into_info(reset_log_levels):
 
 @pytest.mark.asyncio
 async def test_lower_root_level_is_not_overridden(reset_log_levels):
-    """With root set below INFO, task_init enables the logger for that level."""
+    """With root set below INFO, task_init sets the logger to that lower level."""
     os.environ["PROXMOX_HOST"] = ENV_SENTINEL_HOST
     logging.getLogger().setLevel(logging.DEBUG)
     await ProxmoxSandboxEnvironment.task_init("test_task", None)
-    assert logging.getLogger(LOGGER_NAME).isEnabledFor(logging.DEBUG)
+    assert logging.getLogger("proxmoxsandbox").level == logging.DEBUG
 
 
 def _make_mock_infra():


### PR DESCRIPTION
Fixes #118.

## Change

`min(INFO, root effective level)` in place of the flat pin, moved out of module
scope into `_init_package_log_level()`, called from `task_init` and
`cli_cleanup`.

It can't stay at import: `platform_init()` imports extensions before
`init_logger()` sets the root level, so at import the root is always `WARNING`
and `min(INFO, WARNING)` is just `INFO`.

## Tests

`test_provider_logger_opted_into_info` (changed) — with root left at
`WARNING`, calls `task_init` and asserts the logger is enabled for `INFO`,
ensuring default behaviour remains as expected.

`test_lower_root_level_is_not_overridden` (new) — sets root to `DEBUG`
before `task_init` and asserts the logger is enabled for `DEBUG`, proving a
lower `--log-level` works as expected once this PR is merged.

`reset_log_levels` (new pytest fixture) — resets the package logger to `NOTSET`
before each test and restores both levels after.

## Result

Same task and host described in issue #118. The trace file increases from 19 records to 55, and
the record the issue showed was being dropped now appears, wrapping the INFO
exactly where predicted:

```
 TRACE   proxmox_qemu_command: await VM 101 QEMU agent (enter)
  INFO   VM 101 QEMU agent ping attempt 1
 TRACE   proxmox_qemu_command: await VM 101 QEMU agent (exit)
```

<details>
<summary>Full trace file after the fix</summary>

```
  INFO   Initializing pool 'default' with 1 instances
 TRACE   Run Task: task: repro (mockllm/model) (enter)
 TRACE   Log Write: .../logs/2026-08-21T16-49-37... (enter)
 TRACE   Log Write: .../logs/2026-08-21T16-49-37... (exit)
  INFO   Acquired instance default from pool 'default': host=127.0.0.1 port=11001
 TRACE   async_proxmox: login (enter)
 TRACE   async_proxmox: login (exit)
 TRACE   proxmox_sdn_command: get SDN zones (enter)
 TRACE   proxmox_sdn_command: get SDN zones (exit)
 TRACE   proxmox_qemu_command: list all VMs (enter)
 TRACE   proxmox_qemu_command: list all VMs (exit)
 TRACE   proxmox_sdn_command: get SDN zones (enter)
 TRACE   proxmox_sdn_command: get SDN zones (exit)
 TRACE   proxmox_sdn_command: get SDN zones (enter)
 TRACE   proxmox_sdn_command: get SDN zones (exit)
 TRACE   proxmox_sdn_command: create sdn  sdn_zone_id='rep329z' (enter)
 TRACE   proxmox_sdn_command: create sdn  sdn_zone_id='rep329z' (exit)
 TRACE   proxmox_sdn_command: update all SDN (enter)
 TRACE   proxmox_sdn_command: update all SDN (exit)
 TRACE   proxmox_qemu_command: list all VMs (enter)
 TRACE   proxmox_qemu_command: list all VMs (exit)
  INFO   Creating VM 1/1: None
 TRACE   proxmox_infra_command: create VM vm_config=VmConfig(...) (enter)
 TRACE   proxmox_infra_command: create VM vm_config=VmConfig(...) (exit)
  INFO   Waiting for VM None (ID=101)
 TRACE   proxmox_qemu_command: await VM 101 to be in status running (enter)
 TRACE   proxmox_qemu_command: await VM 101 to be in status running (exit)
 TRACE   proxmox_qemu_command: await VM 101 QEMU agent (enter)
  INFO   VM 101 QEMU agent ping attempt 1
 TRACE   proxmox_qemu_command: await VM 101 QEMU agent (exit)
  INFO   VM 101 QEMU agent responded after 9 attempts
  INFO   VM None (ID=101) is ready
 TRACE   Model: generate (mockllm/model) (enter)
 TRACE   Model: generate (mockllm/model) (exit)
 TRACE   proxmox_qemu_command: stop VM 101 (enter)
 TRACE   proxmox_qemu_command: stop VM 101 (exit)
 TRACE   proxmox_qemu_command: await VM 101 stopped (enter)
 TRACE   proxmox_qemu_command: await VM 101 stopped (exit)
 TRACE   proxmox_qemu_command: delete VM 101 (enter)
 TRACE   proxmox_qemu_command: delete VM 101 (exit)
 TRACE   proxmox_qemu_command: await VM 101 deleted (enter)
 TRACE   proxmox_qemu_command: await VM 101 deleted (exit)
 TRACE   proxmox_sdn_command: delete SDNs ['rep329z'] (enter)
 TRACE   proxmox_sdn_command: delete IPAM IP allocations (enter)
 TRACE   proxmox_sdn_command: delete IPAM IP allocations (exit)
 TRACE   proxmox_sdn_command: delete SDNs ['rep329z'] (exit)
 TRACE   proxmox_sdn_command: update all SDN (enter)
 TRACE   proxmox_sdn_command: update all SDN (exit)
  INFO   Successfully cleaned up VMs for instance default
  INFO   Releasing instance default from pool 'default' back to queue
 TRACE   Log Write: .../logs/2026-08-21T16-49-37... (enter)
 TRACE   Log Write: .../logs/2026-08-21T16-49-37... (exit)
 TRACE   Log Write: .../logs/2026-08-21T16-49-37... (enter)
 TRACE   Log Write: .../logs/2026-08-21T16-49-37... (exit)
 TRACE   Run Task: task: repro (mockllm/model) (exit)
```

</details>

The nine INFO records and Inspect's own ten TRACE records are unchanged from the
issue's run, so both did the same work.

## Follow-up

UKGovernmentBEIS/inspect_ec2_sandbox#38 should see a similar update to correct the new bug and match expected behaviour.